### PR TITLE
ci: official MCP registry publish + server.json per skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-skills",
-  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners — works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
+  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners - works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
   "version": "0.1.0",
   "owner": {
     "name": "Servosity",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "msp-skills",
+  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners — works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
+  "version": "0.1.0",
+  "owner": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "plugins": [
+    {
+      "name": "halopsa",
+      "source": "./skills/halopsa",
+      "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
+      "version": "0.1.0",
+      "category": "psa",
+      "tags": [
+        "halopsa",
+        "halo",
+        "psa",
+        "msp",
+        "ticket-automation",
+        "sla",
+        "mcp",
+        "claude-code",
+        "claude-mcp"
+      ]
+    },
+    {
+      "name": "servosity",
+      "source": "./skills/servosity",
+      "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
+      "version": "0.1.0",
+      "category": "backup-dr",
+      "tags": [
+        "servosity",
+        "backup",
+        "bcdr",
+        "disaster-recovery",
+        "msp",
+        "fleet-monitoring",
+        "mcp",
+        "claude-code",
+        "claude-mcp"
+      ]
+    }
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -1,0 +1,97 @@
+name: 🛠 Request a Skill / MCP
+description: Ask us to build a Claude Code Skill + MCP server for your PSA, RMM, backup, security, or M365 tool
+title: "[Skill request] "
+labels: ["skill-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) — no code, no terminal.
+
+  - type: input
+    id: vendor
+    attributes:
+      label: System / vendor name
+      description: The product you want a Skill for.
+      placeholder: e.g. Autotask, NinjaOne, Datto BCDR, IT Glue, Hudu
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What kind of system is it?
+      options:
+        - PSA (Professional Services Automation)
+        - RMM (Remote Monitoring & Management)
+        - Backup / DR / BCDR
+        - Security (EDR, MDR, email security)
+        - M365 / Google Workspace governance
+        - Documentation (IT Glue, Hudu, Confluence)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: One question you'd ask the AI
+      description: If this Skill existed, what's the FIRST cross-client or cross-engine question you'd ask?
+      placeholder: |
+        e.g. "Which of my clients have open Autotask tickets older than 30 days, grouped by contract type?"
+        or  "Show me every endpoint with a NinjaOne agent that hasn't checked in for 7 days."
+    validations:
+      required: true
+
+  - type: input
+    id: api_docs
+    attributes:
+      label: Link to the vendor's API docs (if you know it)
+      description: Helpful but not required. Type "I don't know" if you're not sure.
+      placeholder: https://docs.vendor.com/api  OR  "I don't know"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: msp_size
+    attributes:
+      label: MSP size
+      description: Helps us prioritize against demand.
+      options:
+        - 1-2 techs
+        - 3-10 techs
+        - 11-25 techs
+        - 26-50 techs
+        - 51+ techs
+        - I'm not an MSP, I'm researching for one
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build_session
+    attributes:
+      label: Would you join a Build Session to co-build this live?
+      description: Build Sessions are free, weekly Thursdays. We co-build with the cohort using a volunteer MSP's real tenant.
+      options:
+        - "Yes — sign me up"
+        - "Maybe — depends on the date"
+        - "No — I'd rather wait for it to ship"
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: Existing tools you use, related Skills, edge cases, etc. Optional.
+      placeholder: |
+        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA — this would help us evaluate."
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **What happens next:** we comment within a few days — usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) — no code, no terminal.
+        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) - no code, no terminal.
 
   - type: input
     id: vendor
@@ -74,9 +74,9 @@ body:
       label: Would you join a Build Session to co-build this live?
       description: Build Sessions are free, weekly Thursdays. We co-build with the cohort using a volunteer MSP's real tenant.
       options:
-        - "Yes — sign me up"
-        - "Maybe — depends on the date"
-        - "No — I'd rather wait for it to ship"
+        - "Yes - sign me up"
+        - "Maybe - depends on the date"
+        - "No - I'd rather wait for it to ship"
     validations:
       required: true
 
@@ -86,7 +86,7 @@ body:
       label: Anything else?
       description: Existing tools you use, related Skills, edge cases, etc. Optional.
       placeholder: |
-        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA — this would help us evaluate."
+        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA - this would help us evaluate."
     validations:
       required: false
 
@@ -94,4 +94,4 @@ body:
     attributes:
       value: |
         ---
-        **What happens next:** we comment within a few days — usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).
+        **What happens next:** we comment within a few days - usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,161 @@
+name: MCP Registry Publish
+
+# Triggers after the Release workflow completes successfully on a per-skill
+# tag. Bundles each skill's MCP binary into an .mcpb (zip), attaches it to the
+# release, computes its SHA-256, patches the corresponding server.json with the
+# hash + version + download URL, and publishes to the official MCP Registry
+# (registry.modelcontextprotocol.io). One publish fans out to PulseMCP, GitHub
+# MCP Registry, Glama, mcp.so, Smithery, and LobeHub within 1–7 days.
+#
+# Skipped automatically if the tag is not a per-skill release tag.
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write   # upload .mcpb to the release
+  id-token: write   # GitHub OIDC for mcp-publisher auth
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'refs/tags/') == false }}
+    outputs:
+      skill: ${{ steps.parse.outputs.skill }}
+      version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
+      proceed: ${{ steps.parse.outputs.proceed }}
+    steps:
+      - name: Parse triggering tag
+        id: parse
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          tag="$HEAD_BRANCH"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          case "$tag" in
+            halopsa-v*)
+              echo "skill=halopsa" >> "$GITHUB_OUTPUT"
+              echo "version=${tag#halopsa-v}" >> "$GITHUB_OUTPUT"
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            servosity-v*)
+              echo "skill=servosity" >> "$GITHUB_OUTPUT"
+              echo "version=${tag#servosity-v}" >> "$GITHUB_OUTPUT"
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Tag '$tag' is not a per-skill release tag; skipping MCP publish."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  publish:
+    needs: detect
+    if: needs.detect.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.detect.outputs.tag }}
+
+      - name: Set up jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Download MCP binaries from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          mkdir -p mcpb-build
+          cd mcpb-build
+          # The release.yml workflow uploads platform-suffixed binaries like
+          # halopsa-mcp-darwin-arm64, halopsa-mcp-linux-amd64, etc. We bundle
+          # ALL platforms into one .mcpb so the registry-published artifact
+          # works on every platform Claude Desktop runs on.
+          for suffix in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64 windows-amd64.exe; do
+            gh release download "$TAG" --pattern "${SKILL}-mcp-${suffix}" --dir . || true
+          done
+          ls -la
+
+      - name: Build MCPB bundle
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          # MCPB is a zip with manifest.json + a bin/ directory of the binaries.
+          mkdir -p bundle/bin
+          cp ../skills/$SKILL/manifest.json bundle/manifest.json
+          for f in ${SKILL}-mcp-*; do
+            [ -f "$f" ] || continue
+            cp "$f" "bundle/bin/$f"
+          done
+          (cd bundle && zip -r "../${SKILL}-mcp.mcpb" .)
+          ls -la "${SKILL}-mcp.mcpb"
+
+      - name: Compute SHA-256
+        id: sha
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          hash=$(openssl dgst -sha256 "${SKILL}-mcp.mcpb" | awk '{print $NF}')
+          echo "sha=$hash" >> "$GITHUB_OUTPUT"
+          echo "Computed SHA-256: $hash"
+
+      - name: Upload MCPB to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          gh release upload "$TAG" "${SKILL}-mcp.mcpb" --clobber
+
+      - name: Patch server.json with SHA + version + download URL
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          src=skills/$SKILL/server.json
+          out=mcpb-build/server.json
+          download="https://github.com/${{ github.repository }}/releases/download/${TAG}/${SKILL}-mcp.mcpb"
+          jq \
+            --arg version "$VERSION" \
+            --arg sha "$SHA" \
+            --arg download "$download" \
+            '.version = $version | .packages[0].version = $version | .packages[0].fileSha256 = $sha | .packages[0].download = $download' \
+            "$src" > "$out"
+          echo "--- patched server.json ---"
+          cat "$out"
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher-linux-amd64 -o mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --version
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to official MCP Registry
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          ../mcp-publisher publish --file server.json
+          echo "✓ Published to registry.modelcontextprotocol.io"
+          echo "Fan-out to PulseMCP, GitHub MCP Registry, Glama, mcp.so, Smithery, LobeHub takes 1–7 days."

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,10 @@ test-output/
 .codex/
 .cursor/
 .aider*
+# Vercel `skills` CLI installs third-party skills (e.g. marketingskills)
+# into .agents/ at the project root. Local-only dev tooling, never committed.
+.agents/
+skills-lock.json
 
 # ===== Misc =====
 *.zip

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MSP Skills — HaloPSA and Servosity, for the AI you already use
+# MSP Skills - HaloPSA and Servosity, for the AI you already use
 
-**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot — no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
+**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot - no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
 
-> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system — or bring your own.
+> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system - or bring your own.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Skills](https://img.shields.io/badge/skills-2-green.svg)](./catalog.json)
@@ -16,59 +16,51 @@ The four agents MSP owners actually use:
 
 | Your AI agent | Why MSPs use it | How to install MSP Skills |
 | --- | --- | --- |
-| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice — no terminal, just a chat window | Run installer, add MSP block to `claude_desktop_config.json` |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
+| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice - no terminal, just a chat window | Run installer, then Settings > Extensions to register the MCP server |
+| **ChatGPT** (paid plans) | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
 | **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt into the chat, or run the installer yourself |
 | **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | Paste the install prompt, or run the installer |
-
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). MSP Skills' binaries are local (stdio) — for ChatGPT you expose them over HTTPS via the `mcp-remote` bridge. Step-by-step in [docs/which-agent.md](./docs/which-agent.md).
 
 > **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. MSP Skills speaks the open MCP standard, so any current or future MCP-capable agent can use it. Full per-tool deep-dive: **[docs/which-agent.md](./docs/which-agent.md)**.
 
 ## What's in the box
 
 <!-- catalog:start -->
-| Skill | System | Install (Skill) | Install (MCP) |
+| Skill | System | Status | Install |
 | --- | --- | --- | --- |
-| [halopsa](./skills/halopsa) | HaloPSA, HaloITSM, HaloCRM | `bash skills/halopsa/install.sh` | [mcp-install](./skills/halopsa/mcp-install.md) |
-| [servosity](./skills/servosity) | Servosity backup and DR | `bash skills/servosity/install.sh` | [mcp-install](./skills/servosity/mcp-install.md) |
+| [halopsa](./skills/halopsa) | HaloPSA, HaloITSM, HaloCRM | ![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32) | [Install](./skills/halopsa/README.md) |
+| [servosity](./skills/servosity) | Servosity backup and DR | ![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32) | [Install](./skills/servosity/README.md) |
 <!-- catalog:end -->
 
-The table is regenerated from each skill's `manifest.json` whenever a PR touches `skills/`. The machine-readable form is [`catalog.json`](./catalog.json). Both skills are **beta** and being validated live against real MSPs in weekly Build Sessions (see below).
+> **About status badges.** `Tested` means at least one MSP has run this skill against a real production tenant and it worked. `Untested` (yellow) means the skill was generated, the gates passed, and we shipped it - but no MSP has driven it against live data yet. Untested skills may have rough edges; **feedback is valuable** - open an issue if something breaks.
 
 ## What makes this different
 
 ### Local mirror, not live calls
 
-Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" — that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
+Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" - that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
 
 MSP Skills syncs HaloPSA and Servosity into a local SQLite mirror with full-text search. Cross-client and cross-engine questions become one local query: instant, offline, and the AI sees the answer, not the raw data.
 
 ### Works with the AI you already use
 
-You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both — your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
+You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both - your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
 
 ### MSP owner first, not developer first
 
-You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** — mutations show you what they would do before they do it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
+You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** - any write shows you what it would do before it does it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
 
 Swap `halopsa` for `servosity` (and `halopsa-cli --version` for `servosity-cli doctor`) to install the Servosity skill. Your agent does the rest.
 
-### Path B — run the installer yourself
-
-**HaloPSA on macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
-```
+### Path B - run the installer yourself
 
 **HaloPSA on Windows (PowerShell):**
 
@@ -76,10 +68,10 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
 ```
 
-**Servosity on macOS / Linux:**
+**HaloPSA on macOS / Linux:**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 ```
 
 **Servosity on Windows (PowerShell):**
@@ -88,13 +80,19 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
+**Servosity on macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
 Each installer drops both the CLI and the MCP server, so you can use the Skill (Claude Code / Codex) and the MCP server (Claude Desktop / ChatGPT / Cursor / etc.) from one install. For Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot wire-up, see [docs/which-agent.md](./docs/which-agent.md) and each skill's `mcp-install.md`.
 
-> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** — we'll work it live with the MSP cohort and the same Skills you just installed.
+> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** - we'll work it live with the MSP cohort and the same Skills you just installed.
 
 ## What your agent can do
 
-Outcomes, not endpoints. Today, with the two skills available:
+Outcomes, not hype. Today, with the two skills available:
 
 | Outcome | Skill | Command |
 | --- | --- | --- |
@@ -114,19 +112,19 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Claude?
 
-Yes — **Claude Code**, **Claude Desktop**, and the **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly; Claude Desktop loads MSP Skills as an MCP server you add to `claude_desktop_config.json`. Both paths are first-class. Most MSP owners start with Claude Desktop because it's a Mac/Windows app — no terminal.
+Yes - **Claude Code**, **Claude Desktop**, and **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly. For Claude Desktop, run the installer, then go to **Settings > Extensions** to register the HaloPSA / Servosity MCP server - the panel walks you through it without editing JSON. (Power users can still hand-edit `claude_desktop_config.json` via Settings > Developer > Edit Config if you prefer.) Both paths are first-class.
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
+Yes - all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
 
 ### Do I need to know how to code?
 
-No. The recommended install path is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
+No. The recommended install path is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
 
 ### Is my HaloPSA or Servosity data safe? Does it leave my network?
 
-Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns — typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
+Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns - typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
 
 ### Will this hit my HaloPSA API rate limits?
 
@@ -134,7 +132,7 @@ Almost never. HaloPSA's rate limits aren't publicly documented and vary between 
 
 ### How is this different from HaloPSA's built-in ChatGPT integration?
 
-HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work — rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
+HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work - rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
 
 ### Can I run this on Windows?
 
@@ -142,7 +140,7 @@ Yes. The PowerShell installer in "Install in 60 seconds" above is the same insta
 
 ### What does it cost?
 
-The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed — free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
+The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed - free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
 
 ### Can I try it on one client first?
 
@@ -150,15 +148,14 @@ Yes. Every command takes a client / company filter (e.g. `halopsa-cli client car
 
 ### What if my AI doesn't speak MCP?
 
-If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell — you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
+If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell - you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
 
 ## Safety model
 
 These skills hold privileged, multi-tenant access to systems that run MSP businesses, so safety is a first-class concern, not a footnote:
 
 - **You supply your own credentials at runtime.** Nothing is stored in this repo.
-- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode and makes no change until you pass `--confirm`.
-- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent.
+- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent. Writes plan first: the CLI shows you what it would do, then waits for `--confirm` before it changes anything.
 
 The safe default for an autonomous agent is **read plus planned (dry-run) writes**; gate destructive and credential-touching operations behind a human. See [skills/halopsa/governance.md](./skills/halopsa/governance.md) and [skills/servosity/governance.md](./skills/servosity/governance.md).
 
@@ -180,9 +177,15 @@ Want one of these next? Bring the system to a Build Session (below) or open an i
 
 ## Don't see the system you need?
 
-Tell us what to build next. **[Open an issue →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)** and name the PSA, RMM, backup, security, or M365 tool — the more votes a system gets, the faster it moves up the roadmap.
+**Easiest path - tell your AI.** Paste this into Claude Code, Codex, Claude Desktop, or ChatGPT:
 
-First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** — a 90-second walkthrough for MSP business owners. No terminal required, no developer experience needed.
+> Open an issue on https://github.com/servosity/msp-skills using the skill-request template. The system I want is **[YOUR SYSTEM NAME]** - my one question for the AI would be **"[YOUR QUESTION]"**, I'm on **[Mac or Windows]**, and my MSP has about **[N] techs**. Submit it.
+
+Your AI fills the form and posts the issue. Done. (You'll need to be signed in to GitHub in your browser or have a GitHub CLI token where your AI can see it.)
+
+**Don't have an AI set up yet?** Open the issue directly: **[Submit a skill request →](https://github.com/Servosity/msp-skills/issues/new?template=skill-request.yml)**. First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** for a 90-second walkthrough.
+
+More votes (👍 reactions on an issue) move a system up the roadmap. Share with one MSP friend who'd want the same skill.
 
 ## Co-build a new Skill or MCP with us live
 
@@ -206,16 +209,16 @@ MSPs are the channel that brings AI to small business. The durable moat is the [
 
 ## Glossary (for the non-developer)
 
-- **Skill** — a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
-- **MCP** — Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
-- **MCP server** — the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
-- **PSA** — Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
-- **BCDR / Backup and DR** — Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
-- **Cross-client analytics** — questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
+- **Skill** - a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
+- **MCP** - Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
+- **MCP server** - the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
+- **PSA** - Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
+- **BCDR / Backup and DR** - Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
+- **Cross-client analytics** - questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works on both skills.
 
 Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens. Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability. Methodology: [Compounding Teams](https://compoundingteams.com). Generated CLIs and MCP servers built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,31 @@
-# MSP Skills
+# MSP Skills — HaloPSA and Servosity, for the AI you already use
 
-Open-source Claude Code Skills and MCP servers for the PSA, RMM, backup, DR, and
-M365 workflows MSPs run every day. Install one, and your AI agent operates the
-system directly - it does the clicking, not the narrating.
+**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot — no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
+
+> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system — or bring your own.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Skills](https://img.shields.io/badge/skills-2-green.svg)](./catalog.json)
-![Status](https://img.shields.io/badge/status-early-yellow.svg)
+[![MCP](https://img.shields.io/badge/MCP-compatible-7C3AED.svg)](https://modelcontextprotocol.io)
+[![Agent Skills](https://img.shields.io/badge/Agent_Skills-spec-2E7D32.svg)](https://agentskills.io)
+![Status](https://img.shields.io/badge/status-beta-yellow.svg)
 
-## What your agent can do with these
+## Works with your agent
 
-Outcomes, not endpoints. With the two skills available today:
+The four agents MSP owners actually use:
 
-| Outcome | Skill | Command |
+| Your AI agent | Why MSPs use it | How to install MSP Skills |
 | --- | --- | --- |
-| Pre-empt SLA breaches before a hand-off | halopsa | `halopsa-cli sla breaching --within 24h` |
-| Find stale backups across every client | servosity | `servosity-cli stale-backups --days 7` |
-| Build a per-client situational-awareness card | halopsa | `halopsa-cli client card "Acme Corp"` |
-| Triage what needs attention across every client | servosity | `servosity-cli attention` |
-| Pull a client's full backup picture for a ticket | servosity | `servosity-cli company show 4421` |
-| See what changed across your fleet overnight | servosity | `servosity-cli drift --from yesterday --to now` |
+| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice — no terminal, just a chat window | Run installer, add MSP block to `claude_desktop_config.json` |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
+| **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt into the chat, or run the installer yourself |
+| **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | Paste the install prompt, or run the installer |
 
-## Pick your agent
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). MSP Skills' binaries are local (stdio) — for ChatGPT you expose them over HTTPS via the `mcp-remote` bridge. Step-by-step in [docs/which-agent.md](./docs/which-agent.md).
 
-| Your agent | What you install | How |
-| --- | --- | --- |
-| Claude Code | Claude Code Skill (plus CLI binary) | `bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)` |
-| Codex CLI | Same as Claude Code | (same one-liner) |
-| Claude Desktop | MCP server (local binary) | see [skills/halopsa/mcp-install.md](./skills/halopsa/mcp-install.md) |
-| ChatGPT (Developer Mode, beta) | Remote MCP connector (not a local binary) | see the ChatGPT section in [mcp-install.md](./skills/halopsa/mcp-install.md) |
-| Not sure what you have | start here | [docs/which-agent.md](./docs/which-agent.md) |
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. MSP Skills speaks the open MCP standard, so any current or future MCP-capable agent can use it. Full per-tool deep-dive: **[docs/which-agent.md](./docs/which-agent.md)**.
 
-## Current skills
+## What's in the box
 
 <!-- catalog:start -->
 | Skill | System | Install (Skill) | Install (MCP) |
@@ -40,26 +34,35 @@ Outcomes, not endpoints. With the two skills available today:
 | [servosity](./skills/servosity) | Servosity backup and DR | `bash skills/servosity/install.sh` | [mcp-install](./skills/servosity/mcp-install.md) |
 <!-- catalog:end -->
 
-The table above is regenerated automatically from each skill's `manifest.json`
-whenever a PR touches `skills/`. See [`catalog.json`](./catalog.json) for the
-machine-readable form. Both skills are **beta**.
+The table is regenerated from each skill's `manifest.json` whenever a PR touches `skills/`. The machine-readable form is [`catalog.json`](./catalog.json). Both skills are **beta** and being validated live against real MSPs in weekly Build Sessions (see below).
 
-## Install in 30 seconds
+## What makes this different
 
-### Easiest: let your agent install it
+### Local mirror, not live calls
 
-You do not have to run anything by hand. Point your AI agent (Claude Code or Codex) at this
-repo and let it do the setup - it reads the Skill, installs the binary, and walks you through
-authentication. Paste this into Claude Code or Codex:
+Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" — that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
 
-> Set up the Servosity skill from https://github.com/servosity/msp-skills - read
-> skills/servosity/SKILL.md, run its install steps, then run `servosity-cli doctor` to confirm
-> it works.
+MSP Skills syncs HaloPSA and Servosity into a local SQLite mirror with full-text search. Cross-client and cross-engine questions become one local query: instant, offline, and the AI sees the answer, not the raw data.
 
-Swap `servosity` for `halopsa` (and `servosity-cli doctor` for `halopsa-cli --version`) for the
-HaloPSA skill. You can also just give your agent the repo URL and say "install the HaloPSA skill."
+### Works with the AI you already use
 
-### Or run the installer yourself
+You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both — your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
+
+### MSP owner first, not developer first
+
+You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** — mutations show you what they would do before they do it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+Swap `halopsa` for `servosity` (and `halopsa-cli --version` for `servosity-cli doctor`) to install the Servosity skill. Your agent does the rest.
+
+### Path B — run the installer yourself
 
 **HaloPSA on macOS / Linux:**
 
@@ -85,60 +88,105 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
-Each install drops both the CLI and the MCP server, so you can use either path
-(Skill in Claude Code, MCP in Claude Desktop) from one install. Binaries are
-published to [GitHub Releases](https://github.com/servosity/msp-skills/releases)
-and built from the source under each skill's `cli/` directory. For Claude Desktop
-or ChatGPT wire-up, read the per-skill `mcp-install.md`.
+Each installer drops both the CLI and the MCP server, so you can use the Skill (Claude Code / Codex) and the MCP server (Claude Desktop / ChatGPT / Cursor / etc.) from one install. For Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot wire-up, see [docs/which-agent.md](./docs/which-agent.md) and each skill's `mcp-install.md`.
 
-## Optional: Claude Code statusline
+> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** — we'll work it live with the MSP cohort and the same Skills you just installed.
 
-Not an MSP skill - a small developer convenience that shows model, working directory, git
-branch, and context-window usage in your Claude Code status line. Install steps and details
-are in [tools/statusline/README.md](./tools/statusline/README.md).
+## What your agent can do
+
+Outcomes, not endpoints. Today, with the two skills available:
+
+| Outcome | Skill | Command |
+| --- | --- | --- |
+| Pre-empt SLA breaches before a hand-off | halopsa | `halopsa-cli sla breaching --within 24h` |
+| Find stale backups across every client | servosity | `servosity-cli stale-backups --days 7` |
+| Build a per-client situational-awareness card | halopsa | `halopsa-cli client card "Acme Corp"` |
+| Triage what needs attention across every client | servosity | `servosity-cli attention` |
+| Pull a client's full backup picture for a ticket | servosity | `servosity-cli company show 4421` |
+| See what changed across your fleet overnight | servosity | `servosity-cli drift --from yesterday --to now` |
+| Find every ticket about backup failures across all clients | halopsa + servosity | combine `halopsa-cli tickets search` with `servosity-cli stale-backups` |
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not to local binaries directly. MSP Skills ships local binaries, so to use them with ChatGPT you run them on your machine and expose them via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step: each skill's `mcp-install.md`.
+
+### Does this work with Claude?
+
+Yes — **Claude Code**, **Claude Desktop**, and the **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly; Claude Desktop loads MSP Skills as an MCP server you add to `claude_desktop_config.json`. Both paths are first-class. Most MSP owners start with Claude Desktop because it's a Mac/Windows app — no terminal.
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
+
+### Do I need to know how to code?
+
+No. The recommended install path is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
+
+### Is my HaloPSA or Servosity data safe? Does it leave my network?
+
+Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns — typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
+
+### Will this hit my HaloPSA API rate limits?
+
+Almost never. HaloPSA's rate limits aren't publicly documented and vary between cloud-hosted and self-hosted instances. MSP Skills syncs your HaloPSA data into a local SQLite mirror once, then incrementally; subsequent questions (triage, SLA breaches, client cards, cross-client analytics) run against the local mirror, not the live API. The big-batch QBR queries that get you 429'd with API-passthrough tools become a single SQL join here.
+
+### How is this different from HaloPSA's built-in ChatGPT integration?
+
+HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work — rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer in "Install in 60 seconds" above is the same install path as macOS / Linux, just packaged for PowerShell. The CLI and MCP binaries are native Windows builds. Cline users on Windows may need a small `npx` workaround documented in [docs/which-agent.md](./docs/which-agent.md).
+
+### What does it cost?
+
+The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed — free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
+
+### Can I try it on one client first?
+
+Yes. Every command takes a client / company filter (e.g. `halopsa-cli client card "Acme Corp"`, `servosity-cli company show 4421`). Read-tier commands plan nothing and change nothing; you can try them against your live system safely. Write-tier commands run `--dry-run` until you pass `--confirm`. The safe starting move is a read-only triage against one client, see the output, then widen scope.
+
+### What if my AI doesn't speak MCP?
+
+If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell — you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
 
 ## Safety model
 
-These skills hold privileged, multi-tenant access to systems that run MSP
-businesses, so safety is a first-class concern, not a footnote:
+These skills hold privileged, multi-tenant access to systems that run MSP businesses, so safety is a first-class concern, not a footnote:
 
 - **You supply your own credentials at runtime.** Nothing is stored in this repo.
-- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode
-  and makes no change until you pass `--confirm`.
-- **Every skill ships a permission matrix.** Each skill's `governance.md` tags
-  commands read / write / destructive and tells you how to scope an agent.
+- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode and makes no change until you pass `--confirm`.
+- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent.
 
-The safe default for an autonomous agent is **read plus planned (dry-run)
-writes**; gate destructive and credential-touching operations behind a human. See
-[skills/halopsa/governance.md](./skills/halopsa/governance.md) and
-[skills/servosity/governance.md](./skills/servosity/governance.md).
+The safe default for an autonomous agent is **read plus planned (dry-run) writes**; gate destructive and credential-touching operations behind a human. See [skills/halopsa/governance.md](./skills/halopsa/governance.md) and [skills/servosity/governance.md](./skills/servosity/governance.md).
 
 ## Tested by MSPs in Build Sessions
 
-These skills are built and tested with real MSPs running them against their own production
-systems, live, in our free weekly Build Sessions. They are currently beta and being validated
-now. Join a session (see [below](#co-build-a-new-skill-or-mcp-with-us-live)) to watch one run
-against a real system, or bring your own to co-build.
+These skills are built and tested with real MSPs running them against their own production systems, live, in our free weekly Build Sessions. They are currently beta and being validated now. Join a session ([RSVP](https://compoundingteams.com/build-sessions)) to watch one run against a real system, or bring your own to co-build.
 
 ## Roadmap
 
-We co-build the next skills live with MSPs in the weekly Build Session. The targets
-the MSP community asks for most:
+We co-build the next skills live with MSPs in the weekly Build Session. The targets the MSP community asks for most:
 
 - **M365 governance / Copilot data-exposure pre-check**
-- **PSA: Autotask, ConnectWise PSA** (HaloPSA shipped)
+- **PSA**: Autotask, ConnectWise PSA (HaloPSA shipped)
 - **NinjaOne fleet hygiene** (silent-failure detector)
 - **RMM ticket-to-doc** (resolution to IT Glue / Hudu)
 - **Datto RMM, Kaseya, Atera, Syncro**
 
 Want one of these next? Bring the system to a Build Session (below) or open an issue.
 
+## Don't see the system you need?
+
+Tell us what to build next. **[Open an issue →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)** and name the PSA, RMM, backup, security, or M365 tool — the more votes a system gets, the faster it moves up the roadmap.
+
+First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** — a 90-second walkthrough for MSP business owners. No terminal required, no developer experience needed.
+
 ## Co-build a new Skill or MCP with us live
 
-Every Thursday we host a free Build Session where an MSP brings a system we have
-not covered (your PSA, RMM, backup product, or security tool) and we co-build the
-Claude Code Skill and MCP server live. You watch, you ask, you walk away with a
-working integration.
+Every Thursday we host a free Build Session where an MSP brings a system we have not covered (your PSA, RMM, backup product, or security tool) and we co-build the Claude Code Skill and MCP server live. You watch, you ask, you walk away with a working integration.
 
 - Free weekly Build Sessions (Thursdays), co-built with a volunteer MSP.
 - Access to every shipped Skill and MCP the day it merges.
@@ -148,85 +196,27 @@ RSVP for the next one at **[compoundingteams.com/build-sessions](https://compoun
 
 ## Contribute a Skill or MCP
 
-If your MSP uses a system we have not covered, send a PR. We co-build alongside
-contributors in Build Sessions when that is easier than going it alone.
+If your MSP uses a system we have not covered, send a PR. We co-build alongside contributors in Build Sessions when that is easier than going it alone.
 
-A skill PR includes: `SKILL.md` (with `vendor` frontmatter), a `README.md` with
-the non-affiliation banner, `install.sh` + `install.ps1`, `mcp-install.md` if it
-ships an MCP server, and ideally `pain-point.md` + `governance.md`. CI enforces
-the contract (DCO sign-off, frontmatter schema, required files, no secrets, no
-personal paths). See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full checklist
-and the non-affiliation banner template.
+A skill PR includes: `SKILL.md` (with `vendor` frontmatter), a `README.md` with the non-affiliation banner, `install.sh` + `install.ps1`, `mcp-install.md` if it ships an MCP server, and ideally `pain-point.md` + `governance.md`. CI enforces the contract (DCO sign-off, frontmatter schema, required files, no secrets, no personal paths). See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full checklist and the non-affiliation banner template.
 
 ## About Compounding Teams
 
-MSPs are the channel that brings AI to small business. The durable moat is the
-[Compounding Teams](https://compoundingteams.com) methodology for running an MSP
-where every interaction with a tool, a customer, or a system makes the next one
-better. Loops close, feedback returns to the source, work compounds instead of
-evaporating. `msp-skills` is the part of that methodology you can install: the
-executable layer that lets your AI agent operate alongside your team in the same
-systems, with the same context, every day.
+MSPs are the channel that brings AI to small business. The durable moat is the [Compounding Teams](https://compoundingteams.com) methodology for running an MSP where every interaction with a tool, a customer, or a system makes the next one better. Loops close, feedback returns to the source, work compounds instead of evaporating. `msp-skills` is the part of that methodology you can install: the executable layer that lets your AI agent operate alongside your team in the same systems, with the same context, every day.
 
-## FAQ
+## Glossary (for the non-developer)
 
-**What is a Claude Code Skill?**
-A Claude Code Skill is a markdown file (and usually a binary it drives) that tells
-Claude Code how to operate a specific tool or API. When you say "use halopsa" (or any
-installed skill), Claude Code loads the Skill, gets a command vocabulary plus an operating
-contract, and acts on your behalf in that system. Codex CLI uses the same Skill format.
+- **Skill** — a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
+- **MCP** — Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
+- **MCP server** — the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
+- **PSA** — Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
+- **BCDR / Backup and DR** — Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
+- **Cross-client analytics** — questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
 
-**What is an MCP server?**
-MCP (Model Context Protocol) is the open standard that lets AI apps call tools on
-a separate server. Claude Desktop launches an MCP server as a local binary on your
-machine. ChatGPT (Developer Mode, beta) connects to a remote MCP server over
-HTTPS instead. The HaloPSA MCP server, for example, gives the agent tools like
-`tickets_list` and `client_card` it can call directly.
+---
 
-**What is the difference between a Skill and an MCP server?**
-A Skill is what skill-capable agents (Claude Code, Codex CLI) use. An MCP server
-is what AI apps (Claude Desktop, ChatGPT) use. Both packages here ship both, so
-you do not have to pick: install once, use either path.
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
 
-**How do I connect Claude Code to a system?**
-Install the skill for the system you want (let your agent do it, or run the one-liner above).
-Claude Code discovers the Skill via `SKILL.md` in `skills/<skill>/` and drives the
-`<skill>-cli` binary. Authenticate with that system's credentials; per-skill instructions are in
-[skills/halopsa/README.md](./skills/halopsa/README.md) and
-[skills/servosity/README.md](./skills/servosity/README.md).
+Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens. Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability. Methodology: [Compounding Teams](https://compoundingteams.com). Generated CLIs and MCP servers built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).
 
-**How do I add a skill's MCP to Claude Desktop?**
-The install drops the skill's `<skill>-mcp` binary on your PATH. Add the MCP config block to
-your `claude_desktop_config.json` as shown in that skill's `mcp-install.md` (for example
-[skills/halopsa/mcp-install.md](./skills/halopsa/mcp-install.md)), and restart Claude Desktop.
-
-**Can I use these with ChatGPT?**
-Yes, but it is not the same as Claude Desktop. ChatGPT connects to remote MCP
-servers over HTTPS via Developer Mode (beta, on paid plans), not to a local
-binary. Each skill's `mcp-install.md` has a ChatGPT section showing how to run the
-MCP server in HTTP mode behind a secure tunnel and register it as a custom
-connector.
-
-**Is this free?**
-Yes. Apache-2.0 licensed - free to use commercially, free to fork. Servosity does not charge
-for API access or API calls to run the Servosity skill. Other PSA, RMM, and backup vendors set
-their own API-access terms, but the Skills and MCP servers in this repository are always free.
-
-**Can my team contribute a Skill or MCP for ConnectWise, Autotask, or NinjaOne?**
-Yes, please. See [CONTRIBUTING.md](./CONTRIBUTING.md). Bring the system to a Build
-Session and we will co-build the first version live, or PR a complete skill
-directly. Skills for systems we directly compete with are welcome too; this
-repository is an MSP capability directory, not a Servosity-product directory.
-
-**Is msp-skills affiliated with HaloPSA, Servosity, or any other vendor named here?**
-Servosity Inc. maintains this repository and ships the Servosity skill, so the
-Servosity skill is first-party. Every other vendor skill is unofficial and
-unaffiliated. Each unofficial skill carries a non-affiliation banner at the top of
-its README. See [TRADEMARKS.md](./TRADEMARKS.md) for the full statement.
-
-## Footer
-
-Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens.
-Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor
-non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability.
-Methodology: [Compounding Teams](https://compoundingteams.com).
+_Last updated: 2026-05-28. Latest releases: [halopsa-v0.1.0](https://github.com/servosity/msp-skills/releases/tag/halopsa-v0.1.0) · [servosity-v0.1.0](https://github.com/servosity/msp-skills/releases/tag/servosity-v0.1.0)._

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-26",
+  "generated_at": "2026-05-28",
   "skills": [
     {
       "name": "halopsa",
@@ -16,7 +16,7 @@
       "first_party": false,
       "install_skill_one_liner": "bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)",
       "install_mcp_doc": "skills/halopsa/mcp-install.md",
-      "description": "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return."
+      "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline."
     },
     {
       "name": "servosity",
@@ -32,7 +32,7 @@
       "first_party": true,
       "install_skill_one_liner": "bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)",
       "install_mcp_doc": "skills/servosity/mcp-install.md",
-      "description": "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show."
+      "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query."
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-28",
+  "generated_at": "2026-05-29",
   "skills": [
     {
       "name": "halopsa",

--- a/docs/requesting-a-skill.md
+++ b/docs/requesting-a-skill.md
@@ -1,0 +1,55 @@
+# How to request a new MSP Skill (90 seconds, no terminal)
+
+You don't see your PSA, RMM, backup, or M365 tool listed yet? Tell us. This is the fastest way to move a system up the roadmap and to get it co-built live in a Build Session.
+
+No code experience required. No terminal. No GitHub-fu. If you can fill in a web form, you can do this.
+
+## What "filing an issue" actually means
+
+A GitHub "issue" is just a public note on the project. Anyone can read it, anyone can vote (👍) it. We use the votes to rank what to build next. Filing one takes about a minute.
+
+## Step 1 — Make sure you have a GitHub account
+
+If you've never used GitHub, you'll need a free account. **[Sign up at github.com →](https://github.com/signup)**
+
+You can use any email. There's nothing to install — it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
+
+## Step 2 — Open the request form
+
+**[Click here to open the skill-request form →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)**
+
+The form will ask:
+
+- **System / vendor name** (the product you want a Skill for — e.g. "Autotask", "NinjaOne", "Datto BCDR")
+- **Category** (PSA, RMM, Backup, Security, M365, Other)
+- **One question you'd ask the AI** if this Skill existed (e.g. "Which clients have open tickets older than 30 days?")
+- **Link to the vendor's API docs**, if you know it — or just write "I don't know," that's fine
+- **MSP size** (number of techs / clients) — helps us prioritize
+- **Would you join a Build Session for this?** — yes/no
+
+That's it. Click **Submit new issue** at the bottom.
+
+## Step 3 — What happens next
+
+1. **You'll see your issue on the public list.** Other MSPs can vote on it.
+2. **We comment within a few days** with one of three responses:
+   - "Already on the roadmap — here's the ETA."
+   - "We need more votes — share with one MSP friend who'd want this."
+   - "Bring it to next Thursday's Build Session and we'll co-build it live."
+3. **If it gets enough demand**, it goes into the queue. The Servosity skill in this repo got built that way.
+
+## Step 4 — Boost the signal (optional)
+
+If you want this Skill built faster:
+
+- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment — the 👍 above the title). Issues with more 👍s move up.
+- **Share the issue URL** with one MSP friend who'd want the same Skill. One additional vote moves your issue notably up the list.
+- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) — bring your tenant, your questions, and we co-build with the cohort.
+
+## I have a question, not a Skill request
+
+That's fine too — open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
+
+---
+
+_Last updated: 2026-05-28._

--- a/docs/requesting-a-skill.md
+++ b/docs/requesting-a-skill.md
@@ -8,47 +8,47 @@ No code experience required. No terminal. No GitHub-fu. If you can fill in a web
 
 A GitHub "issue" is just a public note on the project. Anyone can read it, anyone can vote (👍) it. We use the votes to rank what to build next. Filing one takes about a minute.
 
-## Step 1 — Make sure you have a GitHub account
+## Step 1 - Make sure you have a GitHub account
 
 If you've never used GitHub, you'll need a free account. **[Sign up at github.com →](https://github.com/signup)**
 
-You can use any email. There's nothing to install — it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
+You can use any email. There's nothing to install - it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
 
-## Step 2 — Open the request form
+## Step 2 - Open the request form
 
 **[Click here to open the skill-request form →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)**
 
 The form will ask:
 
-- **System / vendor name** (the product you want a Skill for — e.g. "Autotask", "NinjaOne", "Datto BCDR")
+- **System / vendor name** (the product you want a Skill for - e.g. "Autotask", "NinjaOne", "Datto BCDR")
 - **Category** (PSA, RMM, Backup, Security, M365, Other)
 - **One question you'd ask the AI** if this Skill existed (e.g. "Which clients have open tickets older than 30 days?")
-- **Link to the vendor's API docs**, if you know it — or just write "I don't know," that's fine
-- **MSP size** (number of techs / clients) — helps us prioritize
-- **Would you join a Build Session for this?** — yes/no
+- **Link to the vendor's API docs**, if you know it - or just write "I don't know," that's fine
+- **MSP size** (number of techs / clients) - helps us prioritize
+- **Would you join a Build Session for this?** - yes/no
 
 That's it. Click **Submit new issue** at the bottom.
 
-## Step 3 — What happens next
+## Step 3 - What happens next
 
 1. **You'll see your issue on the public list.** Other MSPs can vote on it.
 2. **We comment within a few days** with one of three responses:
-   - "Already on the roadmap — here's the ETA."
-   - "We need more votes — share with one MSP friend who'd want this."
+   - "Already on the roadmap - here's the ETA."
+   - "We need more votes - share with one MSP friend who'd want this."
    - "Bring it to next Thursday's Build Session and we'll co-build it live."
 3. **If it gets enough demand**, it goes into the queue. The Servosity skill in this repo got built that way.
 
-## Step 4 — Boost the signal (optional)
+## Step 4 - Boost the signal (optional)
 
 If you want this Skill built faster:
 
-- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment — the 👍 above the title). Issues with more 👍s move up.
+- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment - the 👍 above the title). Issues with more 👍s move up.
 - **Share the issue URL** with one MSP friend who'd want the same Skill. One additional vote moves your issue notably up the list.
-- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) — bring your tenant, your questions, and we co-build with the cohort.
+- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) - bring your tenant, your questions, and we co-build with the cohort.
 
 ## I have a question, not a Skill request
 
-That's fine too — open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
+That's fine too - open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
 
 ---
 

--- a/docs/which-agent.md
+++ b/docs/which-agent.md
@@ -1,33 +1,356 @@
-# Which agent do I have?
+# Which AI agent? Install MSP Skills in any of them.
 
-`msp-skills` works with two families of AI agents. Pick yours, follow the matching install link, and skip the rest.
+MSP Skills works with **any AI tool that speaks MCP** (Model Context Protocol). This page tells you which AI tools speak MCP today, how to install the HaloPSA and Servosity skills in each one, and the gotchas to watch for.
 
-## You typed `claude` in a terminal and got an interactive AI prompt
+Pick the row for your agent and follow that section. If you're not sure what you have, jump to ["I don't know what I have"](#i-dont-know-what-i-have-yet) at the bottom.
 
-You have **Claude Code** (or Codex CLI). Both are skill-capable agents. They read `SKILL.md` files directly and drive CLIs.
+> **All paths assume you already ran the installer** for at least one skill — see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
 
-Install path: [install-skill.md](./install-skill.md).
+## Quick lookup
 
-## You downloaded Claude Desktop from claude.ai
+**The 4 MSP-owner primaries — lead here:**
 
-You have **Claude Desktop**. It is a Mac / Windows app with a chat window. It does not load `SKILL.md` files; it talks to MCP servers instead.
+| AI agent | Supports MCP? | Config file or panel | Verified |
+| --- | --- | --- | --- |
+| [Claude Desktop](#claude-desktop-anthropic) | Yes | `claude_desktop_config.json` | 2026-05-28 |
+| [ChatGPT (Plus / Pro+)](#chatgpt-openai-plus-pro-team-business-enterprise-education) | Yes¹ | Settings → Connectors | 2026-05-28 |
+| [Claude Code](#claude-code-anthropic-cli) | Yes | `claude mcp add ...` | 2026-05-28 |
+| [Codex CLI](#codex-cli-openai) | Yes | `~/.codex/config.toml` | 2026-05-28 |
 
-Install path: [install-mcp.md](./install-mcp.md).
+**Long-tail and developer IDEs:**
 
-## You use ChatGPT in the desktop app, not the website
+| AI agent | Supports MCP? | Config file or panel | Verified |
+| --- | --- | --- | --- |
+| [Cursor](#cursor) | Yes | `.cursor/mcp.json` | 2026-05-28 |
+| [Windsurf](#windsurf) | Yes | Cascade → MCP Servers | 2026-05-28 |
+| [Cline](#cline-vs-code) | Yes | `Ctrl+Shift+M` / `⌘+Shift+M` | 2026-05-28 |
+| [Continue.dev](#continuedev-vs-code--jetbrains) | Yes (Agent mode) | `config.json` | 2026-05-28 |
+| [Gemini CLI](#gemini-cli-google) | Yes | `~/.gemini/config.json` | 2026-05-28 |
+| [GitHub Copilot in VS Code](#github-copilot-in-vs-code) | Yes (Agent mode) | `mcp.json` (key: `servers`) | 2026-05-28 |
+| [Zed](#zed) | Partial² | `context_servers` in `settings.json` | 2026-05-28 |
+| [JetBrains AI Assistant / Junie](#jetbrains-ai-assistant--junie) | _Verify_ | _verify_ | _pending_ |
 
-You have **ChatGPT Desktop**. Same story as Claude Desktop: it talks to MCP servers, not Skills.
+**Niche / pre-wired (advanced):**
 
-Install path: [install-mcp.md](./install-mcp.md).
+| AI agent | Status | Install path | Verified |
+| --- | --- | --- | --- |
+| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install servosity/msp-skills/skills/<name>` | 2026-05-28 (paper — install not yet end-to-end tested) |
+| [OpenClaw](#openclaw) | Pre-wired (awaiting launch) | `openclaw:` frontmatter block already in every SKILL.md | 2026-05-28 (frontmatter wiring; OpenClaw not yet GA) |
 
-## You only use ChatGPT or Claude on the web
+¹ ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education). Free tier does not yet expose Developer Mode. ChatGPT connects only to **remote** MCP servers; local stdio binaries like MSP Skills need an HTTPS bridge (e.g. `mcp-remote`).
+² Zed supports MCP Tools and Prompts today, not the full spec. Most MSP Skills functionality works; some advanced features may not.
 
-Web-only chat surfaces do not yet have a way to install MCP servers or Skills. There is nothing to install here for that path. When the web surfaces add MCP, we will document it.
+---
 
-## You use Cursor, Cline, Aider, Continue, or another agent
+## Claude Desktop (Anthropic)
 
-These agents are evolving fast. Some load Skills, some only use MCP, some have their own format. Check your agent's docs for "MCP server" or "Skill" support and pick the matching install path here.
+The Mac / Windows app with a chat window. First-class MCP host — the original.
 
-## Still not sure
+**Config file:**
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-If you are working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and do not remember: open whatever you call up to chat with the AI and look at the menu / settings. The presence of a "skills" or "MCP" section in the settings tells you which family.
+**Setup** (Settings → Developer → Edit Config), add the block for HaloPSA and / or Servosity:
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "<your-tenant>",
+        "HALOPSA_CLIENT_ID": "<your-client-id>",
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+      }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
+      }
+    }
+  }
+}
+```
+
+**Restart Claude Desktop fully** (quit and reopen). An MCP indicator appears in the bottom-right of the chat input once the server connects. Source: [modelcontextprotocol.io/quickstart/user](https://modelcontextprotocol.io/quickstart/user).
+
+---
+
+## Claude Code (Anthropic CLI)
+
+Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code — just install the skill normally — but you can register the MCP server too if you prefer that interface.
+
+**Skill path (recommended):** the install script symlinks the skill into `~/.claude/skills/`. Restart Claude Code; invoke with `use halopsa` or `use servosity`.
+
+**MCP path (alternative):**
+
+```bash
+claude mcp add halopsa -- halopsa-mcp
+claude mcp add servosity -- servosity-mcp
+claude mcp list   # confirm status
+```
+
+For HTTP / remote: `claude mcp add --transport http <name> <url>`. Source: [code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp).
+
+---
+
+## Codex CLI (OpenAI)
+
+Skill-capable CLI like Claude Code. Reads the same `SKILL.md`. Also supports MCP.
+
+**Skill path (recommended):** the install script registers the skill with Codex; invoke `use halopsa` or `use servosity`.
+
+**MCP path (alternative):** edit `~/.codex/config.toml` (global) or `.codex/config.toml` (project):
+
+```toml
+[mcp_servers.halopsa]
+command = "halopsa-mcp"
+env = { HALOPSA_TENANT = "<your-tenant>", HALOPSA_CLIENT_ID = "<id>", HALOPSA_CLIENT_SECRET = "<secret>" }
+
+[mcp_servers.servosity]
+command = "servosity-mcp"
+env = { SERVOSITY_MSP_TOKEN = "<token>" }
+```
+
+Codex supports stdio + Streamable HTTP, and runs concurrent read-only tools when advertised. Source: [developers.openai.com/codex/mcp](https://developers.openai.com/codex/mcp).
+
+---
+
+## ChatGPT (OpenAI) — Plus, Pro, Team, Business, Enterprise, Education
+
+**Free tier does not yet expose Developer Mode**; you need a paid plan. ChatGPT speaks MCP through "Developer Mode" connectors (beta as of Sept 2025).
+
+**Important transport caveat:** ChatGPT connects only to **remote** MCP servers (HTTPS). MSP Skills binaries are local (stdio). To use them with ChatGPT, expose them over HTTPS:
+
+**Option 1 — `mcp-remote` bridge (simplest):**
+
+```bash
+# In one terminal, expose halopsa-mcp over HTTPS via the bridge
+mcp-remote halopsa-mcp --port 7777
+# (Repeat for servosity-mcp on a different port)
+```
+
+Then in ChatGPT: Settings → Advanced → **enable Developer Mode** → Connectors tab → Add MCP server → URL = `https://<your-tunnel>:7777`. If your tunnel is local-only (e.g. ngrok), Developer Mode will refuse without HTTPS. Use a TLS tunnel (Cloudflare Tunnel, ngrok with HTTPS, your own reverse proxy).
+
+**Option 2 — run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
+
+```bash
+HALOPSA_TENANT=... halopsa-mcp --transport http --addr :7777
+```
+
+Then expose `https://<your-public-host>:7777` to ChatGPT via Developer Mode. Always behind a secure tunnel; never expose your MCP server bare on the internet.
+
+Sources: [InfoQ ChatGPT MCP](https://www.infoq.com/news/2025/10/chat-gpt-mcp/) · [OpenAI Connectors help](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) · [Developer Mode docs](https://platform.openai.com/docs/guides/developer-mode).
+
+---
+
+## Cursor
+
+AI-first code editor. Native MCP. Stdio, SSE, and Streamable HTTP.
+
+**Config:** `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global).
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  }
+}
+```
+
+Or use the Settings → MCP UI to add it via the panel. Cursor supports config interpolation for env vars. Source: [cursor.com/docs/mcp](https://cursor.com/docs/mcp).
+
+---
+
+## Windsurf
+
+The Cascade panel speaks MCP. Stdio, Streamable HTTP, and SSE. OAuth supported.
+
+**Setup:** Click the **MCP Marketplace** icon in the Cascade panel, or Settings → Cascade → MCP Servers → Add. Use the same `command` / `env` block shape as Claude Desktop.
+
+April 2026 update: OAuth fixes; Streamable HTTP replacing SSE. Source: [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp).
+
+---
+
+## Cline (VS Code)
+
+VS Code extension. Built-in MCP Marketplace.
+
+**Setup:** `Ctrl+Shift+M` (Windows / Linux) or `⌘+Shift+M` (macOS) opens the marketplace. Or click the **MCP Servers** icon → **Configure** tab → add `halopsa` / `servosity` with the `command` + `env` block.
+
+**Windows gotcha:** if Cline reports `spawn npx ENOENT`, wrap the command as `cmd` + `npx` per Cline's docs. MSP Skills' own binaries don't use `npx`, so this only matters if you're also installing Node-based MCP servers alongside.
+
+Source: [docs.cline.bot/mcp/adding-and-configuring-servers](https://docs.cline.bot/mcp/adding-and-configuring-servers).
+
+---
+
+## Continue.dev (VS Code / JetBrains)
+
+Open-source AI assistant. **MCP tools only work in Agent mode.** Stdio, SSE, Streamable HTTP. OAuth + env-var templating.
+
+**Setup:** edit Continue's `config.json` (per-IDE path varies; see Continue docs) and add:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "halopsa",
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    {
+      "name": "servosity",
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  ]
+}
+```
+
+**Switch Continue to Agent mode** in the chat panel for tools to fire. Source: [docs.continue.dev/customize/deep-dives/mcp](https://docs.continue.dev/customize/deep-dives/mcp).
+
+---
+
+## Gemini CLI (Google)
+
+Google's CLI agent. Native MCP — Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
+
+**Setup:** edit `~/.gemini/config.json` (or the path Gemini CLI prints with `gemini config path`) and add an `mcpServers` block with the same shape as Claude Desktop. Gemini CLI's tool list will include the MCP tools after restart.
+
+Google Cloud also offers fully-managed remote MCP servers for Google services — not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog — official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
+
+---
+
+## GitHub Copilot in VS Code
+
+GA in VS Code 1.102 (July 2025). Most enterprise-ready MCP client by reputation: sandboxing, OAuth, Settings Sync, curated marketplace.
+
+**Critical gotchas:**
+
+1. **Config file is `mcp.json`** (not `settings.json`).
+2. **Root key is `servers`** (NOT `mcpServers` like Claude). Easy to miss.
+3. **Works only in Copilot Agent mode** — pick "Agent" in the Copilot Chat mode dropdown.
+
+```json
+{
+  "servers": {
+    "halopsa": {
+      "type": "stdio",
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    "servosity": {
+      "type": "stdio",
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  }
+}
+```
+
+Or install through the Extensions view: search `@mcp` and install from the gallery. Source: [code.visualstudio.com/docs/copilot/customization/mcp-servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+
+---
+
+## Zed
+
+Calls them "context servers." **Partial MCP support** — Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
+
+**Setup:** open the Agent Panel (`Cmd+Shift+A`) → top-right menu → install server extensions. Or edit `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "halopsa": {
+      "command": { "path": "halopsa-mcp", "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" } }
+    },
+    "servosity": {
+      "command": { "path": "servosity-mcp", "env": { "SERVOSITY_MSP_TOKEN": "<token>" } }
+    }
+  }
+}
+```
+
+Most MSP Skills tools will appear in Zed's tool list; some advanced features that depend on full-spec MCP may not work yet. Source: [zed.dev/docs/ai/mcp](https://zed.dev/docs/ai/mcp).
+
+---
+
+## JetBrains AI Assistant / Junie
+
+JetBrains reportedly added MCP support in late 2025; we have not yet verified the install path against primary docs. If you use JetBrains AI Assistant or Junie and want MSP Skills support documented here, open an issue with the path you used and we'll add it.
+
+---
+
+## Hermes (Nous Research)
+
+Hermes is Nous Research's autonomous research agent. It speaks MCP natively per the [Nous Research docs](https://hermes-agent.nousresearch.com/docs) and has its own SKILL.md installer for Claude-Code-compatible skills.
+
+**MSP Skills works two ways under Hermes:**
+
+1. **Via MCP** (preferred — same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
+
+2. **Via Skill install** (uses the upstream cli-printing-press template). From the Hermes CLI:
+
+   ```bash
+   hermes skills install servosity/msp-skills/skills/halopsa --force
+   hermes skills install servosity/msp-skills/skills/servosity --force
+   ```
+
+   Inside a Hermes chat session:
+
+   ```
+   /skills install servosity/msp-skills/skills/halopsa --force
+   ```
+
+**Honest status:** the cli-printing-press alignment work for Hermes (PR #655) ships the frontmatter + README install sections, but end-to-end install of a printed CLI from a non-canonical path (i.e. `servosity/msp-skills/...` instead of `mvanhorn/printing-press-library/cli-skills/...`) has not been verified end-to-end by upstream. The MCP path (#1) is the more reliable route until Hermes confirms arbitrary GitHub-path resolution.
+
+---
+
+## OpenClaw
+
+OpenClaw is a browser-based Claude Code fork in active development. It's not yet generally available — but cli-printing-press wires every generated SKILL.md with an `openclaw:` metadata block that OpenClaw will recognize on launch.
+
+```yaml
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - halopsa-cli
+```
+
+That block is already in `skills/halopsa/SKILL.md` and `skills/servosity/SKILL.md`. When OpenClaw ships, the user-side install will be:
+
+> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI can be installed.
+
+(Same pattern for the servosity skill.) No action required from the MSP owner today; the wiring is forward-looking.
+
+---
+
+## I don't know what I have yet
+
+A 30-second triage:
+
+| You typed this and got an AI prompt | You have | Install path |
+| --- | --- | --- |
+| `claude` in a terminal | **Claude Code** | Skill or MCP — see above |
+| `codex` in a terminal | **Codex CLI** | Skill or MCP — see above |
+| `gemini` in a terminal | **Gemini CLI** | MCP — see above |
+| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP — see above |
+| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) — see above |
+| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP — see above |
+| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet — web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
+| You're not sure | — | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
+
+If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" — whichever has an app is what you have.
+
+---
+
+_All "Verified" dates reflect the date this document was last confirmed against primary sources. If you find a step that no longer works, please open an issue or send a PR. Last updated: 2026-05-28._

--- a/docs/which-agent.md
+++ b/docs/which-agent.md
@@ -4,11 +4,11 @@ MSP Skills works with **any AI tool that speaks MCP** (Model Context Protocol). 
 
 Pick the row for your agent and follow that section. If you're not sure what you have, jump to ["I don't know what I have"](#i-dont-know-what-i-have-yet) at the bottom.
 
-> **All paths assume you already ran the installer** for at least one skill — see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
+> **All paths assume you already ran the installer** for at least one skill - see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
 
 ## Quick lookup
 
-**The 4 MSP-owner primaries — lead here:**
+**The 4 MSP-owner primaries - lead here:**
 
 | AI agent | Supports MCP? | Config file or panel | Verified |
 | --- | --- | --- | --- |
@@ -30,12 +30,12 @@ Pick the row for your agent and follow that section. If you're not sure what you
 | [Zed](#zed) | Partial² | `context_servers` in `settings.json` | 2026-05-28 |
 | [JetBrains AI Assistant / Junie](#jetbrains-ai-assistant--junie) | _Verify_ | _verify_ | _pending_ |
 
-**Niche / pre-wired (advanced):**
+**Other agents:**
 
 | AI agent | Status | Install path | Verified |
 | --- | --- | --- | --- |
-| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install servosity/msp-skills/skills/<name>` | 2026-05-28 (paper — install not yet end-to-end tested) |
-| [OpenClaw](#openclaw) | Pre-wired (awaiting launch) | `openclaw:` frontmatter block already in every SKILL.md | 2026-05-28 (frontmatter wiring; OpenClaw not yet GA) |
+| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install Servosity/msp-skills/skills/<name>` | 2026-05-29 (paper - install not yet end-to-end tested) |
+| [OpenClaw](#openclaw) | Yes (GA) | `openclaw skills install git:Servosity/msp-skills/skills/<name>@main` | 2026-05-29 (frontmatter spec match; subdir install path needs final dogfood) |
 
 ¹ ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education). Free tier does not yet expose Developer Mode. ChatGPT connects only to **remote** MCP servers; local stdio binaries like MSP Skills need an HTTPS bridge (e.g. `mcp-remote`).
 ² Zed supports MCP Tools and Prompts today, not the full spec. Most MSP Skills functionality works; some advanced features may not.
@@ -44,7 +44,7 @@ Pick the row for your agent and follow that section. If you're not sure what you
 
 ## Claude Desktop (Anthropic)
 
-The Mac / Windows app with a chat window. First-class MCP host — the original.
+The Mac / Windows app with a chat window. First-class MCP host - the original.
 
 **Config file:**
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -79,7 +79,7 @@ The Mac / Windows app with a chat window. First-class MCP host — the original.
 
 ## Claude Code (Anthropic CLI)
 
-Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code — just install the skill normally — but you can register the MCP server too if you prefer that interface.
+Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code - just install the skill normally - but you can register the MCP server too if you prefer that interface.
 
 **Skill path (recommended):** the install script symlinks the skill into `~/.claude/skills/`. Restart Claude Code; invoke with `use halopsa` or `use servosity`.
 
@@ -117,13 +117,13 @@ Codex supports stdio + Streamable HTTP, and runs concurrent read-only tools when
 
 ---
 
-## ChatGPT (OpenAI) — Plus, Pro, Team, Business, Enterprise, Education
+## ChatGPT (OpenAI) - Plus, Pro, Team, Business, Enterprise, Education
 
 **Free tier does not yet expose Developer Mode**; you need a paid plan. ChatGPT speaks MCP through "Developer Mode" connectors (beta as of Sept 2025).
 
 **Important transport caveat:** ChatGPT connects only to **remote** MCP servers (HTTPS). MSP Skills binaries are local (stdio). To use them with ChatGPT, expose them over HTTPS:
 
-**Option 1 — `mcp-remote` bridge (simplest):**
+**Option 1 - `mcp-remote` bridge (simplest):**
 
 ```bash
 # In one terminal, expose halopsa-mcp over HTTPS via the bridge
@@ -133,7 +133,7 @@ mcp-remote halopsa-mcp --port 7777
 
 Then in ChatGPT: Settings → Advanced → **enable Developer Mode** → Connectors tab → Add MCP server → URL = `https://<your-tunnel>:7777`. If your tunnel is local-only (e.g. ngrok), Developer Mode will refuse without HTTPS. Use a TLS tunnel (Cloudflare Tunnel, ngrok with HTTPS, your own reverse proxy).
 
-**Option 2 — run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
+**Option 2 - run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
 
 ```bash
 HALOPSA_TENANT=... halopsa-mcp --transport http --addr :7777
@@ -221,11 +221,11 @@ Open-source AI assistant. **MCP tools only work in Agent mode.** Stdio, SSE, Str
 
 ## Gemini CLI (Google)
 
-Google's CLI agent. Native MCP — Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
+Google's CLI agent. Native MCP - Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
 
 **Setup:** edit `~/.gemini/config.json` (or the path Gemini CLI prints with `gemini config path`) and add an `mcpServers` block with the same shape as Claude Desktop. Gemini CLI's tool list will include the MCP tools after restart.
 
-Google Cloud also offers fully-managed remote MCP servers for Google services — not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog — official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
+Google Cloud also offers fully-managed remote MCP servers for Google services - not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog - official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
 
 ---
 
@@ -237,7 +237,7 @@ GA in VS Code 1.102 (July 2025). Most enterprise-ready MCP client by reputation:
 
 1. **Config file is `mcp.json`** (not `settings.json`).
 2. **Root key is `servers`** (NOT `mcpServers` like Claude). Easy to miss.
-3. **Works only in Copilot Agent mode** — pick "Agent" in the Copilot Chat mode dropdown.
+3. **Works only in Copilot Agent mode** - pick "Agent" in the Copilot Chat mode dropdown.
 
 ```json
 {
@@ -262,7 +262,7 @@ Or install through the Extensions view: search `@mcp` and install from the galle
 
 ## Zed
 
-Calls them "context servers." **Partial MCP support** — Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
+Calls them "context servers." **Partial MCP support** - Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
 
 **Setup:** open the Agent Panel (`Cmd+Shift+A`) → top-right menu → install server extensions. Or edit `settings.json`:
 
@@ -295,7 +295,7 @@ Hermes is Nous Research's autonomous research agent. It speaks MCP natively per 
 
 **MSP Skills works two ways under Hermes:**
 
-1. **Via MCP** (preferred — same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
+1. **Via MCP** (preferred - same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
 
 2. **Via Skill install** (uses the upstream cli-printing-press template). From the Hermes CLI:
 
@@ -316,21 +316,42 @@ Hermes is Nous Research's autonomous research agent. It speaks MCP natively per 
 
 ## OpenClaw
 
-OpenClaw is a browser-based Claude Code fork in active development. It's not yet generally available — but cli-printing-press wires every generated SKILL.md with an `openclaw:` metadata block that OpenClaw will recognize on launch.
+[OpenClaw](https://docs.openclaw.ai) is GA (latest stable as of May 2026). Browser-controlled AI agent with native Skill support (SKILL.md superset of Anthropic's spec) and native MCP. Public skill registry at [ClawHub](https://clawhub.ai).
 
-```yaml
-metadata:
-  openclaw:
-    requires:
-      bins:
-        - halopsa-cli
+**One-time setup:** install OpenClaw itself ([install docs](https://docs.openclaw.ai/install)).
+
+```bash
+# macOS / Linux / WSL2
+curl -fsSL https://openclaw.ai/install.sh | bash
+
+# Windows (PowerShell)
+iwr -useb https://openclaw.ai/install.ps1 | iex
 ```
 
-That block is already in `skills/halopsa/SKILL.md` and `skills/servosity/SKILL.md`. When OpenClaw ships, the user-side install will be:
+**Install MSP Skills' HaloPSA skill:**
 
-> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI can be installed.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/halopsa@main
+```
 
-(Same pattern for the servosity skill.) No action required from the MSP owner today; the wiring is forward-looking.
+**Install the Servosity skill:**
+
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/servosity@main
+```
+
+OpenClaw reads each skill's `SKILL.md`, sees the `metadata.openclaw.requires.bins` block (already in our frontmatter via cli-printing-press), and installs the required CLI. Run `openclaw doctor` to confirm the install + env vars.
+
+**Register the MCP servers too** (optional - the Skill path already gives you most of the value):
+
+```bash
+openclaw mcp set halopsa '{"command":"halopsa-mcp"}'
+openclaw mcp set servosity '{"command":"servosity-mcp"}'
+```
+
+See the [OpenClaw MCP CLI docs](https://docs.openclaw.ai/cli/mcp) for the canonical command shape.
+
+**Note on subdirectory install path.** OpenClaw's monorepo subdirectory `git:` syntax for `skills install` is documented in the ClawHub skill-format spec; if `git:Servosity/msp-skills/skills/halopsa@main` does not resolve in your build, fall back to cloning the repo locally and running `openclaw skills install ./msp-skills/skills/halopsa`. We are updating the dogfood receipt in the next release.
 
 ---
 
@@ -340,16 +361,16 @@ A 30-second triage:
 
 | You typed this and got an AI prompt | You have | Install path |
 | --- | --- | --- |
-| `claude` in a terminal | **Claude Code** | Skill or MCP — see above |
-| `codex` in a terminal | **Codex CLI** | Skill or MCP — see above |
-| `gemini` in a terminal | **Gemini CLI** | MCP — see above |
-| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP — see above |
-| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) — see above |
-| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP — see above |
-| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet — web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
-| You're not sure | — | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
+| `claude` in a terminal | **Claude Code** | Skill or MCP - see above |
+| `codex` in a terminal | **Codex CLI** | Skill or MCP - see above |
+| `gemini` in a terminal | **Gemini CLI** | MCP - see above |
+| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP - see above |
+| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) - see above |
+| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP - see above |
+| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet - web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
+| You're not sure | - | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
 
-If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" — whichever has an app is what you have.
+If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" - whichever has an app is what you have.
 
 ---
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["dstevens"]
+}

--- a/skills/halopsa/.claude-plugin/plugin.json
+++ b/skills/halopsa/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "halopsa",
+  "version": "0.1.0",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners. No code required.",
+  "author": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "homepage": "https://github.com/servosity/msp-skills/tree/main/skills/halopsa",
+  "repository": "https://github.com/servosity/msp-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "halopsa",
+    "halo",
+    "psa",
+    "msp",
+    "ticket-triage",
+    "sla-breach",
+    "client-card",
+    "contracts-burn",
+    "mcp",
+    "claude-code",
+    "claude-mcp"
+  ]
+}

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -1,15 +1,33 @@
-# HaloPSA Claude Code Skill and MCP Server - install, commands, examples
+# HaloPSA + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA,
-> HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by
-> Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of
-> Halo Service Solutions Ltd.
+> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA, HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of Halo Service Solutions Ltd.
 
-A HaloPSA Claude Code Skill and HaloPSA MCP server in one package, so your AI agent (Claude Code, Codex, Claude Desktop, or ChatGPT Desktop) can triage your queue, audit SLA breaches, build a per-client situational-awareness card, and reconcile contract hours without anyone clicking through five tabs in the Halo UI.
+Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot — no rate-limit hits during QBR prep. Built for MSP owners. No code required.
 
-The CLI wraps the full Halo REST API (952 endpoints across tickets, clients, assets, contracts, time, KB, and workflows) and stores a local SQLite mirror so cross-entity queries like `triage`, `client card`, and `contracts burn` are instant and answer questions the live API alone cannot.
+## Works with your agent
 
-## Install as a Claude Code Skill (also works for Codex)
+The four agents MSP owners actually use:
+
+| Your AI agent | How to install the HaloPSA skill |
+| --- | --- |
+| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
+| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The HaloPSA MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+### Path B — run the installer yourself
 
 **macOS / Linux:**
 
@@ -23,17 +41,17 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
 ```
 
-The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex will discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
+The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
 
-After install, verify:
+Verify:
 
 ```bash
 halopsa-cli --version
 ```
 
-## Install as an MCP server (Claude Desktop, ChatGPT Desktop)
+### Add to Claude Desktop
 
-Same install command as above also installs `halopsa-mcp`. Then wire it into your desktop agent. Full per-agent instructions in [mcp-install.md](./mcp-install.md). The TL;DR Claude Desktop config:
+After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
 
 ```json
 {
@@ -50,9 +68,36 @@ Same install command as above also installs `halopsa-mcp`. Then wire it into you
 }
 ```
 
-## Authenticate
+Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
 
-HaloPSA uses OAuth2 client_credentials. Create an API application in your tenant under Configuration > Integrations > Halo PSA API (Authentication Method: Client ID and Secret, Services), then run:
+<!-- pp-hermes-install-anchor -->
+### Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install servosity/msp-skills/skills/halopsa --force
+```
+
+Inside a Hermes chat session:
+
+```
+/skills install servosity/msp-skills/skills/halopsa --force
+```
+
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly — same install path, same env vars.
+
+### Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI (`halopsa-cli`) can be installed via the `openclaw:` frontmatter block.
+
+OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+
+### Authenticate
+
+HaloPSA uses OAuth2 client_credentials. Create an API application in your tenant under **Configuration → Integrations → Halo PSA API** (Authentication Method: Client ID and Secret, Services), then:
 
 ```bash
 HALOPSA_TENANT=<yourtenant> halopsa-cli auth login \
@@ -61,31 +106,79 @@ HALOPSA_TENANT=<yourtenant> halopsa-cli auth login \
 
 The CLI caches the access token and auto-refreshes before expiry.
 
-## First command
+## What this skill does
 
-```bash
-halopsa-cli triage --team Support --json
-```
+Outcome-first, with the single command that answers each question:
 
-Per-agent open ticket load, stale tickets, and 24-hour SLA-breach count in one table. The dispatcher view Halo's UI scatters across five tabs.
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What's about to breach SLA in the next 24 hours? | `halopsa-cli sla breaching --within 24h` |
+| What's the dispatcher view across all agents and teams? | `halopsa-cli triage --team Support` |
+| Who's overloaded right now? | `halopsa-cli agent workload` |
+| What's the whole story for this client, on one screen? | `halopsa-cli client card "Acme Corp"` |
+| How much contract time is left across every contract? | `halopsa-cli contracts burn` |
+| Which clients have stale tickets aging out? | `halopsa-cli tickets age-out` |
+| What changed in Halo since this morning? | `halopsa-cli tickets changed-since 9:00` |
+| What's the asset history for this device? | `halopsa-cli asset history <id>` |
+| Which KB article should the tech link to? | `halopsa-cli kbarticle suggest <ticket>` |
+| First-time hydration of the local SQLite mirror | `halopsa-cli sync --full` |
 
-## All commands
+Full command reference: [guide.md](./guide.md). For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), see [AGENTS.md](./AGENTS.md).
 
-Full reference: [guide.md](./guide.md). Highlights:
+## What makes this different
 
-- `halopsa-cli triage` - dispatcher view
-- `halopsa-cli sla breaching --within 24h` - pre-empt SLA breaches before a hand-off
-- `halopsa-cli client card "Acme Corp"` - one-panel client situational awareness
-- `halopsa-cli contracts burn` - contract hours remaining
-- `halopsa-cli agent workload` - per-agent open load, billable hours, oldest ticket
-- `halopsa-cli sync --full` - first-time hydration of the local SQLite mirror
+Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* — that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
 
-For the AI-agent operating contract (when to use `--agent` flag, `--dry-run`, etc.), read [AGENTS.md](./AGENTS.md).
+This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets — work a stateless API wrapper can't do.
+
+It complements HaloPSA's built-in ChatGPT integration (which is great for per-ticket work like rewriting replies and sentiment-flagging). The two are non-overlapping.
+
+## The pain this closes
+
+Two pains MSP owners name repeatedly:
+
+- **Cost-to-serve is rising faster than contract value.** The squeeze is operational: queue overload, SLA fires, unpriced work eating margin on every ticket.
+- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head — and in a PSA nobody else triages quickly.
+
+This skill puts the PSA's cross-entity truth one sentence away from any team member or their agent: `triage` / `sla breaching` surface what will breach before it does; `client card` gives any teammate one situational-awareness panel on demand; `contracts burn` catches unpriced work early; `agent workload` makes the queue legible across the whole team. The knowledge of how to read the PSA moves from a person into a Skill any teammate (or their agent) can run.
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not local stdio binaries. The HaloPSA MCP server is local, so for ChatGPT you expose it via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step in [mcp-install.md](./mcp-install.md).
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+
+### Do I need to know how to code?
+
+No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
+
+### Is my HaloPSA data safe?
+
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
+
+### Will this hit my HaloPSA API rate limits?
+
+Almost never. HaloPSA's rate limits aren't publicly documented and vary between cloud-hosted and self-hosted instances. This skill syncs once with `sync --full`, then incrementally; subsequent triage, SLA, client-card, and cross-client analytics queries run against the local mirror, not the live API. The big-batch queries that get you 429'd with API-passthrough tools become one SQL join here.
+
+### How is this different from HaloPSA's built-in ChatGPT integration?
+
+HaloPSA's built-in ChatGPT integration is great for **single-ticket** work — rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries are native Windows builds. Cline users on Windows may need a small `npx` workaround documented in [docs/which-agent.md](../../docs/which-agent.md).
+
+### What does it cost?
+
+Free. Apache-2.0 licensed. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and that's billed by your AI provider, not by us.
 
 ## Safety model
 
-The skill authenticates to **your own Halo tenant** with an OAuth application you
-create and scope. It defaults to discovery and dry-run before any mutation.
+The skill authenticates to **your own Halo tenant** with an OAuth application you create and scope. It defaults to discovery and dry-run before any mutation.
 
 | Tier | Examples | Recommended agent policy |
 | --- | --- | --- |
@@ -93,6 +186,14 @@ create and scope. It defaults to discovery and dry-run before any mutation.
 | Write (routine) | ticket updates, notes, assignment | Preview with `--dry-run`, then a reviewed write |
 | Destructive / config | deletes, configuration changes | Human-in-the-loop only |
 
-The strongest control is the **scope you grant the Halo OAuth application** - the
-CLI can only do what that application is permitted to do. Full details, including
-how to lock it down, are in [governance.md](./governance.md).
+The strongest control is the **scope you grant the Halo OAuth application** — the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
+
+## Status
+
+Beta. Validated against the HaloPSA API surface and being validated with MSPs running it live against their own production tenant in our weekly Build Sessions. RSVP at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions).
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). See [TRADEMARKS.md](../../TRADEMARKS.md) for vendor non-affiliation. _Last updated: 2026-05-28._

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -1,8 +1,8 @@
-# HaloPSA + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
+# HaloPSA + AI - for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
 > Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA, HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of Halo Service Solutions Ltd.
 
-Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot — no rate-limit hits during QBR prep. Built for MSP owners. No code required.
+Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot - no rate-limit hits during QBR prep. Built for MSP owners. No code required.
 
 ## Works with your agent
 
@@ -10,35 +10,35 @@ The four agents MSP owners actually use:
 
 | Your AI agent | How to install the HaloPSA skill |
 | --- | --- |
-| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Desktop** | Run installer, then **Settings > Extensions** to register `halopsa-mcp` (no JSON editing). |
+| **ChatGPT** (paid plans) | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
 | **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
 
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The HaloPSA MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
-> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
 
-### Path B — run the installer yourself
-
-**macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
-```
+### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 ```
 
 The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
@@ -85,15 +85,21 @@ Inside a Hermes chat session:
 /skills install servosity/msp-skills/skills/halopsa --force
 ```
 
-Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly — same install path, same env vars.
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly - same install path, same env vars.
 
 ### Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+[OpenClaw](https://docs.openclaw.ai) is GA. Install the skill directly from this repo:
 
-> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI (`halopsa-cli`) can be installed via the `openclaw:` frontmatter block.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/halopsa@main
+```
 
-OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+Or tell your OpenClaw agent (copy this):
+
+> Install the halopsa skill from https://github.com/Servosity/msp-skills/tree/main/skills/halopsa. The `metadata.openclaw` frontmatter declares the required CLI (`halopsa-cli`) and env vars; run `openclaw doctor` if anything is missing.
+
+`openclaw` also speaks MCP natively (see `openclaw mcp set` in the [OpenClaw MCP docs](https://docs.openclaw.ai/cli/mcp)) so you can wire `halopsa-mcp` as an MCP server alongside the skill.
 
 ### Authenticate
 
@@ -127,9 +133,9 @@ Full command reference: [guide.md](./guide.md). For the AI-agent operating contr
 
 ## What makes this different
 
-Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* — that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
+Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* - that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
 
-This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets — work a stateless API wrapper can't do.
+This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets - work a stateless API wrapper can't do.
 
 It complements HaloPSA's built-in ChatGPT integration (which is great for per-ticket work like rewriting replies and sentiment-flagging). The two are non-overlapping.
 
@@ -138,7 +144,7 @@ It complements HaloPSA's built-in ChatGPT integration (which is great for per-ti
 Two pains MSP owners name repeatedly:
 
 - **Cost-to-serve is rising faster than contract value.** The squeeze is operational: queue overload, SLA fires, unpriced work eating margin on every ticket.
-- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head — and in a PSA nobody else triages quickly.
+- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head - and in a PSA nobody else triages quickly.
 
 This skill puts the PSA's cross-entity truth one sentence away from any team member or their agent: `triage` / `sla breaching` surface what will breach before it does; `client card` gives any teammate one situational-awareness panel on demand; `contracts burn` catches unpriced work early; `agent workload` makes the queue legible across the whole team. The knowledge of how to read the PSA moves from a person into a Skill any teammate (or their agent) can run.
 
@@ -150,15 +156,15 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+Yes - all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
 
 ### Do I need to know how to code?
 
-No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
+No. The recommended install is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
 
 ### Is my HaloPSA data safe?
 
-Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns - typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
 
 ### Will this hit my HaloPSA API rate limits?
 
@@ -166,7 +172,7 @@ Almost never. HaloPSA's rate limits aren't publicly documented and vary between 
 
 ### How is this different from HaloPSA's built-in ChatGPT integration?
 
-HaloPSA's built-in ChatGPT integration is great for **single-ticket** work — rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
+HaloPSA's built-in ChatGPT integration is great for **single-ticket** work - rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
 
 ### Can I run this on Windows?
 
@@ -186,7 +192,7 @@ The skill authenticates to **your own Halo tenant** with an OAuth application yo
 | Write (routine) | ticket updates, notes, assignment | Preview with `--dry-run`, then a reviewed write |
 | Destructive / config | deletes, configuration changes | Human-in-the-loop only |
 
-The strongest control is the **scope you grant the Halo OAuth application** — the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
+The strongest control is the **scope you grant the Halo OAuth application** - the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
 
 ## Status
 
@@ -194,6 +200,6 @@ Beta. Validated against the HaloPSA API surface and being validated with MSPs ru
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works directly.
 
 Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). See [TRADEMARKS.md](../../TRADEMARKS.md) for vendor non-affiliation. _Last updated: 2026-05-28._

--- a/skills/halopsa/SKILL.md
+++ b/skills/halopsa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: halopsa
-description: "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return. Trigger phrases: `triage my Halo queue`, `check SLA breaches in HaloPSA`, `who's overloaded in Halo`, `client card for Acme`, `Halo contract burn-down`, `what changed in Halo since this morning`, `use halopsa`, `run halopsa`."
+description: "Use when the user asks to triage their HaloPSA queue, audit SLA breaches, build a per-client situational-awareness card, reconcile contract hours, check agent workload, or run any cross-client analytic question against HaloPSA, HaloITSM, or HaloCRM. Wraps the full HaloPSA REST API plus a local SQLite mirror so cross-entity queries the live API can't return in one shot are fast and offline. Trigger phrases: `triage my Halo queue`, `check SLA breaches in HaloPSA`, `who's overloaded in Halo`, `client card for Acme`, `Halo contract burn-down`, `what changed in Halo since this morning`, `HaloPSA + ChatGPT`, `HaloPSA + Claude`, `use halopsa`, `run halopsa`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "HaloPSA"

--- a/skills/halopsa/manifest.json
+++ b/skills/halopsa/manifest.json
@@ -3,7 +3,7 @@
   "name": "halopsa-mcp",
   "display_name": "Halo",
   "version": "0.1.0",
-  "description": "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return.",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
   "author": {
     "name": "Servosity Inc."
   },

--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.servosity/halopsa-mcp",
+  "title": "HaloPSA MCP",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners.",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/servosity/msp-skills",
+    "source": "github",
+    "subfolder": "skills/halopsa"
+  },
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "halopsa-mcp",
+      "version": "0.1.0",
+      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-mcp-v0.1.0/halopsa-mcp.mcpb",
+      "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "HALOPSA_TENANT",
+          "description": "Your HaloPSA tenant identifier.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "HALOPSA_CLIENT_ID",
+          "description": "OAuth2 client_credentials ID from Configuration → Integrations → Halo PSA API.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "HALOPSA_CLIENT_SECRET",
+          "description": "OAuth2 client_credentials secret.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "HALOPSA_DOMAIN",
+          "description": "Domain template variable. Defaults to halopsa.com.",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "halopsa.com"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/servosity/.claude-plugin/plugin.json
+++ b/skills/servosity/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "servosity",
+  "version": "0.1.0",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
+  "author": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "homepage": "https://github.com/servosity/msp-skills/tree/main/skills/servosity",
+  "repository": "https://github.com/servosity/msp-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "servosity",
+    "backup",
+    "bcdr",
+    "disaster-recovery",
+    "msp",
+    "fleet-monitoring",
+    "stale-backup",
+    "cross-engine",
+    "mcp",
+    "claude-code",
+    "claude-mcp"
+  ]
+}

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -1,8 +1,8 @@
-# Servosity + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
+# Servosity + AI - for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
 > Published by Servosity Inc. for MSP partners. Servosity is a trademark of Servosity Inc. Apache-2.0 licensed.
 
-Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen — Friday-email-ready in seconds. Built for MSP partners. No code required.
+Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen - Friday-email-ready in seconds. Built for MSP partners. No code required.
 
 ## Works with your agent
 
@@ -10,35 +10,35 @@ The four agents MSP owners actually use:
 
 | Your AI agent | How to install the Servosity skill |
 | --- | --- |
-| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Desktop** | Run installer, then **Settings > Extensions** to register `servosity-mcp` (no JSON editing). |
+| **ChatGPT** (paid plans) | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
 | **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
 
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The Servosity MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
-> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **Servosity** skill from https://github.com/servosity/msp-skills — read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
+> Set up the **Servosity** skill from https://github.com/servosity/msp-skills - read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
 
-### Path B — run the installer yourself
-
-**macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
-```
+### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
 ```
 
 The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory.
@@ -83,15 +83,21 @@ Inside a Hermes chat session:
 /skills install servosity/msp-skills/skills/servosity --force
 ```
 
-Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly — same install path, same env vars.
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly - same install path, same env vars.
 
 ### Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+[OpenClaw](https://docs.openclaw.ai) is GA. Install the skill directly from this repo:
 
-> Install the servosity skill from https://github.com/servosity/msp-skills/tree/main/skills/servosity. The skill defines how its required CLI (`servosity-cli`) can be installed via the `openclaw:` frontmatter block.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/servosity@main
+```
 
-OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+Or tell your OpenClaw agent (copy this):
+
+> Install the servosity skill from https://github.com/Servosity/msp-skills/tree/main/skills/servosity. The `metadata.openclaw` frontmatter declares the required CLI (`servosity-cli`) and env vars; run `openclaw doctor` if anything is missing.
+
+`openclaw` also speaks MCP natively (see `openclaw mcp set` in the [OpenClaw MCP docs](https://docs.openclaw.ai/cli/mcp)) so you can wire `servosity-mcp` as an MCP server alongside the skill.
 
 ### Authenticate
 
@@ -123,15 +129,15 @@ Full command reference: [guide.md](./guide.md). For the AI-agent operating contr
 
 ## What makes this different
 
-Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* — the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
+Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* - the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
 
-This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events — work a stateless API wrapper can't do.
+This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events - work a stateless API wrapper can't do.
 
 ## The pain this closes
 
 Backup and DR is where "silent failure" hurts most. The pains MSP owners name:
 
-- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore — the worst possible moment to find out.
+- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore - the worst possible moment to find out.
 - **No fleet-wide view.** Each client's backup state lives in its own portal view; there is no single screen that says "across my whole book, here's what's stale, failing, or in-flight right now."
 - **Alert-queue noise buries the real failure.** Dozens of repeat and known-safe issues pile up per client; the one that matters hides in the pile.
 - **Per-client questions mean portal archaeology.** Answering "is this client OK?" means clicking through metadata, three backup engines, contracts, and issues by hand.
@@ -146,7 +152,7 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+Yes - all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
 
 ### Do I need to be a Servosity MSP partner?
 
@@ -154,15 +160,15 @@ Yes. The Servosity API surface this skill wraps is the one available to **authen
 
 ### Will this replace my Servosity partner portal?
 
-No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI — so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
+No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI - so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
 
 ### Do I need to know how to code?
 
-No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
+No. The recommended install is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
 
 ### Is my Servosity / client data safe?
 
-Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns - typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
 
 ### Can I run this on Windows?
 
@@ -170,7 +176,7 @@ Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries ar
 
 ### What does it cost?
 
-Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill — the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
+Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill - the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
 
 ## Safety model
 
@@ -192,6 +198,6 @@ Already used inside Servosity's own backup / DR operations; published here for M
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works directly.
 
 Maintained by [Servosity](https://www.servosity.com). Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). _Last updated: 2026-05-28._

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -1,13 +1,33 @@
-# Servosity Claude Code Skill and MCP Server - install, commands, examples
+# Servosity + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
-> Published by Servosity Inc. for MSP partners. Servosity is a trademark of
-> Servosity Inc. Apache-2.0 licensed.
+> Published by Servosity Inc. for MSP partners. Servosity is a trademark of Servosity Inc. Apache-2.0 licensed.
 
-A Servosity Claude Code Skill and Servosity MCP server in one package, so your AI agent (Claude Code, Codex, Claude Desktop, or ChatGPT Desktop) can triage your backup fleet, surface stale backup sets, diff yesterday's snapshot against today, and answer cross-engine questions without anyone clicking through the partner portal.
+Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen — Friday-email-ready in seconds. Built for MSP partners. No code required.
 
-The CLI wraps the Servosity REST API surface available to authenticated MSP partners, with a local fleet mirror, snapshot history, and cross-engine rollups so commands like `attention`, `drift`, and `stale-backups` work offline once cached.
+## Works with your agent
 
-## Install as a Claude Code Skill (also works for Codex)
+The four agents MSP owners actually use:
+
+| Your AI agent | How to install the Servosity skill |
+| --- | --- |
+| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
+| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The Servosity MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **Servosity** skill from https://github.com/servosity/msp-skills — read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
+
+### Path B — run the installer yourself
 
 **macOS / Linux:**
 
@@ -21,7 +41,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
-The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex will discover the Skill via `SKILL.md` in this directory.
+The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory.
 
 Verify:
 
@@ -29,9 +49,9 @@ Verify:
 servosity-cli --version
 ```
 
-## Install as an MCP server (Claude Desktop, ChatGPT Desktop)
+### Add to Claude Desktop
 
-Same install command also installs `servosity-mcp`. Then wire it into your desktop agent. Full per-agent instructions in [mcp-install.md](./mcp-install.md). The TL;DR Claude Desktop config:
+After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
 
 ```json
 {
@@ -46,7 +66,34 @@ Same install command also installs `servosity-mcp`. Then wire it into your deskt
 }
 ```
 
-## Authenticate
+Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
+
+<!-- pp-hermes-install-anchor -->
+### Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install servosity/msp-skills/skills/servosity --force
+```
+
+Inside a Hermes chat session:
+
+```
+/skills install servosity/msp-skills/skills/servosity --force
+```
+
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly — same install path, same env vars.
+
+### Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+> Install the servosity skill from https://github.com/servosity/msp-skills/tree/main/skills/servosity. The skill defines how its required CLI (`servosity-cli`) can be installed via the `openclaw:` frontmatter block.
+
+OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+
+### Authenticate
 
 Get your partner API token from the Servosity partner portal, then:
 
@@ -56,32 +103,78 @@ SERVOSITY_MSP_TOKEN=<token> servosity-cli doctor
 
 `doctor` confirms the token works and the local mirror is reachable before you run anything that touches client data.
 
-## First command
+## What this skill does
 
-```bash
-servosity-cli attention --json
-```
+Outcome-first, with the single command that answers each question:
 
-One screen across your whole book of clients: merged open issues, stale backups, and in-flight DR events, ranked per company. Run this in the morning to triage what needs follow-up without clicking through the portal.
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What needs my attention across every client this morning? | `servosity-cli attention` |
+| Which backups went stale across all clients? | `servosity-cli stale-backups --days 7` |
+| What changed across my fleet overnight? | `servosity-cli drift --from yesterday --to now` |
+| What's the whole story for this client, on one screen? | `servosity-cli company show <id>` |
+| Search across companies, backups, and issues at once | `servosity-cli find "image manager"` |
+| Triage what's worth keeping in the alert queue | `servosity-cli triage` |
+| Clear known-safe alert noise so real failures show | `servosity-cli clear` |
+| List DR restores in flight | `servosity-cli restore-queue list` |
+| First-time hydration of the local fleet mirror | `servosity-cli sync --full` |
 
-## All commands
+Full command reference: [guide.md](./guide.md). For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), see [AGENTS.md](./AGENTS.md).
 
-Full reference: [guide.md](./guide.md). Highlights:
+## What makes this different
 
-- `servosity-cli attention` - cross-client morning triage
-- `servosity-cli drift --from yesterday --to now` - what changed overnight
-- `servosity-cli stale-backups` - stale-backup-sets by company, age, engine
-- `servosity-cli sync --full` - first-time hydration of the local fleet mirror
-- `servosity-cli company show 4421` - per-client situational awareness (metadata, contracts, backups across 3 engines, open issues)
-- `servosity-cli find "image manager"` - one FTS5 query across companies, issues, and backups
+Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* — the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
 
-For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), read [AGENTS.md](./AGENTS.md).
+This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events — work a stateless API wrapper can't do.
+
+## The pain this closes
+
+Backup and DR is where "silent failure" hurts most. The pains MSP owners name:
+
+- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore — the worst possible moment to find out.
+- **No fleet-wide view.** Each client's backup state lives in its own portal view; there is no single screen that says "across my whole book, here's what's stale, failing, or in-flight right now."
+- **Alert-queue noise buries the real failure.** Dozens of repeat and known-safe issues pile up per client; the one that matters hides in the pile.
+- **Per-client questions mean portal archaeology.** Answering "is this client OK?" means clicking through metadata, three backup engines, contracts, and issues by hand.
+
+This skill turns per-client portal views into fleet-wide, offline-fast intelligence: `attention` is one screen across every client; `stale-backups` is the Friday-email list, ready; `drift` opens Monday with situational awareness instead of a blank slate; `triage` / `clear` / `stale-issues` batch-suppress known-safe noise so the queue shows only what's new; `company show` / `find` answer per-client and cross-fleet questions in one command.
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not local stdio binaries. The Servosity MCP server is local, so for ChatGPT you expose it via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step in [mcp-install.md](./mcp-install.md).
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+
+### Do I need to be a Servosity MSP partner?
+
+Yes. The Servosity API surface this skill wraps is the one available to **authenticated MSP partners**. You'll need a partner API token from the Servosity partner portal. The skill itself is free; the token is part of your Servosity partner agreement. Not a Servosity partner yet? Reach out via [servosity.com](https://www.servosity.com).
+
+### Will this replace my Servosity partner portal?
+
+No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI — so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
+
+### Do I need to know how to code?
+
+No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
+
+### Is my Servosity / client data safe?
+
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries are native Windows builds.
+
+### What does it cost?
+
+Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill — the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
 
 ## Safety model
 
-The skill authenticates with one partner token, scoped to **your reseller
-account only** (no cross-reseller access). Every mutating command plans by
-default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
+The skill authenticates with one partner token, scoped to **your reseller account only** (no cross-reseller access). Every mutating command plans by default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
 
 | Tier | Examples | Recommended agent policy |
 | --- | --- | --- |
@@ -91,6 +184,14 @@ default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
 | Destructive | `companies delete`, `backups delete`, `restic-backups restic-prune`, `users delete` | Human-in-the-loop only |
 | Admin (hidden) | `admin ...` | Operator-only, not for agents |
 
-Keep autonomous agents to **Read plus planned writes**; gate everything below
-that behind a human. Full matrix and lock-down guidance in
-[governance.md](./governance.md).
+Keep autonomous agents to **Read plus planned writes**; gate everything below that behind a human. Full matrix and lock-down guidance in [governance.md](./governance.md).
+
+## Status
+
+Already used inside Servosity's own backup / DR operations; published here for MSP partners. The public surface is in beta and being validated with MSPs in live Build Sessions. RSVP at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions).
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com). Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). _Last updated: 2026-05-28._

--- a/skills/servosity/SKILL.md
+++ b/skills/servosity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: servosity
-description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query — offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
+description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query - offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "Servosity"
@@ -39,28 +39,28 @@ Servosity REST API surface available to authenticated MSP partners. All operatio
 These capabilities aren't available in any other tool for this API.
 
 ### Fleet-wide intelligence
-- **`attention`**  -  One screen across your whole book of clients. Merges open issues, stale backups, and in-flight DR events into a per-company ranked view, then persists the result so tomorrow's drift command can compare.
+- **`attention`** - One screen across your whole book of clients. Merges open issues, stale backups, and in-flight DR events into a per-company ranked view, then persists the result so tomorrow's drift command can compare.
 
   _Reach for this in the morning to triage what needs follow-up across every client without clicking through a portal._
 
   ```bash
   servosity-cli attention --json
   ```
-- **`drift`**  -  Diff two snapshots the CLI collected  -  show which companies got worse, which recovered, and which are new since a past anchor. Default compares yesterday-to-now on the attention metric.
+- **`drift`** - Diff two snapshots the CLI collected - show which companies got worse, which recovered, and which are new since a past anchor. Default compares yesterday-to-now on the attention metric.
 
   _Use Monday morning to start with situation awareness instead of treating every week as a fresh slate._
 
   ```bash
   servosity-cli drift --metric attention --from yesterday --to now --json
   ```
-- **`stale-backups`**  -  Slice the synced `/reports/stale-backup-sets/` snapshot by reseller, company, age window, and backup engine  -  entirely offline once synced. Use --refresh to re-pull freshness from the live report.
+- **`stale-backups`** - Slice the synced `/reports/stale-backup-sets/` snapshot by reseller, company, age window, and backup engine - entirely offline once synced. Use --refresh to re-pull freshness from the live report.
 
   _Run this Friday afternoon to compile the list of clients you need to email about a stalled backup._
 
   ```bash
   servosity-cli stale-backups --days 7 --engine restic --json
   ```
-- **`backup-facts`**  -  Unified view across Servosity's three backup engines (classic, restic, DR) for one company or all. Engine, ID, hostname, last_successful_at, status  -  joined from three local store tables into one table.
+- **`backup-facts`** - Unified view across Servosity's three backup engines (classic, restic, DR) for one company or all. Engine, ID, hostname, last_successful_at, status - joined from three local store tables into one table.
 
   _Reach for this when triaging a client who has multiple engines protecting different devices and you need to know which engine is failing where._
 
@@ -68,25 +68,25 @@ These capabilities aren't available in any other tool for this API.
   servosity-cli backup-facts --company 4421 --status fail --json
   ```
 
-- **`find`**  -  SQLite FTS5 across companies (name, billing notes), issues (title and comments), and backups (descriptive name, last error)  -  one query hits the whole fleet.
+- **`find`** - SQLite FTS5 across companies (name, billing notes), issues (title and comments), and backups (descriptive name, last error) - one query hits the whole fleet.
 
-  _Use when you remember a phrase but not which entity owned it  -  one call replaces hunting through three list pages._
+  _Use when you remember a phrase but not which entity owned it - one call replaces hunting through three list pages._
 
   ```bash
   servosity-cli find "image manager" --in issues,backups --json
   ```
 
 ### Per-company quick view
-- **`company show`**  -  One command pulls a company's metadata + addresses + contracts + all backups across three engines + open issues + agent sessions into one human or `--json` view.
+- **`company show`** - One command pulls a company's metadata + addresses + contracts + all backups across three engines + open issues + agent sessions into one human or `--json` view.
 
-  _Use when a customer asks "is my backup OK?"  -  one call, every relevant fact, ready to paste into a ticket._
+  _Use when a customer asks "is my backup OK?" - one call, every relevant fact, ready to paste into a ticket._
 
   ```bash
   servosity-cli company show 4421 --json
   ```
 
 ### Daily ops efficiency
-- **`triage`**  -  List open issues with filters, then batch ignore / archive / reactivate / comment in one invocation. Plans by default; pass --confirm to mutate. Typed exit codes.
+- **`triage`** - List open issues with filters, then batch ignore / archive / reactivate / comment in one invocation. Plans by default; pass --confirm to mutate. Typed exit codes.
 
   _Use when the issue queue is bursty or during a planned-outage window where many alerts cluster around one client._
 
@@ -96,7 +96,7 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Disaster recovery
-- **`restore-queue list`**  -  List per-company restore queues across the whole book; `--watch` repolls on an interval and prints diffs since the last tick.
+- **`restore-queue list`** - List per-company restore queues across the whole book; `--watch` repolls on an interval and prints diffs since the last tick.
 
   _Use during an active disaster recovery event when multiple clients have restores in flight._
 
@@ -106,15 +106,15 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Tier-One support workflows
-- **`clear`**  -  Resolve one or more names as companies (then resellers) and batch-ignore their active issues until a human-readable time. Defaults to --dry-run; pass --confirm to mutate.
+- **`clear`** - Resolve one or more names as companies (then resellers) and batch-ignore their active issues until a human-readable time. Defaults to --dry-run; pass --confirm to mutate.
 
-  _Use when a partner is doing planned maintenance and you want their alert noise paused until morning  -  one command instead of dozens of UI clicks._
+  _Use when a partner is doing planned maintenance and you want their alert noise paused until morning - one command instead of dozens of UI clicks._
 
   ```bash
   servosity-cli clear "ACME Corp" --until "6am tomorrow"
   servosity-cli clear "ACME Corp" --until "6am tomorrow" --confirm
   ```
-- **`stale-issues`**  -  Pull your FMDB companies, fetch active issues, classify known-safe-to-archive patterns from a shipped rule table, auto-archive the safe ones, ignore non-dashboard noise, and print unknowns for review. Defaults to --dry-run.
+- **`stale-issues`** - Pull your FMDB companies, fetch active issues, classify known-safe-to-archive patterns from a shipped rule table, auto-archive the safe ones, ignore non-dashboard noise, and print unknowns for review. Defaults to --dry-run.
 
   _Run this every weekday before standup to clear the obvious stale noise off your dashboard so triage focuses on what's actually new._
 
@@ -125,200 +125,200 @@ These capabilities aren't available in any other tool for this API.
 
 ## Command Reference
 
-**agent-login**  -  Manage agent login
+**agent-login** - Manage agent login
 
-- `servosity-cli agent-login create`  -  Create
-- `servosity-cli agent-login list`  -  List
+- `servosity-cli agent-login create` - Create
+- `servosity-cli agent-login list` - List
 
-**agent-sessions**  -  Manage agent sessions
+**agent-sessions** - Manage agent sessions
 
-- `servosity-cli agent-sessions <agent_session_id>`  -  Read
+- `servosity-cli agent-sessions <agent_session_id>` - Read
 
-**backup-job-report**  -  Manage backup job report
+**backup-job-report** - Manage backup job report
 
-- `servosity-cli backup-job-report <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>`  -  View detailed backup report for a backup job and destination.
+- `servosity-cli backup-job-report <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>` - View detailed backup report for a backup job and destination.
 
-**backup-job-report-summary**  -  Manage backup job report summary
+**backup-job-report-summary** - Manage backup job report summary
 
-- `servosity-cli backup-job-report-summary <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>`  -  View summary backup report for a backup job and destination.
+- `servosity-cli backup-job-report-summary <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>` - View summary backup report for a backup job and destination.
 
-**backup-job-status**  -  Manage backup job status
+**backup-job-status** - Manage backup job status
 
-- `servosity-cli backup-job-status <backup_id>`  -  List backup job status for a backup account on a specific date.
+- `servosity-cli backup-job-status <backup_id>` - List backup job status for a backup account on a specific date.
 
-**backup-jobs**  -  Manage backup jobs
+**backup-jobs** - Manage backup jobs
 
-- `servosity-cli backup-jobs <backup_id>`  -  List backup jobs for a backup account.
+- `servosity-cli backup-jobs <backup_id>` - List backup jobs for a backup account.
 
-**backup-plans**  -  Manage backup plans
+**backup-plans** - Manage backup plans
 
-- `servosity-cli backup-plans list`  -  List backup plans.
-- `servosity-cli backup-plans read`  -  View a backup plan.
+- `servosity-cli backup-plans list` - List backup plans.
+- `servosity-cli backup-plans read` - View a backup plan.
 
-**backup-search**  -  Manage backup search
+**backup-search** - Manage backup search
 
-- `servosity-cli backup-search`  -  List
+- `servosity-cli backup-search` - List
 
-**backup-sets**  -  Manage backup sets
+**backup-sets** - Manage backup sets
 
-- `servosity-cli backup-sets create`  -  Create a backup-set for a backup account.
-- `servosity-cli backup-sets delete`  -  Delete a backup-set for a backup account.
-- `servosity-cli backup-sets list`  -  List backup-sets for a backup account.
-- `servosity-cli backup-sets read`  -  View a backup-set for a backup account.
-- `servosity-cli backup-sets update`  -  Accepts a json body with the following optional parameters.
+- `servosity-cli backup-sets create` - Create a backup-set for a backup account.
+- `servosity-cli backup-sets delete` - Delete a backup-set for a backup account.
+- `servosity-cli backup-sets list` - List backup-sets for a backup account.
+- `servosity-cli backup-sets read` - View a backup-set for a backup account.
+- `servosity-cli backup-sets update` - Accepts a json body with the following optional parameters.
 
-**backups**  -  Manage backups
+**backups** - Manage backups
 
-- `servosity-cli backups create`  -  Create a backup account.
-- `servosity-cli backups delete`  -  Delete a backup account, also deleting all backup data.
-- `servosity-cli backups list`  -  List backup accounts.
-- `servosity-cli backups mfa-codes`  -  Mfa codes
-- `servosity-cli backups partial-update`  -  Partial update
-- `servosity-cli backups read`  -  View a backup account.
-- `servosity-cli backups update`  -  Update a backup account.
+- `servosity-cli backups create` - Create a backup account.
+- `servosity-cli backups delete` - Delete a backup account, also deleting all backup data.
+- `servosity-cli backups list` - List backup accounts.
+- `servosity-cli backups mfa-codes` - Mfa codes
+- `servosity-cli backups partial-update` - Partial update
+- `servosity-cli backups read` - View a backup account.
+- `servosity-cli backups update` - Update a backup account.
 
-**companies**  -  Manage companies
+**companies** - Manage companies
 
-- `servosity-cli companies create`  -  Create a company.
-- `servosity-cli companies delete`  -  Delete a company, also deleting all backup accounts and backup data.
-- `servosity-cli companies fully-managed`  -  List fully-managed companies.
-- `servosity-cli companies fully-managed-ng`  -  List fully-managed companies.
-- `servosity-cli companies list`  -  List companies.
-- `servosity-cli companies partial-update`  -  Partial update
-- `servosity-cli companies read`  -  View a company.
-- `servosity-cli companies summary`  -  List companies with account summaries.
-- `servosity-cli companies summary-ng`  -  Summary ng
-- `servosity-cli companies update`  -  Update a company.
+- `servosity-cli companies create` - Create a company.
+- `servosity-cli companies delete` - Delete a company, also deleting all backup accounts and backup data.
+- `servosity-cli companies fully-managed` - List fully-managed companies.
+- `servosity-cli companies fully-managed-ng` - List fully-managed companies.
+- `servosity-cli companies list` - List companies.
+- `servosity-cli companies partial-update` - Partial update
+- `servosity-cli companies read` - View a company.
+- `servosity-cli companies summary` - List companies with account summaries.
+- `servosity-cli companies summary-ng` - Summary ng
+- `servosity-cli companies update` - Update a company.
 
-**company-notes**  -  Manage company notes
+**company-notes** - Manage company notes
 
-- `servosity-cli company-notes create`  -  Create
-- `servosity-cli company-notes delete`  -  Delete
-- `servosity-cli company-notes list`  -  List
-- `servosity-cli company-notes partial-update`  -  Partial update
-- `servosity-cli company-notes read`  -  Read
-- `servosity-cli company-notes update`  -  Update
+- `servosity-cli company-notes create` - Create
+- `servosity-cli company-notes delete` - Delete
+- `servosity-cli company-notes list` - List
+- `servosity-cli company-notes partial-update` - Partial update
+- `servosity-cli company-notes read` - Read
+- `servosity-cli company-notes update` - Update
 
-**components**  -  Manage components
+**components** - Manage components
 
-- `servosity-cli components`  -  List
+- `servosity-cli components` - List
 
-**contracts**  -  Manage contracts
+**contracts** - Manage contracts
 
-- `servosity-cli contracts create`  -  Create
-- `servosity-cli contracts get-by-token`  -  Get by token
-- `servosity-cli contracts list`  -  List
-- `servosity-cli contracts partial-update`  -  Partial update
-- `servosity-cli contracts read`  -  Read
-- `servosity-cli contracts signatures`  -  Signatures
-- `servosity-cli contracts update`  -  Update
+- `servosity-cli contracts create` - Create
+- `servosity-cli contracts get-by-token` - Get by token
+- `servosity-cli contracts list` - List
+- `servosity-cli contracts partial-update` - Partial update
+- `servosity-cli contracts read` - Read
+- `servosity-cli contracts signatures` - Signatures
+- `servosity-cli contracts update` - Update
 
-**credentials**  -  Manage credentials
+**credentials** - Manage credentials
 
-- `servosity-cli credentials create`  -  Create
-- `servosity-cli credentials delete`  -  Delete
-- `servosity-cli credentials list`  -  List
-- `servosity-cli credentials partial-update`  -  Partial update
-- `servosity-cli credentials read`  -  Read
-- `servosity-cli credentials update`  -  Update
+- `servosity-cli credentials create` - Create
+- `servosity-cli credentials delete` - Delete
+- `servosity-cli credentials list` - List
+- `servosity-cli credentials partial-update` - Partial update
+- `servosity-cli credentials read` - Read
+- `servosity-cli credentials update` - Update
 
-**current-user**  -  Manage current user
+**current-user** - Manage current user
 
-- `servosity-cli current-user api-token-delete`  -  Delete the current user's API token. A new one will be generated when requested.
-- `servosity-cli current-user api-token-list`  -  You will receive JSON response with `token`.
-- `servosity-cli current-user create`  -  Change the password of the current logged in user.
-- `servosity-cli current-user groups-list`  -  Groups list
-- `servosity-cli current-user helpjuice-sso-create`  -  Helpjuice sso create
-- `servosity-cli current-user hubspot-sso-create`  -  Hubspot sso create
-- `servosity-cli current-user list`  -  Get information about the current logged in user.
-- `servosity-cli current-user mfa-backup-codes-list`  -  Get unused backup codes. If no unused codes are left, remove all and generate new codes.
-- `servosity-cli current-user mfa-backup-codes-update`  -  Remove all backup codes and generate new codes.
-- `servosity-cli current-user notifications-delete`  -  Notifications delete
-- `servosity-cli current-user notifications-list`  -  Get current user notifications
-- `servosity-cli current-user profile-create`  -  Profile create
-- `servosity-cli current-user profile-list`  -  Profile list
-- `servosity-cli current-user start-mfa-create`  -  Start mfa create
-- `servosity-cli current-user start-mfa-list`  -  Start mfa list
-- `servosity-cli current-user start-mfa-verify-create`  -  Start mfa verify create
-- `servosity-cli current-user verified-mfa-delete`  -  Verified mfa delete
-- `servosity-cli current-user verified-mfa-list`  -  Verified mfa list
-- `servosity-cli current-user verified-mfa-send-code-create`  -  Verified mfa send code create
+- `servosity-cli current-user api-token-delete` - Delete the current user's API token. A new one will be generated when requested.
+- `servosity-cli current-user api-token-list` - You will receive JSON response with `token`.
+- `servosity-cli current-user create` - Change the password of the current logged in user.
+- `servosity-cli current-user groups-list` - Groups list
+- `servosity-cli current-user helpjuice-sso-create` - Helpjuice sso create
+- `servosity-cli current-user hubspot-sso-create` - Hubspot sso create
+- `servosity-cli current-user list` - Get information about the current logged in user.
+- `servosity-cli current-user mfa-backup-codes-list` - Get unused backup codes. If no unused codes are left, remove all and generate new codes.
+- `servosity-cli current-user mfa-backup-codes-update` - Remove all backup codes and generate new codes.
+- `servosity-cli current-user notifications-delete` - Notifications delete
+- `servosity-cli current-user notifications-list` - Get current user notifications
+- `servosity-cli current-user profile-create` - Profile create
+- `servosity-cli current-user profile-list` - Profile list
+- `servosity-cli current-user start-mfa-create` - Start mfa create
+- `servosity-cli current-user start-mfa-list` - Start mfa list
+- `servosity-cli current-user start-mfa-verify-create` - Start mfa verify create
+- `servosity-cli current-user verified-mfa-delete` - Verified mfa delete
+- `servosity-cli current-user verified-mfa-list` - Verified mfa list
+- `servosity-cli current-user verified-mfa-send-code-create` - Verified mfa send code create
 
-**download**  -  Manage download
+**download** - Manage download
 
-- `servosity-cli download`  -  Servosity one windows list
+- `servosity-cli download` - Servosity one windows list
 
-**dr-backups**  -  Manage dr backups
+**dr-backups** - Manage dr backups
 
-- `servosity-cli dr-backups create`  -  Create a DR backup account.
-- `servosity-cli dr-backups delete`  -  Delete a DR backup account.
-- `servosity-cli dr-backups list`  -  List
-- `servosity-cli dr-backups partial-update`  -  Update a DR backup account.
-- `servosity-cli dr-backups read`  -  Read
-- `servosity-cli dr-backups update`  -  Update a DR backup account.
+- `servosity-cli dr-backups create` - Create a DR backup account.
+- `servosity-cli dr-backups delete` - Delete a DR backup account.
+- `servosity-cli dr-backups list` - List
+- `servosity-cli dr-backups partial-update` - Update a DR backup account.
+- `servosity-cli dr-backups read` - Read
+- `servosity-cli dr-backups update` - Update a DR backup account.
 
-**issue-comments**  -  Manage issue comments
+**issue-comments** - Manage issue comments
 
-- `servosity-cli issue-comments delete`  -  Delete
-- `servosity-cli issue-comments update`  -  Update
+- `servosity-cli issue-comments delete` - Delete
+- `servosity-cli issue-comments update` - Update
 
-**issues**  -  Manage issues
+**issues** - Manage issues
 
-- `servosity-cli issues archived`  -  Archived
-- `servosity-cli issues ignored`  -  Ignored
-- `servosity-cli issues list`  -  List
-- `servosity-cli issues read`  -  Read
+- `servosity-cli issues archived` - Archived
+- `servosity-cli issues ignored` - Ignored
+- `servosity-cli issues list` - List
+- `servosity-cli issues read` - Read
 
-**report-subscriptions**  -  Manage report subscriptions
+**report-subscriptions** - Manage report subscriptions
 
-- `servosity-cli report-subscriptions read`  -  Read
-- `servosity-cli report-subscriptions unsubscribe`  -  Unsubscribe
-- `servosity-cli report-subscriptions verify`  -  Verify
+- `servosity-cli report-subscriptions read` - Read
+- `servosity-cli report-subscriptions unsubscribe` - Unsubscribe
+- `servosity-cli report-subscriptions verify` - Verify
 
-**reports**  -  Manage reports
+**reports** - Manage reports
 
-- `servosity-cli reports account-list`  -  Get a report of backup account types for each company and reseller in CSV format.
-- `servosity-cli reports classic-usage-list`  -  Get a usage report for all backup accounts in CSV format.
-- `servosity-cli reports clients-list`  -  Get a report of backup account client versions.
-- `servosity-cli reports dr-from-email-list`  -  Get a report of user profiles.
-- `servosity-cli reports maxio-price-points-list`  -  Get CSV with all Maxio price points.
-- `servosity-cli reports product-list`  -  Product list
-- `servosity-cli reports stale-backup-sets-list`  -  Get a report of all backup set last backup complete times.
-- `servosity-cli reports usage-list`  -  Usage list
-- `servosity-cli reports user-profiles-list`  -  Get a report of user profiles.
+- `servosity-cli reports account-list` - Get a report of backup account types for each company and reseller in CSV format.
+- `servosity-cli reports classic-usage-list` - Get a usage report for all backup accounts in CSV format.
+- `servosity-cli reports clients-list` - Get a report of backup account client versions.
+- `servosity-cli reports dr-from-email-list` - Get a report of user profiles.
+- `servosity-cli reports maxio-price-points-list` - Get CSV with all Maxio price points.
+- `servosity-cli reports product-list` - Product list
+- `servosity-cli reports stale-backup-sets-list` - Get a report of all backup set last backup complete times.
+- `servosity-cli reports usage-list` - Usage list
+- `servosity-cli reports user-profiles-list` - Get a report of user profiles.
 
-**resellers**  -  Manage resellers
+**resellers** - Manage resellers
 
-- `servosity-cli resellers partial-update`  -  Partial update
-- `servosity-cli resellers read`  -  View a reseller.
-- `servosity-cli resellers update`  -  Update a reseller.
+- `servosity-cli resellers partial-update` - Partial update
+- `servosity-cli resellers read` - View a reseller.
+- `servosity-cli resellers update` - Update a reseller.
 
-**restic-backups**  -  Manage restic backups
+**restic-backups** - Manage restic backups
 
-- `servosity-cli restic-backups create`  -  Create a restic backup account.
-- `servosity-cli restic-backups delete`  -  Delete a restic backup account.
-- `servosity-cli restic-backups list`  -  List
-- `servosity-cli restic-backups partial-update`  -  Update a restic backup account.
-- `servosity-cli restic-backups read`  -  Read
-- `servosity-cli restic-backups update`  -  Update a restic backup account.
+- `servosity-cli restic-backups create` - Create a restic backup account.
+- `servosity-cli restic-backups delete` - Delete a restic backup account.
+- `servosity-cli restic-backups list` - List
+- `servosity-cli restic-backups partial-update` - Update a restic backup account.
+- `servosity-cli restic-backups read` - Read
+- `servosity-cli restic-backups update` - Update a restic backup account.
 
-**screenshot**  -  Manage screenshot
+**screenshot** - Manage screenshot
 
-- `servosity-cli screenshot <key>`  -  Read
+- `servosity-cli screenshot <key>` - Read
 
-**stats**  -  Manage stats
+**stats** - Manage stats
 
-- `servosity-cli stats list`  -  List
-- `servosity-cli stats live-list`  -  Live list
-- `servosity-cli stats user-list`  -  User list
+- `servosity-cli stats list` - List
+- `servosity-cli stats live-list` - Live list
+- `servosity-cli stats user-list` - User list
 
-**users**  -  Manage users
+**users** - Manage users
 
-- `servosity-cli users create`  -  Create
-- `servosity-cli users delete`  -  Remove a user from a reseller or company group.
-- `servosity-cli users list`  -  List
-- `servosity-cli users request-password-recovery-create`  -  Request password recovery for a user.
-- `servosity-cli users reset-password-create`  -  Pass only `token` to confirm the token is valid. Pass `token` and `password` to set the user's password.
+- `servosity-cli users create` - Create
+- `servosity-cli users delete` - Remove a user from a reseller or company group.
+- `servosity-cli users list` - List
+- `servosity-cli users request-password-recovery-create` - Request password recovery for a user.
+- `servosity-cli users reset-password-create` - Pass only `token` to confirm the token is valid. Pass `token` and `password` to set the user's password.
 
 
 ### Finding the right command
@@ -329,7 +329,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 servosity-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match  -  fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match - fall back to `--help` or use a narrower query.
 
 ## Auth Setup
 Run `servosity-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
@@ -346,16 +346,16 @@ Run `servosity-cli doctor` to verify setup.
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
 
-- **Pipeable**  -  JSON on stdout, errors on stderr
-- **Filterable**  -  `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+- **Pipeable** - JSON on stdout, errors on stderr
+- **Filterable** - `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
   servosity-cli agent-login list --agent --select id,name,status
   ```
-- **Previewable**  -  `--dry-run` shows the request without sending
-- **Offline-friendly**  -  sync/search commands can use the local SQLite store when available
-- **Non-interactive**  -  never prompts, every input is a flag
-- **Explicit retries**  -  use `--idempotent` only when an already-existing create should count as success, and `--ignore-missing` only when a missing delete target should count as success
+- **Previewable** - `--dry-run` shows the request without sending
+- **Offline-friendly** - sync/search commands can use the local SQLite store when available
+- **Non-interactive** - never prompts, every input is a flag
+- **Explicit retries** - use `--idempotent` only when an already-existing create should count as success, and `--ignore-missing` only when a missing delete target should count as success
 
 ### Response envelope
 
@@ -368,7 +368,7 @@ Commands that read from the local store or the API wrap output in a provenance e
 }
 ```
 
-Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set  -  piped/agent consumers and explicit-format runs get pure JSON on stdout.
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set - piped/agent consumers and explicit-format runs get pure JSON on stdout.
 
 ## Agent Feedback
 

--- a/skills/servosity/SKILL.md
+++ b/skills/servosity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: servosity
-description: "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `use servosity`, `run servosity`."
+description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query — offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "Servosity"

--- a/skills/servosity/manifest.json
+++ b/skills/servosity/manifest.json
@@ -3,7 +3,7 @@
   "name": "servosity-mcp",
   "display_name": "Servosity",
   "version": "0.1.0",
-  "description": "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show.",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
   "author": {
     "name": "Servosity Inc."
   },

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.servosity/servosity-mcp",
+  "title": "Servosity MCP",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/servosity/msp-skills",
+    "source": "github",
+    "subfolder": "skills/servosity"
+  },
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "servosity-mcp",
+      "version": "0.1.0",
+      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-mcp-v0.1.0/servosity-mcp.mcpb",
+      "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SERVOSITY_MSP_TOKEN",
+          "description": "Servosity partner API token from the partner portal. Scoped to your reseller account only.",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -72,16 +72,30 @@ def build_entry(skill_dir: Path) -> dict:
     }
 
 
+def status_badge(status: str) -> str:
+    """Map a skill's status to a shields.io badge URL.
+
+    'tested' / 'beta' (the launch state for halopsa + servosity, where MSPs
+    have run the skill against a real production tenant): green Tested badge.
+    Anything else ('untested', etc.) for a skill that shipped but has not
+    been driven against live data yet: yellow Untested badge. Feedback on
+    untested skills is the high-leverage signal we want from MSPs.
+    """
+    if status in ("tested", "beta"):
+        return "![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32)"
+    return "![Untested](https://img.shields.io/badge/Untested-feedback_welcome-EAB308)"
+
+
 def render_catalog_table(skills: list[dict]) -> str:
     rows = [
-        "| Skill | System | Install (Skill) | Install (MCP) |",
+        "| Skill | System | Status | Install |",
         "| --- | --- | --- | --- |",
     ]
     for s in skills:
         rows.append(
             f"| [{s['name']}](./skills/{s['name']}) | {s['system']} | "
-            f"`bash skills/{s['name']}/install.sh` | "
-            f"[mcp-install](./{s['install_mcp_doc']}) |"
+            f"{status_badge(s['status'])} | "
+            f"[Install](./skills/{s['name']}/README.md) |"
         )
     return "\n".join(rows)
 

--- a/tools/maintainer/check_md_links.py
+++ b/tools/maintainer/check_md_links.py
@@ -25,8 +25,28 @@ def md_files() -> list[Path]:
         parts = p.relative_to(ROOT).parts
         if ".git" in parts:
             continue
+        # Skip local-only third-party skill installs (`.agents/` is gitignored
+        # so this only matters when running locally). Same for `node_modules`.
+        if parts[0] in (".agents", "node_modules", "vendor"):
+            continue
         # Skip vendored, generated module trees.
         if "cli" in parts and parts[0] == "skills":
+            continue
+        # Skip the Jekyll-rendered landing site under docs/. Those pages use
+        # Jekyll permalinks like /integrations/claude-desktop/ that only
+        # resolve at render time, not as raw filesystem paths. The Jekyll
+        # build itself is the right gate for those.
+        # The repo-doc files in docs/ (which-agent.md, requesting-a-skill.md,
+        # install-skill.md, install-mcp.md, contributing.md) ARE checked because
+        # they live at docs/ top level and link with relative paths that resolve
+        # on the filesystem too. The Jekyll-specific tree is docs/_layouts,
+        # docs/_includes, docs/integrations, docs/skills, docs/guides, and
+        # docs/index.md / docs/llms.txt.
+        if parts[:1] == ("docs",) and len(parts) > 1 and parts[1] in (
+            "_layouts", "_includes", "integrations", "skills", "guides"
+        ):
+            continue
+        if parts == ("docs", "index.md"):
             continue
         out.append(p)
     return out


### PR DESCRIPTION
Stacked on top of #2. Once that merges, retarget this PR's base to `main`.

## Summary

- **`server.json` per skill** (official MCP Registry manifest, schema 2025-12-11). HaloPSA server includes the four env vars (tenant + OAuth2 credentials + domain); Servosity server includes the partner token.
- **`.github/workflows/mcp-publish.yml`** runs after each successful per-skill Release (`halopsa-v*` / `servosity-v*` tag), bundles all platform MCP binaries into a single `.mcpb`, computes SHA-256, attaches it to the release, patches `server.json` (version + download URL + fileSha256), and publishes via `mcp-publisher` using GitHub OIDC. One publish fans out to PulseMCP, GitHub MCP Registry, Glama, mcp.so, Smithery, and LobeHub within 1-7 days.

## Files

3 files, +244 / -0.

- `skills/halopsa/server.json` — new
- `skills/servosity/server.json` — new
- `.github/workflows/mcp-publish.yml` — new

## How to test

After PR #2 merges and this PR is retargeted to `main`:

1. Cut a per-skill release tag: `git tag halopsa-v0.1.1 && git push --tags`.
2. Watch the Release workflow build + upload platform binaries.
3. Watch the MCP Registry Publish workflow:
   - Download MCP binaries from the release
   - Bundle into `halopsa-mcp.mcpb` (zip with `manifest.json` + `bin/`)
   - Compute + log SHA-256
   - Upload `.mcpb` to the release
   - Patch `server.json` with the SHA + download URL
   - Run `mcp-publisher login github-oidc` then `mcp-publisher publish`
4. Verify the listing at https://registry.modelcontextprotocol.io for `io.github.servosity/halopsa-mcp`.
5. Verify fan-out within a week: PulseMCP, mcp.so, Glama, Smithery, LobeHub, GitHub MCP Registry should all carry the same metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)