### PR TITLE
docs: GitHub Pages landing site (Jekyll) for AEO

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-skills",
-  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners — works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
+  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners - works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
   "version": "0.1.0",
   "owner": {
     "name": "Servosity",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "msp-skills",
+  "description": "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. For MSP business owners — works with Claude, ChatGPT, Codex, Cursor, and any MCP-capable agent.",
+  "version": "0.1.0",
+  "owner": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "plugins": [
+    {
+      "name": "halopsa",
+      "source": "./skills/halopsa",
+      "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
+      "version": "0.1.0",
+      "category": "psa",
+      "tags": [
+        "halopsa",
+        "halo",
+        "psa",
+        "msp",
+        "ticket-automation",
+        "sla",
+        "mcp",
+        "claude-code",
+        "claude-mcp"
+      ]
+    },
+    {
+      "name": "servosity",
+      "source": "./skills/servosity",
+      "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
+      "version": "0.1.0",
+      "category": "backup-dr",
+      "tags": [
+        "servosity",
+        "backup",
+        "bcdr",
+        "disaster-recovery",
+        "msp",
+        "fleet-monitoring",
+        "mcp",
+        "claude-code",
+        "claude-mcp"
+      ]
+    }
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -1,0 +1,97 @@
+name: 🛠 Request a Skill / MCP
+description: Ask us to build a Claude Code Skill + MCP server for your PSA, RMM, backup, security, or M365 tool
+title: "[Skill request] "
+labels: ["skill-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) — no code, no terminal.
+
+  - type: input
+    id: vendor
+    attributes:
+      label: System / vendor name
+      description: The product you want a Skill for.
+      placeholder: e.g. Autotask, NinjaOne, Datto BCDR, IT Glue, Hudu
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What kind of system is it?
+      options:
+        - PSA (Professional Services Automation)
+        - RMM (Remote Monitoring & Management)
+        - Backup / DR / BCDR
+        - Security (EDR, MDR, email security)
+        - M365 / Google Workspace governance
+        - Documentation (IT Glue, Hudu, Confluence)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: One question you'd ask the AI
+      description: If this Skill existed, what's the FIRST cross-client or cross-engine question you'd ask?
+      placeholder: |
+        e.g. "Which of my clients have open Autotask tickets older than 30 days, grouped by contract type?"
+        or  "Show me every endpoint with a NinjaOne agent that hasn't checked in for 7 days."
+    validations:
+      required: true
+
+  - type: input
+    id: api_docs
+    attributes:
+      label: Link to the vendor's API docs (if you know it)
+      description: Helpful but not required. Type "I don't know" if you're not sure.
+      placeholder: https://docs.vendor.com/api  OR  "I don't know"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: msp_size
+    attributes:
+      label: MSP size
+      description: Helps us prioritize against demand.
+      options:
+        - 1-2 techs
+        - 3-10 techs
+        - 11-25 techs
+        - 26-50 techs
+        - 51+ techs
+        - I'm not an MSP, I'm researching for one
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build_session
+    attributes:
+      label: Would you join a Build Session to co-build this live?
+      description: Build Sessions are free, weekly Thursdays. We co-build with the cohort using a volunteer MSP's real tenant.
+      options:
+        - "Yes — sign me up"
+        - "Maybe — depends on the date"
+        - "No — I'd rather wait for it to ship"
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: Existing tools you use, related Skills, edge cases, etc. Optional.
+      placeholder: |
+        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA — this would help us evaluate."
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **What happens next:** we comment within a few days — usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) — no code, no terminal.
+        Thanks for telling us what to build. First time on GitHub? See the [90-second guide](../blob/main/docs/requesting-a-skill.md) - no code, no terminal.
 
   - type: input
     id: vendor
@@ -74,9 +74,9 @@ body:
       label: Would you join a Build Session to co-build this live?
       description: Build Sessions are free, weekly Thursdays. We co-build with the cohort using a volunteer MSP's real tenant.
       options:
-        - "Yes — sign me up"
-        - "Maybe — depends on the date"
-        - "No — I'd rather wait for it to ship"
+        - "Yes - sign me up"
+        - "Maybe - depends on the date"
+        - "No - I'd rather wait for it to ship"
     validations:
       required: true
 
@@ -86,7 +86,7 @@ body:
       label: Anything else?
       description: Existing tools you use, related Skills, edge cases, etc. Optional.
       placeholder: |
-        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA — this would help us evaluate."
+        e.g. "We already use ConnectWise Manage but want to migrate to HaloPSA - this would help us evaluate."
     validations:
       required: false
 
@@ -94,4 +94,4 @@ body:
     attributes:
       value: |
         ---
-        **What happens next:** we comment within a few days — usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).
+        **What happens next:** we comment within a few days - usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,161 @@
+name: MCP Registry Publish
+
+# Triggers after the Release workflow completes successfully on a per-skill
+# tag. Bundles each skill's MCP binary into an .mcpb (zip), attaches it to the
+# release, computes its SHA-256, patches the corresponding server.json with the
+# hash + version + download URL, and publishes to the official MCP Registry
+# (registry.modelcontextprotocol.io). One publish fans out to PulseMCP, GitHub
+# MCP Registry, Glama, mcp.so, Smithery, and LobeHub within 1–7 days.
+#
+# Skipped automatically if the tag is not a per-skill release tag.
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write   # upload .mcpb to the release
+  id-token: write   # GitHub OIDC for mcp-publisher auth
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'refs/tags/') == false }}
+    outputs:
+      skill: ${{ steps.parse.outputs.skill }}
+      version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
+      proceed: ${{ steps.parse.outputs.proceed }}
+    steps:
+      - name: Parse triggering tag
+        id: parse
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          tag="$HEAD_BRANCH"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          case "$tag" in
+            halopsa-v*)
+              echo "skill=halopsa" >> "$GITHUB_OUTPUT"
+              echo "version=${tag#halopsa-v}" >> "$GITHUB_OUTPUT"
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            servosity-v*)
+              echo "skill=servosity" >> "$GITHUB_OUTPUT"
+              echo "version=${tag#servosity-v}" >> "$GITHUB_OUTPUT"
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Tag '$tag' is not a per-skill release tag; skipping MCP publish."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  publish:
+    needs: detect
+    if: needs.detect.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.detect.outputs.tag }}
+
+      - name: Set up jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Download MCP binaries from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          mkdir -p mcpb-build
+          cd mcpb-build
+          # The release.yml workflow uploads platform-suffixed binaries like
+          # halopsa-mcp-darwin-arm64, halopsa-mcp-linux-amd64, etc. We bundle
+          # ALL platforms into one .mcpb so the registry-published artifact
+          # works on every platform Claude Desktop runs on.
+          for suffix in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64 windows-amd64.exe; do
+            gh release download "$TAG" --pattern "${SKILL}-mcp-${suffix}" --dir . || true
+          done
+          ls -la
+
+      - name: Build MCPB bundle
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          # MCPB is a zip with manifest.json + a bin/ directory of the binaries.
+          mkdir -p bundle/bin
+          cp ../skills/$SKILL/manifest.json bundle/manifest.json
+          for f in ${SKILL}-mcp-*; do
+            [ -f "$f" ] || continue
+            cp "$f" "bundle/bin/$f"
+          done
+          (cd bundle && zip -r "../${SKILL}-mcp.mcpb" .)
+          ls -la "${SKILL}-mcp.mcpb"
+
+      - name: Compute SHA-256
+        id: sha
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          hash=$(openssl dgst -sha256 "${SKILL}-mcp.mcpb" | awk '{print $NF}')
+          echo "sha=$hash" >> "$GITHUB_OUTPUT"
+          echo "Computed SHA-256: $hash"
+
+      - name: Upload MCPB to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SKILL: ${{ needs.detect.outputs.skill }}
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          gh release upload "$TAG" "${SKILL}-mcp.mcpb" --clobber
+
+      - name: Patch server.json with SHA + version + download URL
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          src=skills/$SKILL/server.json
+          out=mcpb-build/server.json
+          download="https://github.com/${{ github.repository }}/releases/download/${TAG}/${SKILL}-mcp.mcpb"
+          jq \
+            --arg version "$VERSION" \
+            --arg sha "$SHA" \
+            --arg download "$download" \
+            '.version = $version | .packages[0].version = $version | .packages[0].fileSha256 = $sha | .packages[0].download = $download' \
+            "$src" > "$out"
+          echo "--- patched server.json ---"
+          cat "$out"
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher-linux-amd64 -o mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --version
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to official MCP Registry
+        run: |
+          set -euo pipefail
+          cd mcpb-build
+          ../mcp-publisher publish --file server.json
+          echo "✓ Published to registry.modelcontextprotocol.io"
+          echo "Fan-out to PulseMCP, GitHub MCP Registry, Glama, mcp.so, Smithery, LobeHub takes 1–7 days."

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,10 @@ test-output/
 .codex/
 .cursor/
 .aider*
+# Vercel `skills` CLI installs third-party skills (e.g. marketingskills)
+# into .agents/ at the project root. Local-only dev tooling, never committed.
+.agents/
+skills-lock.json
 
 # ===== Misc =====
 *.zip

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MSP Skills — HaloPSA and Servosity, for the AI you already use
+# MSP Skills - HaloPSA and Servosity, for the AI you already use
 
-**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot — no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
+**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot - no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
 
-> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system — or bring your own.
+> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system - or bring your own.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Skills](https://img.shields.io/badge/skills-2-green.svg)](./catalog.json)
@@ -16,59 +16,51 @@ The four agents MSP owners actually use:
 
 | Your AI agent | Why MSPs use it | How to install MSP Skills |
 | --- | --- | --- |
-| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice — no terminal, just a chat window | Run installer, add MSP block to `claude_desktop_config.json` |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
+| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice - no terminal, just a chat window | Run installer, then Settings > Extensions to register the MCP server |
+| **ChatGPT** (paid plans) | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
 | **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt into the chat, or run the installer yourself |
 | **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | Paste the install prompt, or run the installer |
-
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). MSP Skills' binaries are local (stdio) — for ChatGPT you expose them over HTTPS via the `mcp-remote` bridge. Step-by-step in [docs/which-agent.md](./docs/which-agent.md).
 
 > **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. MSP Skills speaks the open MCP standard, so any current or future MCP-capable agent can use it. Full per-tool deep-dive: **[docs/which-agent.md](./docs/which-agent.md)**.
 
 ## What's in the box
 
 <!-- catalog:start -->
-| Skill | System | Install (Skill) | Install (MCP) |
+| Skill | System | Status | Install |
 | --- | --- | --- | --- |
-| [halopsa](./skills/halopsa) | HaloPSA, HaloITSM, HaloCRM | `bash skills/halopsa/install.sh` | [mcp-install](./skills/halopsa/mcp-install.md) |
-| [servosity](./skills/servosity) | Servosity backup and DR | `bash skills/servosity/install.sh` | [mcp-install](./skills/servosity/mcp-install.md) |
+| [halopsa](./skills/halopsa) | HaloPSA, HaloITSM, HaloCRM | ![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32) | [Install](./skills/halopsa/README.md) |
+| [servosity](./skills/servosity) | Servosity backup and DR | ![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32) | [Install](./skills/servosity/README.md) |
 <!-- catalog:end -->
 
-The table is regenerated from each skill's `manifest.json` whenever a PR touches `skills/`. The machine-readable form is [`catalog.json`](./catalog.json). Both skills are **beta** and being validated live against real MSPs in weekly Build Sessions (see below).
+> **About status badges.** `Tested` means at least one MSP has run this skill against a real production tenant and it worked. `Untested` (yellow) means the skill was generated, the gates passed, and we shipped it - but no MSP has driven it against live data yet. Untested skills may have rough edges; **feedback is valuable** - open an issue if something breaks.
 
 ## What makes this different
 
 ### Local mirror, not live calls
 
-Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" — that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
+Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" - that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
 
 MSP Skills syncs HaloPSA and Servosity into a local SQLite mirror with full-text search. Cross-client and cross-engine questions become one local query: instant, offline, and the AI sees the answer, not the raw data.
 
 ### Works with the AI you already use
 
-You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both — your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
+You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both - your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
 
 ### MSP owner first, not developer first
 
-You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** — mutations show you what they would do before they do it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
+You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** - any write shows you what it would do before it does it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
 
 Swap `halopsa` for `servosity` (and `halopsa-cli --version` for `servosity-cli doctor`) to install the Servosity skill. Your agent does the rest.
 
-### Path B — run the installer yourself
-
-**HaloPSA on macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
-```
+### Path B - run the installer yourself
 
 **HaloPSA on Windows (PowerShell):**
 
@@ -76,10 +68,10 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
 ```
 
-**Servosity on macOS / Linux:**
+**HaloPSA on macOS / Linux:**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 ```
 
 **Servosity on Windows (PowerShell):**
@@ -88,13 +80,19 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
+**Servosity on macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
 Each installer drops both the CLI and the MCP server, so you can use the Skill (Claude Code / Codex) and the MCP server (Claude Desktop / ChatGPT / Cursor / etc.) from one install. For Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot wire-up, see [docs/which-agent.md](./docs/which-agent.md) and each skill's `mcp-install.md`.
 
-> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** — we'll work it live with the MSP cohort and the same Skills you just installed.
+> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** - we'll work it live with the MSP cohort and the same Skills you just installed.
 
 ## What your agent can do
 
-Outcomes, not endpoints. Today, with the two skills available:
+Outcomes, not hype. Today, with the two skills available:
 
 | Outcome | Skill | Command |
 | --- | --- | --- |
@@ -114,19 +112,19 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Claude?
 
-Yes — **Claude Code**, **Claude Desktop**, and the **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly; Claude Desktop loads MSP Skills as an MCP server you add to `claude_desktop_config.json`. Both paths are first-class. Most MSP owners start with Claude Desktop because it's a Mac/Windows app — no terminal.
+Yes - **Claude Code**, **Claude Desktop**, and **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly. For Claude Desktop, run the installer, then go to **Settings > Extensions** to register the HaloPSA / Servosity MCP server - the panel walks you through it without editing JSON. (Power users can still hand-edit `claude_desktop_config.json` via Settings > Developer > Edit Config if you prefer.) Both paths are first-class.
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
+Yes - all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
 
 ### Do I need to know how to code?
 
-No. The recommended install path is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
+No. The recommended install path is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
 
 ### Is my HaloPSA or Servosity data safe? Does it leave my network?
 
-Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns — typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
+Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns - typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
 
 ### Will this hit my HaloPSA API rate limits?
 
@@ -134,7 +132,7 @@ Almost never. HaloPSA's rate limits aren't publicly documented and vary between 
 
 ### How is this different from HaloPSA's built-in ChatGPT integration?
 
-HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work — rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
+HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work - rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
 
 ### Can I run this on Windows?
 
@@ -142,7 +140,7 @@ Yes. The PowerShell installer in "Install in 60 seconds" above is the same insta
 
 ### What does it cost?
 
-The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed — free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
+The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed - free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
 
 ### Can I try it on one client first?
 
@@ -150,15 +148,14 @@ Yes. Every command takes a client / company filter (e.g. `halopsa-cli client car
 
 ### What if my AI doesn't speak MCP?
 
-If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell — you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
+If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell - you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
 
 ## Safety model
 
 These skills hold privileged, multi-tenant access to systems that run MSP businesses, so safety is a first-class concern, not a footnote:
 
 - **You supply your own credentials at runtime.** Nothing is stored in this repo.
-- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode and makes no change until you pass `--confirm`.
-- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent.
+- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent. Writes plan first: the CLI shows you what it would do, then waits for `--confirm` before it changes anything.
 
 The safe default for an autonomous agent is **read plus planned (dry-run) writes**; gate destructive and credential-touching operations behind a human. See [skills/halopsa/governance.md](./skills/halopsa/governance.md) and [skills/servosity/governance.md](./skills/servosity/governance.md).
 
@@ -180,9 +177,15 @@ Want one of these next? Bring the system to a Build Session (below) or open an i
 
 ## Don't see the system you need?
 
-Tell us what to build next. **[Open an issue →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)** and name the PSA, RMM, backup, security, or M365 tool — the more votes a system gets, the faster it moves up the roadmap.
+**Easiest path - tell your AI.** Paste this into Claude Code, Codex, Claude Desktop, or ChatGPT:
 
-First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** — a 90-second walkthrough for MSP business owners. No terminal required, no developer experience needed.
+> Open an issue on https://github.com/servosity/msp-skills using the skill-request template. The system I want is **[YOUR SYSTEM NAME]** - my one question for the AI would be **"[YOUR QUESTION]"**, I'm on **[Mac or Windows]**, and my MSP has about **[N] techs**. Submit it.
+
+Your AI fills the form and posts the issue. Done. (You'll need to be signed in to GitHub in your browser or have a GitHub CLI token where your AI can see it.)
+
+**Don't have an AI set up yet?** Open the issue directly: **[Submit a skill request →](https://github.com/Servosity/msp-skills/issues/new?template=skill-request.yml)**. First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** for a 90-second walkthrough.
+
+More votes (👍 reactions on an issue) move a system up the roadmap. Share with one MSP friend who'd want the same skill.
 
 ## Co-build a new Skill or MCP with us live
 
@@ -206,16 +209,16 @@ MSPs are the channel that brings AI to small business. The durable moat is the [
 
 ## Glossary (for the non-developer)
 
-- **Skill** — a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
-- **MCP** — Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
-- **MCP server** — the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
-- **PSA** — Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
-- **BCDR / Backup and DR** — Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
-- **Cross-client analytics** — questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
+- **Skill** - a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
+- **MCP** - Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
+- **MCP server** - the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
+- **PSA** - Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
+- **BCDR / Backup and DR** - Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
+- **Cross-client analytics** - questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works on both skills.
 
 Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens. Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability. Methodology: [Compounding Teams](https://compoundingteams.com). Generated CLIs and MCP servers built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,31 @@
-# MSP Skills
+# MSP Skills — HaloPSA and Servosity, for the AI you already use
 
-Open-source Claude Code Skills and MCP servers for the PSA, RMM, backup, DR, and
-M365 workflows MSPs run every day. Install one, and your AI agent operates the
-system directly - it does the clicking, not the narrating.
+**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot — no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
+
+> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** to watch a Skill built against a real MSP system — or bring your own.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Skills](https://img.shields.io/badge/skills-2-green.svg)](./catalog.json)
-![Status](https://img.shields.io/badge/status-early-yellow.svg)
+[![MCP](https://img.shields.io/badge/MCP-compatible-7C3AED.svg)](https://modelcontextprotocol.io)
+[![Agent Skills](https://img.shields.io/badge/Agent_Skills-spec-2E7D32.svg)](https://agentskills.io)
+![Status](https://img.shields.io/badge/status-beta-yellow.svg)
 
-## What your agent can do with these
+## Works with your agent
 
-Outcomes, not endpoints. With the two skills available today:
+The four agents MSP owners actually use:
 
-| Outcome | Skill | Command |
+| Your AI agent | Why MSPs use it | How to install MSP Skills |
 | --- | --- | --- |
-| Pre-empt SLA breaches before a hand-off | halopsa | `halopsa-cli sla breaching --within 24h` |
-| Find stale backups across every client | servosity | `servosity-cli stale-backups --days 7` |
-| Build a per-client situational-awareness card | halopsa | `halopsa-cli client card "Acme Corp"` |
-| Triage what needs attention across every client | servosity | `servosity-cli attention` |
-| Pull a client's full backup picture for a ticket | servosity | `servosity-cli company show 4421` |
-| See what changed across your fleet overnight | servosity | `servosity-cli drift --from yesterday --to now` |
+| **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice — no terminal, just a chat window | Run installer, add MSP block to `claude_desktop_config.json` |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
+| **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt into the chat, or run the installer yourself |
+| **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | Paste the install prompt, or run the installer |
 
-## Pick your agent
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). MSP Skills' binaries are local (stdio) — for ChatGPT you expose them over HTTPS via the `mcp-remote` bridge. Step-by-step in [docs/which-agent.md](./docs/which-agent.md).
 
-| Your agent | What you install | How |
-| --- | --- | --- |
-| Claude Code | Claude Code Skill (plus CLI binary) | `bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)` |
-| Codex CLI | Same as Claude Code | (same one-liner) |
-| Claude Desktop | MCP server (local binary) | see [skills/halopsa/mcp-install.md](./skills/halopsa/mcp-install.md) |
-| ChatGPT (Developer Mode, beta) | Remote MCP connector (not a local binary) | see the ChatGPT section in [mcp-install.md](./skills/halopsa/mcp-install.md) |
-| Not sure what you have | start here | [docs/which-agent.md](./docs/which-agent.md) |
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. MSP Skills speaks the open MCP standard, so any current or future MCP-capable agent can use it. Full per-tool deep-dive: **[docs/which-agent.md](./docs/which-agent.md)**.
 
-## Current skills
+## What's in the box
 
 <!-- catalog:start -->
 | Skill | System | Install (Skill) | Install (MCP) |
@@ -40,26 +34,35 @@ Outcomes, not endpoints. With the two skills available today:
 | [servosity](./skills/servosity) | Servosity backup and DR | `bash skills/servosity/install.sh` | [mcp-install](./skills/servosity/mcp-install.md) |
 <!-- catalog:end -->
 
-The table above is regenerated automatically from each skill's `manifest.json`
-whenever a PR touches `skills/`. See [`catalog.json`](./catalog.json) for the
-machine-readable form. Both skills are **beta**.
+The table is regenerated from each skill's `manifest.json` whenever a PR touches `skills/`. The machine-readable form is [`catalog.json`](./catalog.json). Both skills are **beta** and being validated live against real MSPs in weekly Build Sessions (see below).
 
-## Install in 30 seconds
+## What makes this different
 
-### Easiest: let your agent install it
+### Local mirror, not live calls
 
-You do not have to run anything by hand. Point your AI agent (Claude Code or Codex) at this
-repo and let it do the setup - it reads the Skill, installs the binary, and walks you through
-authentication. Paste this into Claude Code or Codex:
+Most AI tools and MCP servers for PSAs and backup systems call the vendor's API on every question your agent asks. That works fine for "show me ticket #4421." It falls over at QBR time, when you're asking "how many backup-failure tickets across all 47 clients last quarter, grouped by engine?" — that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read.
 
-> Set up the Servosity skill from https://github.com/servosity/msp-skills - read
-> skills/servosity/SKILL.md, run its install steps, then run `servosity-cli doctor` to confirm
-> it works.
+MSP Skills syncs HaloPSA and Servosity into a local SQLite mirror with full-text search. Cross-client and cross-engine questions become one local query: instant, offline, and the AI sees the answer, not the raw data.
 
-Swap `servosity` for `halopsa` (and `servosity-cli doctor` for `halopsa-cli --version`) for the
-HaloPSA skill. You can also just give your agent the repo URL and say "install the HaloPSA skill."
+### Works with the AI you already use
 
-### Or run the installer yourself
+You don't have to switch agents to use MSP Skills. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both — your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
+
+### MSP owner first, not developer first
+
+You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** — mutations show you what they would do before they do it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+Swap `halopsa` for `servosity` (and `halopsa-cli --version` for `servosity-cli doctor`) to install the Servosity skill. Your agent does the rest.
+
+### Path B — run the installer yourself
 
 **HaloPSA on macOS / Linux:**
 
@@ -85,60 +88,105 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
-Each install drops both the CLI and the MCP server, so you can use either path
-(Skill in Claude Code, MCP in Claude Desktop) from one install. Binaries are
-published to [GitHub Releases](https://github.com/servosity/msp-skills/releases)
-and built from the source under each skill's `cli/` directory. For Claude Desktop
-or ChatGPT wire-up, read the per-skill `mcp-install.md`.
+Each installer drops both the CLI and the MCP server, so you can use the Skill (Claude Code / Codex) and the MCP server (Claude Desktop / ChatGPT / Cursor / etc.) from one install. For Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot wire-up, see [docs/which-agent.md](./docs/which-agent.md) and each skill's `mcp-install.md`.
 
-## Optional: Claude Code statusline
+> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, you're 60 seconds from your first real query. **Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** — we'll work it live with the MSP cohort and the same Skills you just installed.
 
-Not an MSP skill - a small developer convenience that shows model, working directory, git
-branch, and context-window usage in your Claude Code status line. Install steps and details
-are in [tools/statusline/README.md](./tools/statusline/README.md).
+## What your agent can do
+
+Outcomes, not endpoints. Today, with the two skills available:
+
+| Outcome | Skill | Command |
+| --- | --- | --- |
+| Pre-empt SLA breaches before a hand-off | halopsa | `halopsa-cli sla breaching --within 24h` |
+| Find stale backups across every client | servosity | `servosity-cli stale-backups --days 7` |
+| Build a per-client situational-awareness card | halopsa | `halopsa-cli client card "Acme Corp"` |
+| Triage what needs attention across every client | servosity | `servosity-cli attention` |
+| Pull a client's full backup picture for a ticket | servosity | `servosity-cli company show 4421` |
+| See what changed across your fleet overnight | servosity | `servosity-cli drift --from yesterday --to now` |
+| Find every ticket about backup failures across all clients | halopsa + servosity | combine `halopsa-cli tickets search` with `servosity-cli stale-backups` |
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not to local binaries directly. MSP Skills ships local binaries, so to use them with ChatGPT you run them on your machine and expose them via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step: each skill's `mcp-install.md`.
+
+### Does this work with Claude?
+
+Yes — **Claude Code**, **Claude Desktop**, and the **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly; Claude Desktop loads MSP Skills as an MCP server you add to `claude_desktop_config.json`. Both paths are first-class. Most MSP owners start with Claude Desktop because it's a Mac/Windows app — no terminal.
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them. Each speaks MCP (some natively, some via an extension or marketplace). The cross-tool table at the top of this README links each one's install path. The pattern is the same: install the MSP Skills binary, point your AI tool at it, authenticate. Tool-specific gotchas (Copilot uses `servers` in `mcp.json` not `mcpServers`, Cline needs an `npx` workaround on Windows, etc.) are documented in [docs/which-agent.md](./docs/which-agent.md).
+
+### Do I need to know how to code?
+
+No. The recommended install path is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
+
+### Is my HaloPSA or Servosity data safe? Does it leave my network?
+
+Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns — typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into this repo or transmitted to MSP Skills servers (there are none).
+
+### Will this hit my HaloPSA API rate limits?
+
+Almost never. HaloPSA's rate limits aren't publicly documented and vary between cloud-hosted and self-hosted instances. MSP Skills syncs your HaloPSA data into a local SQLite mirror once, then incrementally; subsequent questions (triage, SLA breaches, client cards, cross-client analytics) run against the local mirror, not the live API. The big-batch QBR queries that get you 429'd with API-passthrough tools become a single SQL join here.
+
+### How is this different from HaloPSA's built-in ChatGPT integration?
+
+HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work — rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer in "Install in 60 seconds" above is the same install path as macOS / Linux, just packaged for PowerShell. The CLI and MCP binaries are native Windows builds. Cline users on Windows may need a small `npx` workaround documented in [docs/which-agent.md](./docs/which-agent.md).
+
+### What does it cost?
+
+The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed — free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
+
+### Can I try it on one client first?
+
+Yes. Every command takes a client / company filter (e.g. `halopsa-cli client card "Acme Corp"`, `servosity-cli company show 4421`). Read-tier commands plan nothing and change nothing; you can try them against your live system safely. Write-tier commands run `--dry-run` until you pass `--confirm`. The safe starting move is a read-only triage against one client, see the output, then widen scope.
+
+### What if my AI doesn't speak MCP?
+
+If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell — you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
 
 ## Safety model
 
-These skills hold privileged, multi-tenant access to systems that run MSP
-businesses, so safety is a first-class concern, not a footnote:
+These skills hold privileged, multi-tenant access to systems that run MSP businesses, so safety is a first-class concern, not a footnote:
 
 - **You supply your own credentials at runtime.** Nothing is stored in this repo.
-- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode
-  and makes no change until you pass `--confirm`.
-- **Every skill ships a permission matrix.** Each skill's `governance.md` tags
-  commands read / write / destructive and tells you how to scope an agent.
+- **Mutations plan by default.** Each skill's CLI runs in dry-run / discovery mode and makes no change until you pass `--confirm`.
+- **Every skill ships a permission matrix.** Each skill's `governance.md` tags commands read / write / destructive and tells you how to scope an agent.
 
-The safe default for an autonomous agent is **read plus planned (dry-run)
-writes**; gate destructive and credential-touching operations behind a human. See
-[skills/halopsa/governance.md](./skills/halopsa/governance.md) and
-[skills/servosity/governance.md](./skills/servosity/governance.md).
+The safe default for an autonomous agent is **read plus planned (dry-run) writes**; gate destructive and credential-touching operations behind a human. See [skills/halopsa/governance.md](./skills/halopsa/governance.md) and [skills/servosity/governance.md](./skills/servosity/governance.md).
 
 ## Tested by MSPs in Build Sessions
 
-These skills are built and tested with real MSPs running them against their own production
-systems, live, in our free weekly Build Sessions. They are currently beta and being validated
-now. Join a session (see [below](#co-build-a-new-skill-or-mcp-with-us-live)) to watch one run
-against a real system, or bring your own to co-build.
+These skills are built and tested with real MSPs running them against their own production systems, live, in our free weekly Build Sessions. They are currently beta and being validated now. Join a session ([RSVP](https://compoundingteams.com/build-sessions)) to watch one run against a real system, or bring your own to co-build.
 
 ## Roadmap
 
-We co-build the next skills live with MSPs in the weekly Build Session. The targets
-the MSP community asks for most:
+We co-build the next skills live with MSPs in the weekly Build Session. The targets the MSP community asks for most:
 
 - **M365 governance / Copilot data-exposure pre-check**
-- **PSA: Autotask, ConnectWise PSA** (HaloPSA shipped)
+- **PSA**: Autotask, ConnectWise PSA (HaloPSA shipped)
 - **NinjaOne fleet hygiene** (silent-failure detector)
 - **RMM ticket-to-doc** (resolution to IT Glue / Hudu)
 - **Datto RMM, Kaseya, Atera, Syncro**
 
 Want one of these next? Bring the system to a Build Session (below) or open an issue.
 
+## Don't see the system you need?
+
+Tell us what to build next. **[Open an issue →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)** and name the PSA, RMM, backup, security, or M365 tool — the more votes a system gets, the faster it moves up the roadmap.
+
+First time filing a GitHub issue? See **[docs/requesting-a-skill.md](./docs/requesting-a-skill.md)** — a 90-second walkthrough for MSP business owners. No terminal required, no developer experience needed.
+
 ## Co-build a new Skill or MCP with us live
 
-Every Thursday we host a free Build Session where an MSP brings a system we have
-not covered (your PSA, RMM, backup product, or security tool) and we co-build the
-Claude Code Skill and MCP server live. You watch, you ask, you walk away with a
-working integration.
+Every Thursday we host a free Build Session where an MSP brings a system we have not covered (your PSA, RMM, backup product, or security tool) and we co-build the Claude Code Skill and MCP server live. You watch, you ask, you walk away with a working integration.
 
 - Free weekly Build Sessions (Thursdays), co-built with a volunteer MSP.
 - Access to every shipped Skill and MCP the day it merges.
@@ -148,85 +196,27 @@ RSVP for the next one at **[compoundingteams.com/build-sessions](https://compoun
 
 ## Contribute a Skill or MCP
 
-If your MSP uses a system we have not covered, send a PR. We co-build alongside
-contributors in Build Sessions when that is easier than going it alone.
+If your MSP uses a system we have not covered, send a PR. We co-build alongside contributors in Build Sessions when that is easier than going it alone.
 
-A skill PR includes: `SKILL.md` (with `vendor` frontmatter), a `README.md` with
-the non-affiliation banner, `install.sh` + `install.ps1`, `mcp-install.md` if it
-ships an MCP server, and ideally `pain-point.md` + `governance.md`. CI enforces
-the contract (DCO sign-off, frontmatter schema, required files, no secrets, no
-personal paths). See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full checklist
-and the non-affiliation banner template.
+A skill PR includes: `SKILL.md` (with `vendor` frontmatter), a `README.md` with the non-affiliation banner, `install.sh` + `install.ps1`, `mcp-install.md` if it ships an MCP server, and ideally `pain-point.md` + `governance.md`. CI enforces the contract (DCO sign-off, frontmatter schema, required files, no secrets, no personal paths). See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full checklist and the non-affiliation banner template.
 
 ## About Compounding Teams
 
-MSPs are the channel that brings AI to small business. The durable moat is the
-[Compounding Teams](https://compoundingteams.com) methodology for running an MSP
-where every interaction with a tool, a customer, or a system makes the next one
-better. Loops close, feedback returns to the source, work compounds instead of
-evaporating. `msp-skills` is the part of that methodology you can install: the
-executable layer that lets your AI agent operate alongside your team in the same
-systems, with the same context, every day.
+MSPs are the channel that brings AI to small business. The durable moat is the [Compounding Teams](https://compoundingteams.com) methodology for running an MSP where every interaction with a tool, a customer, or a system makes the next one better. Loops close, feedback returns to the source, work compounds instead of evaporating. `msp-skills` is the part of that methodology you can install: the executable layer that lets your AI agent operate alongside your team in the same systems, with the same context, every day.
 
-## FAQ
+## Glossary (for the non-developer)
 
-**What is a Claude Code Skill?**
-A Claude Code Skill is a markdown file (and usually a binary it drives) that tells
-Claude Code how to operate a specific tool or API. When you say "use halopsa" (or any
-installed skill), Claude Code loads the Skill, gets a command vocabulary plus an operating
-contract, and acts on your behalf in that system. Codex CLI uses the same Skill format.
+- **Skill** — a markdown file (and a binary it drives) that tells a Claude Code / Codex agent how to operate a specific tool. Think of it as a recipe card the AI reads on the fly.
+- **MCP** — Model Context Protocol. The open standard that lets AI apps (Claude Desktop, ChatGPT, Cursor, Windsurf, etc.) call tools on a separate server (yours).
+- **MCP server** — the small program on your machine that exposes the tools. MSP Skills includes one for HaloPSA (`halopsa-mcp`) and one for Servosity (`servosity-mcp`).
+- **PSA** — Professional Services Automation. The system MSPs use for tickets, contracts, time, billing. HaloPSA, ConnectWise, Autotask are PSAs.
+- **BCDR / Backup and DR** — Business Continuity and Disaster Recovery. Servosity is a BCDR vendor.
+- **Cross-client analytics** — questions that span multiple clients ("how many backup failures across all 47 clients last quarter") rather than one ("show me ticket #4421").
 
-**What is an MCP server?**
-MCP (Model Context Protocol) is the open standard that lets AI apps call tools on
-a separate server. Claude Desktop launches an MCP server as a local binary on your
-machine. ChatGPT (Developer Mode, beta) connects to a remote MCP server over
-HTTPS instead. The HaloPSA MCP server, for example, gives the agent tools like
-`tickets_list` and `client_card` it can call directly.
+---
 
-**What is the difference between a Skill and an MCP server?**
-A Skill is what skill-capable agents (Claude Code, Codex CLI) use. An MCP server
-is what AI apps (Claude Desktop, ChatGPT) use. Both packages here ship both, so
-you do not have to pick: install once, use either path.
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
 
-**How do I connect Claude Code to a system?**
-Install the skill for the system you want (let your agent do it, or run the one-liner above).
-Claude Code discovers the Skill via `SKILL.md` in `skills/<skill>/` and drives the
-`<skill>-cli` binary. Authenticate with that system's credentials; per-skill instructions are in
-[skills/halopsa/README.md](./skills/halopsa/README.md) and
-[skills/servosity/README.md](./skills/servosity/README.md).
+Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens. Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability. Methodology: [Compounding Teams](https://compoundingteams.com). Generated CLIs and MCP servers built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).
 
-**How do I add a skill's MCP to Claude Desktop?**
-The install drops the skill's `<skill>-mcp` binary on your PATH. Add the MCP config block to
-your `claude_desktop_config.json` as shown in that skill's `mcp-install.md` (for example
-[skills/halopsa/mcp-install.md](./skills/halopsa/mcp-install.md)), and restart Claude Desktop.
-
-**Can I use these with ChatGPT?**
-Yes, but it is not the same as Claude Desktop. ChatGPT connects to remote MCP
-servers over HTTPS via Developer Mode (beta, on paid plans), not to a local
-binary. Each skill's `mcp-install.md` has a ChatGPT section showing how to run the
-MCP server in HTTP mode behind a secure tunnel and register it as a custom
-connector.
-
-**Is this free?**
-Yes. Apache-2.0 licensed - free to use commercially, free to fork. Servosity does not charge
-for API access or API calls to run the Servosity skill. Other PSA, RMM, and backup vendors set
-their own API-access terms, but the Skills and MCP servers in this repository are always free.
-
-**Can my team contribute a Skill or MCP for ConnectWise, Autotask, or NinjaOne?**
-Yes, please. See [CONTRIBUTING.md](./CONTRIBUTING.md). Bring the system to a Build
-Session and we will co-build the first version live, or PR a complete skill
-directly. Skills for systems we directly compete with are welcome too; this
-repository is an MSP capability directory, not a Servosity-product directory.
-
-**Is msp-skills affiliated with HaloPSA, Servosity, or any other vendor named here?**
-Servosity Inc. maintains this repository and ships the Servosity skill, so the
-Servosity skill is first-party. Every other vendor skill is unofficial and
-unaffiliated. Each unofficial skill carries a non-affiliation banner at the top of
-its README. See [TRADEMARKS.md](./TRADEMARKS.md) for the full statement.
-
-## Footer
-
-Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens.
-Apache-2.0 licensed. See [TRADEMARKS.md](./TRADEMARKS.md) for vendor
-non-affiliation and [SECURITY.md](./SECURITY.md) to report a vulnerability.
-Methodology: [Compounding Teams](https://compoundingteams.com).
+_Last updated: 2026-05-28. Latest releases: [halopsa-v0.1.0](https://github.com/servosity/msp-skills/releases/tag/halopsa-v0.1.0) · [servosity-v0.1.0](https://github.com/servosity/msp-skills/releases/tag/servosity-v0.1.0)._

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-26",
+  "generated_at": "2026-05-28",
   "skills": [
     {
       "name": "halopsa",
@@ -16,7 +16,7 @@
       "first_party": false,
       "install_skill_one_liner": "bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)",
       "install_mcp_doc": "skills/halopsa/mcp-install.md",
-      "description": "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return."
+      "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline."
     },
     {
       "name": "servosity",
@@ -32,7 +32,7 @@
       "first_party": true,
       "install_skill_one_liner": "bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)",
       "install_mcp_doc": "skills/servosity/mcp-install.md",
-      "description": "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show."
+      "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query."
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-28",
+  "generated_at": "2026-05-29",
   "skills": [
     {
       "name": "halopsa",

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+msp-skills.compoundingteams.com

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,43 @@
+title: "MSP Skills"
+description: "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. Works with Claude, ChatGPT, Codex, Cursor. For MSP owners."
+url: "https://msp-skills.compoundingteams.com"
+baseurl: ""
+github_repo: "servosity/msp-skills"
+github_url: "https://github.com/servosity/msp-skills"
+
+# AEO surface
+author:
+  name: "Servosity"
+  url: "https://www.servosity.com"
+organization:
+  name: "Servosity Inc."
+  url: "https://www.servosity.com"
+  same_as:
+    - "https://github.com/servosity"
+    - "https://compoundingteams.com"
+
+# Jekyll
+permalink: pretty
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+plugins:
+  - jekyll-sitemap
+  - jekyll-seo-tag
+
+# Don't render these as Jekyll pages (they're repo docs surfaced via GitHub)
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor
+
+# Default front matter for new pages (saves repetition)
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+      image: /assets/social/og-1280x640.png

--- a/docs/_includes/schema.html
+++ b/docs/_includes/schema.html
@@ -1,0 +1,64 @@
+{%- comment -%}
+JSON-LD structured data for AI search engines (Google AI Overviews, Perplexity,
+Claude Search, ChatGPT search). Two graph nodes per page: Organization for
+Servosity Inc., and either SoftwareApplication or FAQPage depending on the
+page's `type` front matter.
+{%- endcomment -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.servosity.com/#organization",
+      "name": "Servosity Inc.",
+      "url": "https://www.servosity.com",
+      "sameAs": [
+        "https://github.com/servosity",
+        "https://compoundingteams.com"
+      ]
+    },
+    {%- if page.skill_name -%}
+    {
+      "@type": "SoftwareApplication",
+      "name": "{{ page.skill_name }}",
+      "description": {{ page.description | jsonify }},
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Linux, Windows",
+      "softwareRequirements": "Model Context Protocol (MCP) compatible AI agent",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "license": "https://www.apache.org/licenses/LICENSE-2.0",
+      "publisher": { "@id": "https://www.servosity.com/#organization" },
+      "url": "{{ page.url | absolute_url }}",
+      "codeRepository": "https://github.com/servosity/msp-skills"
+    }
+    {%- elsif page.faqs -%}
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {%- for q in page.faqs -%}
+        {
+          "@type": "Question",
+          "name": {{ q.q | jsonify }},
+          "acceptedAnswer": { "@type": "Answer", "text": {{ q.a | jsonify }} }
+        }{%- unless forloop.last %},{% endunless -%}
+        {%- endfor -%}
+      ]
+    }
+    {%- else -%}
+    {
+      "@type": "WebPage",
+      "name": {{ page.title | default: site.title | jsonify }},
+      "description": {{ page.description | default: site.description | jsonify }},
+      "url": "{{ page.url | absolute_url }}",
+      "isPartOf": { "@id": "https://www.servosity.com/#organization" }
+    }
+    {%- endif -%}
+  ]
+}
+</script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#7C3AED">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="{{ page.description | default: site.description }}">
+  {% seo title=false description=false %}
+  {% include schema.html %}
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+  <link rel="alternate" type="application/llms+txt" href="/llms.txt">
+  <style>
+    :root {
+      --fg: #1a1a1a;
+      --muted: #555;
+      --bg: #fdfdfd;
+      --accent: #7C3AED;
+      --rule: #e5e5e5;
+      --code-bg: #f4f4f5;
+    }
+    html { box-sizing: border-box; }
+    *, *:before, *:after { box-sizing: inherit; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+      line-height: 1.6;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 1.5rem;
+      font-size: 17px;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    h1, h2, h3 { line-height: 1.25; margin-top: 2.2rem; }
+    h1 { font-size: 2.1rem; margin-top: 0.5rem; }
+    h2 { font-size: 1.5rem; border-top: 1px solid var(--rule); padding-top: 1.5rem; }
+    h3 { font-size: 1.2rem; }
+    blockquote {
+      border-left: 4px solid var(--accent);
+      padding: 0.5rem 1rem;
+      margin: 1.5rem 0;
+      background: #faf7ff;
+      color: var(--fg);
+    }
+    code { background: var(--code-bg); padding: 0.15rem 0.35rem; border-radius: 4px; font-size: 0.92em; }
+    pre { background: var(--code-bg); padding: 1rem; overflow-x: auto; border-radius: 6px; }
+    pre code { background: none; padding: 0; }
+    table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+    th, td { border-bottom: 1px solid var(--rule); padding: 0.5rem 0.7rem; text-align: left; vertical-align: top; }
+    th { font-weight: 600; background: #f9f9fb; }
+    .btn {
+      display: inline-block;
+      padding: 0.5rem 0.9rem;
+      border-radius: 6px;
+      border: 1px solid var(--rule);
+      margin-right: 0.5rem;
+      font-weight: 500;
+    }
+    .btn-primary { background: var(--accent); color: white; border-color: var(--accent); }
+    .btn-primary:hover { text-decoration: none; opacity: 0.92; }
+    nav.site-nav { padding: 0.5rem 0 1.5rem; border-bottom: 1px solid var(--rule); margin-bottom: 1rem; font-size: 0.95rem; }
+    nav.site-nav a { margin-right: 1rem; color: var(--muted); }
+    footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.9rem; }
+    hr { border: none; border-top: 1px solid var(--rule); margin: 2rem 0; }
+  </style>
+</head>
+<body>
+  <nav class="site-nav">
+    <a href="/">Home</a>
+    <a href="/skills/halopsa/">HaloPSA</a>
+    <a href="/skills/servosity/">Servosity</a>
+    <a href="/which-agent/">Which Agent?</a>
+    <a href="/guides/first-time-setup/">First-time setup</a>
+    <a href="https://github.com/servosity/msp-skills">GitHub</a>
+    <a href="https://compoundingteams.com/build-sessions">Build Sessions</a>
+  </nav>
+
+  <main>
+    {{ content }}
+  </main>
+
+  <footer>
+    <p><strong>MSP Skills</strong> · Built by <a href="https://www.servosity.com">Servosity Inc.</a> · Maintained by Damien Stevens · Apache-2.0 · <a href="https://github.com/servosity/msp-skills">github.com/servosity/msp-skills</a></p>
+    <p>Methodology: <a href="https://compoundingteams.com">Compounding Teams</a> · <a href="/llms.txt">/llms.txt</a> for AI search engines.</p>
+  </footer>
+</body>
+</html>

--- a/docs/guides/first-time-setup.md
+++ b/docs/guides/first-time-setup.md
@@ -1,0 +1,224 @@
+---
+layout: default
+title: "First-time setup for MSP business owners"
+description: "Beginner-friendly walkthrough for setting up MSP Skills if you've never used Claude Code, an MCP server, or a CLI. About 10 minutes start to finish."
+permalink: /guides/first-time-setup/
+---
+
+# First-time setup - for MSP business owners new to all this
+
+This guide is for **MSP business owners** who want to use MSP Skills but haven't used Claude Code, an MCP server, or a CLI before. No coding required, no terminal experience required, no developer experience required. About 10 minutes start to finish.
+
+If you're already comfortable in a terminal, the [main install](/#install-in-60-seconds) is faster.
+
+## What you'll get
+
+By the end of this guide, you'll be able to ask **Claude Desktop** (the most common MSP-owner choice) questions like:
+
+- *"Use halopsa: what's about to breach SLA in the next 24 hours?"*
+- *"Use servosity: which clients have backups that haven't succeeded in 7 days?"*
+- *"Use halopsa: build a client card for Acme Corp."*
+
+And get real answers from your live HaloPSA or Servosity data - no clicking through portals.
+
+## Before you start
+
+You need three things:
+
+1. **A Mac or Windows computer** (Linux works too, this guide focuses on Mac/Windows).
+2. **HaloPSA tenant + OAuth credentials**, OR a **Servosity MSP partner API token**, or both. (If you don't have one, you only install the other - they're independent.)
+3. **About 10 minutes.**
+
+## Step 1 - Download Claude Desktop (5 minutes)
+
+Open your browser and go to **[claude.ai](https://claude.ai)**. If you don't have a Claude account, sign up - it's free. The free Claude Desktop is enough for this; you don't need a paid plan.
+
+After signing in, look for a **Download** link on claude.ai (usually in the top-right menu, or there's a banner). Download Claude Desktop for your OS. Install it like any other Mac/Windows app - double-click the downloaded file, drag it to Applications (Mac) or run the installer (Windows).
+
+Open Claude Desktop. You should see a chat window. **You're ready for step 2.**
+
+## Step 2 - Open the Terminal (1 minute, once)
+
+You only need the terminal **once** - for the install. After that, everything happens in Claude Desktop's chat window.
+
+**On Mac:** press `Cmd + Space`, type `Terminal`, press Enter. A black window opens. You'll type one command into it.
+
+**On Windows:** press the Windows key, type `PowerShell`, press Enter. A blue window opens. You'll type one command into it.
+
+## Step 3 - Run the installer (2 minutes)
+
+In the terminal you just opened, **copy and paste one of these commands** depending on what you have:
+
+### If you have HaloPSA credentials:
+
+**Mac:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+```
+
+**Windows:**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+### If you have a Servosity partner token:
+
+**Mac:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows:**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+### If you have both - run both commands, one at a time.
+
+Press Enter after pasting. You'll see some output as the installer downloads and sets up the files. When it's done, the prompt comes back.
+
+## Step 4 - Find your credentials (3 minutes)
+
+### For HaloPSA:
+
+Open your HaloPSA portal in a browser → **Configuration → Integrations → Halo PSA API**. Create an API application:
+
+- **Authentication Method**: Client ID and Secret (Services)
+- Give it a name like "MSP Skills"
+- After saving, **copy the Client ID and Client Secret** somewhere safe (a password manager is ideal)
+
+Also note your **tenant name** - it's part of your HaloPSA URL. If your URL is `https://acmemsp.halopsa.com`, your tenant is `acmemsp`.
+
+### For Servosity:
+
+Log into the Servosity partner portal → look for **API** or **Tokens** section → generate or copy your **MSP partner API token**. (If you can't find it, contact Servosity support.)
+
+## Step 5 - Tell Claude Desktop about MSP Skills (3 minutes)
+
+This is the only "technical" step. You'll edit a small text file that tells Claude Desktop where to find MSP Skills.
+
+In Claude Desktop:
+
+1. Click **Claude → Settings** (top menu).
+2. Click the **Developer** tab.
+3. Click **Edit Config**.
+
+A text file opens in your default editor. **Replace its contents** with this (delete what's there first, paste this in):
+
+**If you only have HaloPSA:**
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "your-tenant-here",
+        "HALOPSA_CLIENT_ID": "your-client-id-here",
+        "HALOPSA_CLIENT_SECRET": "your-client-secret-here"
+      }
+    }
+  }
+}
+```
+
+**If you only have Servosity:**
+
+```json
+{
+  "mcpServers": {
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+**If you have both:**
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "your-tenant-here",
+        "HALOPSA_CLIENT_ID": "your-client-id-here",
+        "HALOPSA_CLIENT_SECRET": "your-client-secret-here"
+      }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+**Replace** `your-tenant-here`, `your-client-id-here`, `your-client-secret-here`, and `your-token-here` with the actual values from Step 4. Keep the quotes.
+
+Save the file. (`Cmd+S` on Mac, `Ctrl+S` on Windows.)
+
+## Step 6 - Restart Claude Desktop
+
+Quit Claude Desktop completely. On Mac, `Cmd+Q` or **Claude → Quit Claude**. On Windows, right-click the Claude icon in the system tray and pick **Quit**.
+
+Reopen Claude Desktop. After a few seconds, you should see a small **MCP icon** appear at the bottom-right of the chat input. **That means it worked.**
+
+## Step 7 - Ask a real question
+
+In the Claude Desktop chat, try:
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+
+Claude will run the right command, return the data, and explain what it found. You're done.
+
+## If something didn't work
+
+**No MCP icon appears after restart.** Your `claude_desktop_config.json` has a typo. Common issues:
+
+- A missing comma between blocks
+- A trailing comma (don't put a comma after the last item)
+- Curly braces don't match - count opening `{` and closing `}`, they should be equal
+
+Use a free JSON validator like [jsonlint.com](https://jsonlint.com) - paste the contents of your config file there and it'll point at the error.
+
+**"halopsa-mcp: command not found" in Claude Desktop logs.** The installer didn't put the binary on your PATH. On Mac:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+```
+
+…then quit and reopen Claude Desktop. On Windows, run PowerShell as Administrator and:
+
+```powershell
+$env:Path += ";$HOME\.local\bin"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, "User")
+```
+
+…then restart Claude Desktop.
+
+**Authentication errors when Claude asks HaloPSA / Servosity.** Open a terminal and run:
+
+- HaloPSA: `halopsa-cli doctor`
+- Servosity: `servosity-cli doctor`
+
+If those don't work, the env-var values in your config are wrong. Compare them to what you saved in Step 4. (`doctor` is safer than calling a real command first - it just tests the connection.)
+
+## You're set. What's next?
+
+- **Try a real workflow live with peers.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions) - we'll work it live with the MSP cohort.
+- **Want a different PSA / RMM / backup tool?** [Request a Skill →](/requesting-a-skill/).
+- **Switching to a different AI?** Same skills work in [ChatGPT](/integrations/chatgpt/), [Claude Code](/integrations/claude-code/), [Codex](/integrations/codex/), [Cursor and others](/which-agent/). No reinstall.
+
+[← Back home](/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,132 @@
+---
+layout: default
+title: "MSP Skills - HaloPSA and Servosity for the AI you already use"
+description: "Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. Works with Claude, ChatGPT, Codex, Cursor, and any AI tool that speaks MCP. Built for MSP owners. No code required."
+permalink: /
+---
+
+# MSP Skills - HaloPSA and Servosity, for the AI you already use
+
+**MSP Skills** installs natural-language AI tools for **HaloPSA tickets** and **Servosity backups** directly into **Claude**, **ChatGPT**, **Codex**, **Cursor**, **Windsurf**, or any AI agent that speaks MCP. Free, open source, runs on your laptop. A local SQLite mirror lets your agent answer cross-client questions the live API can't return in one shot - no rate-limit hits, no per-tech SaaS fee, no data leaves your network. Built for MSP owners. No developer experience required.
+
+> 🛠 **Built live with MSPs.** Join a free weekly **Build Session** at **[compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions)** - watch a Skill built against a real MSP system, or bring your own.
+
+[Install in 60 seconds →](#install-in-60-seconds){: .btn .btn-primary} &nbsp; [View on GitHub →](https://github.com/servosity/msp-skills){: .btn}
+
+## Works with your agent
+
+The four agents MSP owners actually use:
+
+| Your AI agent | Why MSPs use it | Install |
+| --- | --- | --- |
+| **Claude Desktop** | The most common MSP-owner choice - no terminal, just a chat window | [Setup →](/integrations/claude-desktop/) |
+| **ChatGPT** (Plus/Pro+) | The brand most MSPs already pay for; pair with Developer Mode | [Setup →](/integrations/chatgpt/) |
+| **Claude Code** (CLI) | For technical-leaning MSP owners or senior techs | [Setup →](/integrations/claude-code/) |
+| **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | [Setup →](/integrations/codex/) |
+
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. Full per-tool deep-dive in [which agent →](/which-agent/).
+
+## What's in the box
+
+| Skill | What it does | Install |
+| --- | --- | --- |
+| [HaloPSA →](/skills/halopsa/) | Ticket triage, SLA-breach pre-emption, per-client situational awareness, cross-client analytics. Local SQLite mirror so QBR-time questions don't hit rate limits. | [/skills/halopsa →](/skills/halopsa/) |
+| [Servosity →](/skills/servosity/) | Fleet-wide backup triage, stale-backup detection, overnight drift, cross-engine analytics. Local fleet mirror - Friday-email-ready in seconds. | [/skills/servosity →](/skills/servosity/) |
+
+## What makes this different
+
+### Local mirror, not live calls
+
+Most AI integrations for PSA and backup systems call the vendor's API on every question. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter?"* - that's 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON the model has to re-read. MSP Skills syncs HaloPSA and Servosity into a local SQLite mirror with full-text search. Cross-client and cross-engine questions become one local query: instant, offline, and the AI sees the answer, not the raw data.
+
+### Works with the AI you already use
+
+You don't have to switch agents. Same package, two interfaces: a **Claude Code / Codex Skill** for shell-style agents, and an **MCP server** for Claude Desktop, ChatGPT, Cursor, Windsurf, Cline, Continue.dev, Gemini, and Copilot. One install drops both binaries on your machine. Use one or both - your call. No vendor lock-in, no proprietary plugin format, no SaaS subscription that ties you to a single AI.
+
+### MSP owner first, not developer first
+
+You don't have to know JSON, regex, or what "stdio transport" means. Paste one sentence into Claude Code or Codex and your agent reads the Skill, installs the binary, and walks you through authentication. The CLIs **plan by default** - mutations show you what they would do before they do it. Every command has a tier (read / write / destructive) and a recommended agent policy. The hard stuff is hidden; the safety bar is high.
+
+## Install in 60 seconds
+
+### Path A - let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+Swap `halopsa` for `servosity` to install the Servosity skill.
+
+### Path B - run the installer yourself
+
+**HaloPSA on macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+```
+
+**HaloPSA on Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+Swap `halopsa` for `servosity` in either command. New to all this? See the [first-time setup guide →](/guides/first-time-setup/).
+
+> **Now what?** Once `halopsa-cli --version` or `servosity-cli doctor` returns clean, **bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions)** - we'll work it live with the MSP cohort and the same Skills you just installed.
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not local binaries directly. MSP Skills ships local binaries, so to use them with ChatGPT you run them on your machine and expose them via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step: [ChatGPT integration →](/integrations/chatgpt/).
+
+### Does this work with Claude?
+
+Yes - **Claude Code**, **Claude Desktop**, and the **Claude.ai** web (via Claude Desktop's MCP). Claude Code reads the Skill directly; Claude Desktop loads MSP Skills as an MCP server you add to `claude_desktop_config.json`. Both paths are first-class. Most MSP owners start with Claude Desktop because it's a Mac/Windows app - no terminal.
+
+### Do I need to know how to code?
+
+No. The recommended install path is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code, editing JSON in a text editor, or installing Node, Python, Docker, or a database. You will need to enter API credentials your PSA or backup tool gives you.
+
+### Is my HaloPSA or Servosity data safe? Does it leave my network?
+
+Your data stays on **your machine**. MSP Skills runs locally: the CLI and the MCP server are binaries on your laptop. The SQLite mirror sits in a local directory under your user account. The AI agent (Claude, ChatGPT, Codex) only sees what the CLI or MCP server returns - typically the result of a query, not raw bulk data. Credentials are read from your environment or your agent's config; they're never bundled into the repo or transmitted to MSP Skills servers (there are none).
+
+### Will this hit my HaloPSA API rate limits?
+
+Almost never. HaloPSA's rate limits aren't publicly documented and vary between cloud-hosted and self-hosted instances. MSP Skills syncs your HaloPSA data into a local SQLite mirror once, then incrementally; subsequent questions (triage, SLA breaches, client cards, cross-client analytics) run against the local mirror, not the live API. The big-batch QBR queries that get you 429'd with API-passthrough tools become a single SQL join here.
+
+### How is this different from HaloPSA's built-in ChatGPT integration?
+
+HaloPSA's built-in ChatGPT integration is great for ticket-by-ticket work - rewriting replies, summarizing one ticket, classifying sentiment. MSP Skills is the **MSP-owner-on-the-couch-with-Claude** layer: cross-client analytics, ad-hoc questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity. The two complement each other; you don't have to choose.
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer in "Install in 60 seconds" above is the same install path as macOS / Linux, just packaged for PowerShell. The CLI and MCP binaries are native Windows builds.
+
+### What does it cost?
+
+The Skills, the CLI binaries, and the MCP servers are **free**. Apache-2.0 licensed - free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA, RMM, and backup vendors set their own API-access terms. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and those are billed by your AI provider, not by us.
+
+### Can I try it on one client first?
+
+Yes. Every command takes a client / company filter (e.g. `halopsa-cli client card "Acme Corp"`, `servosity-cli company show 4421`). Read-tier commands plan nothing and change nothing; you can try them against your live system safely. Write-tier commands run `--dry-run` until you pass `--confirm`. The safe starting move is a read-only triage against one client, see the output, then widen scope.
+
+### What if my AI doesn't speak MCP?
+
+If your AI doesn't yet support MCP and isn't Claude Code / Codex CLI (which read SKILL.md directly), MSP Skills won't fit yet. The CLI binaries (`halopsa-cli`, `servosity-cli`) still work standalone in a shell - you can pipe their output into anything. As more AI tools add MCP (the protocol is moving fast in 2026), they'll work with MSP Skills automatically without anything changing on our side.
+
+## Tested by MSPs in Build Sessions
+
+These skills are built and tested with real MSPs running them against their own production systems, live, in our free weekly Build Sessions. They are currently beta and being validated now. **[RSVP for the next one →](https://compoundingteams.com/build-sessions)**.
+
+## Don't see the system you need?
+
+Tell us what to build next. **[Open an issue →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)** and name the PSA, RMM, backup, security, or M365 tool. First time filing a GitHub issue? See [the 90-second walkthrough →](/requesting-a-skill/).
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Built by [Servosity](https://www.servosity.com). Maintained by Damien Stevens. Apache-2.0 licensed. Methodology: [Compounding Teams](https://compoundingteams.com).

--- a/docs/integrations/chatgpt.md
+++ b/docs/integrations/chatgpt.md
@@ -1,0 +1,119 @@
+---
+layout: default
+title: "HaloPSA + Servosity in ChatGPT (Plus / Pro / Team / Enterprise)"
+description: "Use HaloPSA and Servosity in ChatGPT via MCP Developer Mode. Step-by-step setup with the mcp-remote bridge for local stdio servers. Free MSP Skills, paid ChatGPT tier required (Plus/Pro/Team/Business/Enterprise/Education)."
+permalink: /integrations/chatgpt/
+faqs:
+  - q: "Does ChatGPT support HaloPSA?"
+    a: "Yes, via MSP Skills' free HaloPSA MCP server connected through ChatGPT Developer Mode. ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education - Free does not yet expose Developer Mode). MSP Skills' MCP server is stdio; expose it over HTTPS with the mcp-remote bridge or your own tunnel."
+  - q: "Does ChatGPT support MCP?"
+    a: "Yes. OpenAI shipped native MCP support for ChatGPT in September 2025 as Developer Mode beta. Available on Plus, Pro, Team, Business, Enterprise, and Education plans. ChatGPT connects only to remote (HTTPS) MCP servers, not to local stdio binaries directly."
+  - q: "Can I use ChatGPT free with HaloPSA?"
+    a: "Not yet - the ChatGPT Free tier does not expose Developer Mode as of 2026-05-28. Plus, Pro, Team, Business, Enterprise, and Education plans all support MCP via Developer Mode. Watch OpenAI's announcements for Free-tier MCP."
+  - q: "Do I need to host my own server for ChatGPT to use MSP Skills?"
+    a: "Effectively yes - ChatGPT only talks to HTTPS endpoints, and MSP Skills' MCP servers are local. You bridge them over HTTPS using mcp-remote (the simplest path), Cloudflare Tunnel, or ngrok with HTTPS. Treat the resulting URL as sensitive; never expose your MCP server bare on the internet."
+---
+
+# HaloPSA and Servosity in ChatGPT
+
+ChatGPT (Plus / Pro / Team / Business / Enterprise / Education) added native MCP support in September 2025 as **Developer Mode** beta. This guide installs the MSP Skills HaloPSA and Servosity MCP servers in ChatGPT.
+
+**Two caveats up front:** ChatGPT Free does not yet expose Developer Mode, and ChatGPT only connects to **remote / HTTPS** MCP servers - not to local stdio binaries directly. MSP Skills ships local binaries, so you bridge them over HTTPS using `mcp-remote` or your own tunnel. The bridge is one extra step; everything else is the same as the [Claude Desktop install](/integrations/claude-desktop/).
+
+## What you need
+
+- **A paid ChatGPT plan** (Plus, Pro, Team, Business, Enterprise, or Education)
+- **A HaloPSA tenant + OAuth credentials** **or** a **Servosity MSP partner API token** - or both
+- **`mcp-remote`** or a secure tunnel (Cloudflare Tunnel, ngrok with HTTPS)
+- A terminal for install (after that, ChatGPT chat handles the rest)
+
+## Step 1 - Install MSP Skills binaries
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+Install only the skills you'll use.
+
+## Step 2 - Choose your HTTPS bridge
+
+**Option A - `mcp-remote` bridge (simplest).** In a terminal:
+
+```bash
+npx mcp-remote halopsa-mcp --port 7777 \
+  --env HALOPSA_TENANT=<tenant> \
+  --env HALOPSA_CLIENT_ID=<id> \
+  --env HALOPSA_CLIENT_SECRET=<secret>
+```
+
+Then expose `https://localhost:7777` to the public internet via Cloudflare Tunnel:
+
+```bash
+cloudflared tunnel --url http://localhost:7777
+```
+
+Cloudflare prints a public HTTPS URL. Treat it as sensitive.
+
+**Option B - run `halopsa-mcp` natively in HTTP mode.** The MSP Skills MCP binaries support `--transport http`:
+
+```bash
+HALOPSA_TENANT=<tenant> \
+HALOPSA_CLIENT_ID=<id> \
+HALOPSA_CLIENT_SECRET=<secret> \
+halopsa-mcp --transport http --addr :7777
+```
+
+Then tunnel it the same way (Cloudflare Tunnel / ngrok HTTPS).
+
+(Repeat the equivalent setup for `servosity-mcp` on a different port.)
+
+## Step 3 - Enable Developer Mode in ChatGPT
+
+In ChatGPT: **Settings → Advanced → Developer Mode** (toggle on). Then go to **Connectors → Add MCP server**. Enter the public HTTPS URL from your tunnel.
+
+## Step 4 - Ask a real question
+
+In ChatGPT chat:
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+
+ChatGPT discovers the MCP tools the connector exposes and runs them.
+
+## Cost
+
+- **MSP Skills:** Free (Apache-2.0).
+- **ChatGPT plan:** see [OpenAI's pricing](https://openai.com/chatgpt/pricing). Plus, Pro, Team, Business, Enterprise, and Education all support MCP. Free does not (as of 2026-05-28).
+- **HaloPSA / Servosity access:** your existing license / partner agreement.
+- **Tunneling:** Cloudflare Tunnel is free. ngrok has a free tier with HTTPS.
+
+## Security
+
+- The HTTPS tunnel URL is effectively a key to your MCP server. Treat it like a credential. **Don't post it publicly.**
+- For team / enterprise deployments, host MSP Skills on a server inside your network and expose via Cloudflare Access (or equivalent SSO-gated tunnel) so only authenticated users hit it.
+- HaloPSA + Servosity credentials are in your local environment, never transmitted to MSP Skills or to OpenAI.
+
+## Troubleshooting
+
+**ChatGPT can't connect to the MCP server:** confirm the tunnel URL responds when you visit it in a browser (you should get an MCP-protocol response or an error - not a connection refused). Test the underlying server with `halopsa-cli doctor` or `servosity-cli doctor` first.
+
+**Developer Mode toggle missing:** you're on the Free tier, or your plan admin disabled it. Check your ChatGPT plan at [chatgpt.com/#pricing](https://chatgpt.com/).
+
+**`mcp-remote: command not found`:** install Node.js (the bridge runs under npx). `brew install node` on macOS, the official Windows installer, or whichever package manager your distro uses.
+
+## What's next
+
+- **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions) - we'll work it live with the MSP cohort.
+- **No paid ChatGPT plan?** Use [Claude Desktop](/integrations/claude-desktop/) instead - Claude Desktop is free and supports MCP natively without HTTPS bridges.
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Claude Code (Anthropic CLI)"
+description: "Install MSP Skills in Claude Code: paste one sentence and your agent reads the SKILL.md, runs the install, walks authentication. For technical-leaning MSP owners or senior techs."
+permalink: /integrations/claude-code/
+faqs:
+  - q: "Does Claude Code support HaloPSA?"
+    a: "Yes. Paste this into Claude Code: 'Set up the HaloPSA skill from https://github.com/servosity/msp-skills - read skills/halopsa/SKILL.md, run its install steps, then run halopsa-cli --version to confirm. Walk me through authentication.' Claude Code does the rest."
+  - q: "What's the difference between Claude Code and Claude Desktop?"
+    a: "Claude Code is Anthropic's command-line agent that reads Skills directly (markdown SKILL.md files) and can run shell commands. Claude Desktop is the Mac/Windows app with a chat window that uses MCP servers (no shell). Most MSP business owners prefer Claude Desktop; senior techs and engineers often prefer Claude Code."
+  - q: "Do I need to know how to code to use Claude Code?"
+    a: "You need to be comfortable in a terminal, but you don't need to write code. The recommended install path is to paste one sentence - Claude Code reads SKILL.md and handles everything else."
+  - q: "Can Claude Code install both HaloPSA and Servosity?"
+    a: "Yes. Paste two prompts (one for each skill), or one prompt that asks for both: 'Set up both the halopsa and servosity skills from https://github.com/servosity/msp-skills.' Claude Code installs both."
+---
+
+# HaloPSA and Servosity in Claude Code
+
+Claude Code is Anthropic's CLI agent - a terminal-native AI that reads `SKILL.md` files directly and runs shell commands. For a **technical-leaning MSP owner** or a **senior tech**, Claude Code is the fastest install path: paste one sentence, your agent does the rest.
+
+If you don't already use Claude Code in a terminal, [Claude Desktop](/integrations/claude-desktop/) is the easier starting point.
+
+## Install in 30 seconds
+
+Paste this into Claude Code chat:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+For both skills in one go:
+
+> Set up both the **halopsa** and **servosity** skills from https://github.com/servosity/msp-skills - read each skill's SKILL.md, run their install steps, then run `halopsa-cli --version` and `servosity-cli doctor` to confirm. Walk me through authentication for both.
+
+Claude Code reads each SKILL.md, runs the installer (which drops the CLI + MCP binary on your PATH), prompts you for the HaloPSA OAuth credentials (Configuration → Integrations → Halo PSA API in your tenant) or the Servosity MSP partner token, runs `doctor` to verify, and confirms.
+
+## Manual install (skip the prompt)
+
+If you'd rather see what's running:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+Then symlink each skill into Claude Code:
+
+```bash
+ln -s "$(pwd)/skills/halopsa" ~/.claude/skills/halopsa
+ln -s "$(pwd)/skills/servosity" ~/.claude/skills/servosity
+```
+
+Restart Claude Code. Invoke with `use halopsa` or `use servosity`.
+
+## Use the skill
+
+In Claude Code:
+
+- *"Use halopsa: triage what needs attention across all clients today, focused on SLA breaches in the next 24 hours."*
+- *"Use servosity: show me stale backups across all clients, grouped by backup engine."*
+- *"Use halopsa: build a client card for Acme Corp, then cross-reference any open Servosity backup issues for them."*
+
+Claude Code knows the command surface (it just read the SKILL.md), runs the right command with the right flags, and pipes the JSON output into its reasoning.
+
+## Add the MCP server too (optional)
+
+Each install drops an MCP binary. To register it with Claude Code's MCP support (parallel to the Skill, lets you use MCP-style tool calls):
+
+```bash
+claude mcp add halopsa -- halopsa-mcp
+claude mcp add servosity -- servosity-mcp
+claude mcp list  # verify
+```
+
+The Skill path and MCP path coexist. Most users only need one (Skill is recommended).
+
+## What's next
+
+- **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Switching agents?** Same skills work in [Claude Desktop](/integrations/claude-desktop/), [Codex CLI](/integrations/codex/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall needed.
+- **Want a different platform?** [Request a Skill →](/requesting-a-skill/).
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Claude Desktop"
+description: "Install MSP Skills (HaloPSA tickets + Servosity backups) in Claude Desktop in 60 seconds. Free, runs on your Mac or Windows. No terminal needed after install. Built for MSP owners."
+permalink: /integrations/claude-desktop/
+faqs:
+  - q: "Does Claude Desktop support MCP?"
+    a: "Yes. Claude Desktop is the original MCP host - it has first-class native support for any MCP server, including MSP Skills' HaloPSA and Servosity servers. You configure them in claude_desktop_config.json."
+  - q: "Can I use HaloPSA in Claude Desktop?"
+    a: "Yes. Install MSP Skills with one shell command, then add the halopsa block to claude_desktop_config.json with your HaloPSA tenant + OAuth credentials, and restart Claude Desktop. The MCP indicator appears bottom-right when it connects."
+  - q: "Does this require a paid Claude plan?"
+    a: "Claude Desktop itself is free. You pay for Claude usage (Anthropic's API or claude.ai subscription) the same way you would without MSP Skills. MSP Skills is free."
+  - q: "Where does the config file live?"
+    a: "On macOS: ~/Library/Application Support/Claude/claude_desktop_config.json. On Windows: %APPDATA%\\Claude\\claude_desktop_config.json. Settings → Developer → Edit Config opens it directly."
+---
+
+# HaloPSA and Servosity in Claude Desktop
+
+Claude Desktop is the **most common MSP-owner choice** for MSP Skills - a Mac/Windows app with a chat window, no terminal after install. This guide installs the HaloPSA and Servosity MSP Skills as MCP servers in Claude Desktop in about 60 seconds.
+
+Claude Desktop is Anthropic's original MCP host - first-class native MCP support, no Plus / Pro tier required (Claude Desktop itself is free; you pay only for Claude usage). [modelcontextprotocol.io/quickstart/user](https://modelcontextprotocol.io/quickstart/user)
+
+## What you need
+
+- **Claude Desktop** installed (from [claude.ai](https://claude.ai) → Download)
+- A **HaloPSA tenant** with API credentials (Configuration → Integrations → Halo PSA API) **or** a **Servosity partner API token** (from the partner portal) - or both
+- A terminal once for install (after that, it's all GUI)
+
+## Step 1 - Install MSP Skills binaries
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+Install only the ones you'll use. Each installer drops the CLI and the MCP server on your PATH.
+
+## Step 2 - Edit Claude Desktop's config
+
+Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens the JSON in your default editor.) Add the `mcpServers` block:
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "<your-tenant>",
+        "HALOPSA_CLIENT_ID": "<your-client-id>",
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+      }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
+      }
+    }
+  }
+}
+```
+
+Save the file.
+
+## Step 3 - Restart Claude Desktop
+
+**Quit completely** (not just close - File → Quit on Mac, or right-click → Quit on Windows) and reopen. An MCP indicator appears bottom-right of the chat input once the servers connect.
+
+## Step 4 - Ask a real question
+
+In Claude Desktop chat:
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+- *"Use halopsa: build a client card for Acme Corp."*
+
+Claude reads the available MCP tools and runs the right commands.
+
+## Troubleshooting
+
+**MCP indicator never appears:** JSON syntax error in `claude_desktop_config.json`. Validate with `jq .` or any JSON linter. Common gotchas: trailing commas, unescaped backslashes on Windows paths.
+
+**"halopsa-mcp: command not found":** the installer didn't put the binary on your PATH. The installer prints the line to add (something like `export PATH="$HOME/.local/bin:$PATH"`). Add it to `~/.zshrc` or `~/.bashrc` (macOS/Linux) or your Windows PATH, restart your terminal, then quit and reopen Claude Desktop.
+
+**Authentication errors:** confirm you can run `halopsa-cli doctor` or `servosity-cli doctor` in a terminal first. If the CLI works, the MCP server will too with the same credentials.
+
+## What's next
+
+- **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions) - we'll work it live with the MSP cohort.
+- **Learn the command surface.** Each skill has a deep `SKILL.md` Claude reads on demand - you don't need to memorize commands.
+- **Want a different platform?** [Request a Skill →](/requesting-a-skill/) for the PSA, RMM, backup, or security tool you actually use.
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: "HaloPSA + Servosity in OpenAI Codex CLI"
+description: "Install MSP Skills in OpenAI Codex CLI: paste one sentence and your agent reads the SKILL.md, runs the install, walks authentication. Same skills, OpenAI-side."
+permalink: /integrations/codex/
+faqs:
+  - q: "Does Codex CLI support HaloPSA?"
+    a: "Yes. Codex CLI reads SKILL.md files the same way Claude Code does. Paste 'Set up the HaloPSA skill from https://github.com/servosity/msp-skills' and Codex does the install. Also supports MCP via ~/.codex/config.toml."
+  - q: "What is OpenAI Codex CLI?"
+    a: "OpenAI's command-line agent - a terminal-native AI similar to Anthropic's Claude Code, but using OpenAI's models (GPT-5/4 family). Supports Claude-Code-style Skills AND the open MCP protocol. Available at developers.openai.com/codex."
+  - q: "Can Codex CLI use the same MSP Skills as Claude Code?"
+    a: "Yes - these skills are agent-agnostic. The CLI binary, the MCP server, the SKILL.md format, and the install path are identical. Switch between Claude Code, Codex CLI, and Claude Desktop without reinstalling MSP Skills."
+  - q: "Do I need to pay OpenAI to use Codex CLI?"
+    a: "Codex CLI usage is billed against your OpenAI API account (token-based) or your ChatGPT subscription, depending on the model. MSP Skills is free regardless."
+---
+
+# HaloPSA and Servosity in OpenAI Codex CLI
+
+Codex CLI is OpenAI's command-line agent - a terminal-native AI that reads `SKILL.md` files (the open Agent Skills spec format) AND speaks MCP natively. For the same audience as Claude Code: a **technical-leaning MSP owner** or a **senior tech**.
+
+If you use Claude Code already, the install is identical - same skills, same SKILL.md, same MCP servers. Switching agents costs nothing.
+
+## Install in 30 seconds
+
+Paste this into Codex CLI:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+For both skills:
+
+> Set up both the **halopsa** and **servosity** skills from https://github.com/servosity/msp-skills - read each skill's SKILL.md, run their install steps, then run `halopsa-cli --version` and `servosity-cli doctor` to confirm.
+
+Codex reads each SKILL.md, runs the installer (drops the CLI + MCP binary on your PATH), prompts you for credentials, runs `doctor` to verify.
+
+## Manual install + MCP registration
+
+If you prefer explicit config:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+Then edit `~/.codex/config.toml` (global) or `.codex/config.toml` (project) to register the MCP servers:
+
+```toml
+[mcp_servers.halopsa]
+command = "halopsa-mcp"
+env = { HALOPSA_TENANT = "<your-tenant>", HALOPSA_CLIENT_ID = "<id>", HALOPSA_CLIENT_SECRET = "<secret>" }
+
+[mcp_servers.servosity]
+command = "servosity-mcp"
+env = { SERVOSITY_MSP_TOKEN = "<token>" }
+```
+
+Restart Codex CLI. Both MCP servers connect on startup.
+
+Codex supports stdio + Streamable HTTP and runs concurrent read-only tools when advertised - useful for cross-client / cross-engine analytics that hit multiple MSP Skills tools at once.
+
+[Source: developers.openai.com/codex/mcp](https://developers.openai.com/codex/mcp)
+
+## Use the skill
+
+In Codex CLI:
+
+- *"Use halopsa: triage what needs attention across all clients today, focused on SLA breaches in the next 24 hours."*
+- *"Use servosity: show me stale backups across all clients, grouped by backup engine."*
+
+Codex knows the command surface (it just read the SKILL.md), runs the right command with the right flags, and pipes the JSON output into reasoning.
+
+## What's next
+
+- **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Switching agents?** Same skills work in [Claude Code](/integrations/claude-code/), [Claude Desktop](/integrations/claude-desktop/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall.
+- **Want a different platform?** [Request a Skill →](/requesting-a-skill/).
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,53 @@
+# MSP Skills
+
+> Free Claude Code skills + MCP servers for HaloPSA tickets and Servosity backups. Works with Claude, ChatGPT (Plus/Pro+), Codex, Cursor, Windsurf, Cline, Continue, Gemini, GitHub Copilot, and any AI agent that speaks MCP. Local SQLite mirror so cross-client questions don't hit API rate limits. Built for MSP business owners. No code required. Free, Apache-2.0 licensed.
+
+MSP Skills is a public GitHub repository (servosity/msp-skills) maintained by Servosity Inc. that ships two Claude Code Skills and MCP servers for two MSP-relevant platforms: **HaloPSA** (a Professional Services Automation / ticketing system) and **Servosity** (a Business Continuity and Disaster Recovery vendor). Each skill includes a CLI binary (`halopsa-cli`, `servosity-cli`) and an MCP server binary (`halopsa-mcp`, `servosity-mcp`), distributed via GitHub Releases for macOS, Linux, and Windows.
+
+The audience is MSP business owners - not developers. Install paths are designed to be runnable by pasting one sentence into Claude Code / Codex (which then handles the install autonomously), or by running a single bash / PowerShell one-liner per OS. No Node, Python, Docker, GPU, or OpenAI key is required to install or run.
+
+## Skills
+
+- [HaloPSA skill](https://github.com/servosity/msp-skills/tree/main/skills/halopsa): HaloPSA, HaloITSM, HaloCRM integration. Wraps the full HaloPSA REST API plus a local SQLite mirror. Outcomes: ticket triage (`halopsa-cli triage`), SLA-breach pre-emption (`halopsa-cli sla breaching --within 24h`), per-client situational-awareness card (`halopsa-cli client card "Acme Corp"`), contract burn-down (`halopsa-cli contracts burn`), agent workload (`halopsa-cli agent workload`). Cross-entity queries that the live HaloPSA API can't return in one shot run against the local mirror - no rate-limit hits during QBR prep.
+
+- [Servosity skill](https://github.com/servosity/msp-skills/tree/main/skills/servosity): Servosity backup and DR for MSP partners. First-party (published by Servosity Inc.). Wraps the partner API surface plus a local fleet mirror with snapshot history and FTS5 search. Outcomes: fleet-wide attention (`servosity-cli attention`), stale-backup detection (`servosity-cli stale-backups --days 7`), overnight drift (`servosity-cli drift --from yesterday --to now`), per-client backup view (`servosity-cli company show 4421`), cross-engine search (`servosity-cli find "image manager"`).
+
+## What makes this different
+
+Most AI integrations for PSA and backup systems proxy each question into a live API call. That's fine for one record but dies at scale - 47 paginated REST calls, rate-limit headaches, and a context window full of raw JSON for cross-client questions. MSP Skills caches into a local SQLite mirror with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer rather than raw data.
+
+## Cross-tool support
+
+MSP Skills speaks the open MCP (Model Context Protocol) standard. The four agents MSP business owners actually use: **Claude Desktop** (Mac/Windows app, no terminal), **ChatGPT** (Plus/Pro/Team/Business/Enterprise/Education plans - Free tier does not yet expose Developer Mode; local stdio binaries need an `mcp-remote` HTTPS bridge), **Claude Code** (CLI), and **OpenAI Codex CLI**. Also works with **Cursor**, **Windsurf**, **Cline**, **Continue.dev**, **Zed**, **GitHub Copilot in VS Code** (uses `servers` key, not `mcpServers`; Agent mode only), **Gemini CLI**, plus **Hermes** (via MCP) and **OpenClaw** (frontmatter pre-wired, awaiting launch). Skills also conform to the open [Agent Skills spec](https://agentskills.io) (40+ agents).
+
+## Install
+
+Three install paths, in order of recommendation:
+
+1. **Paste into Claude Code or Codex** (recommended): "Set up the HaloPSA skill from https://github.com/servosity/msp-skills - read skills/halopsa/SKILL.md, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication." Swap halopsa for servosity for the other skill.
+
+2. **macOS / Linux**: `bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)` (swap `halopsa` for `servosity`).
+
+3. **Windows (PowerShell)**: `iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex` (swap `halopsa` for `servosity`).
+
+Each installer drops both the CLI binary and the MCP server binary on the user's PATH. Authentication uses platform-issued credentials (HaloPSA OAuth2 client_credentials; Servosity MSP partner API token) and is set via environment variables documented in each skill's README.
+
+## Pricing
+
+Free. Apache-2.0 licensed. Free to use commercially, free to fork. Servosity does not charge for API access required to run the Servosity skill. Other PSA / RMM / backup vendors set their own API-access terms. Users pay only for whichever AI agent they choose (Claude, ChatGPT, Codex, etc.), billed by their AI provider.
+
+## Maintainer
+
+Built by Servosity Inc. (servosity.com). Maintained by Damien Stevens. Tested live with real MSPs in free weekly Build Sessions at compoundingteams.com/build-sessions. Methodology: Compounding Teams. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).
+
+## Roadmap
+
+Co-built with MSPs in weekly Build Sessions. Targets the community asks for most: M365 governance / Copilot data-exposure pre-check, Autotask PSA, ConnectWise PSA, NinjaOne fleet hygiene, RMM ticket-to-doc (resolution to IT Glue / Hudu), Datto RMM, Kaseya, Atera, Syncro.
+
+## Request a Skill
+
+MSPs can request new Skills by filing a structured GitHub issue at https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml. First-timer guide at https://github.com/servosity/msp-skills/blob/main/docs/requesting-a-skill.md walks through GitHub account creation, the request form, and what happens next.
+
+## License
+
+Apache-2.0. See LICENSE in the repo.

--- a/docs/requesting-a-skill.md
+++ b/docs/requesting-a-skill.md
@@ -1,0 +1,55 @@
+# How to request a new MSP Skill (90 seconds, no terminal)
+
+You don't see your PSA, RMM, backup, or M365 tool listed yet? Tell us. This is the fastest way to move a system up the roadmap and to get it co-built live in a Build Session.
+
+No code experience required. No terminal. No GitHub-fu. If you can fill in a web form, you can do this.
+
+## What "filing an issue" actually means
+
+A GitHub "issue" is just a public note on the project. Anyone can read it, anyone can vote (👍) it. We use the votes to rank what to build next. Filing one takes about a minute.
+
+## Step 1 — Make sure you have a GitHub account
+
+If you've never used GitHub, you'll need a free account. **[Sign up at github.com →](https://github.com/signup)**
+
+You can use any email. There's nothing to install — it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
+
+## Step 2 — Open the request form
+
+**[Click here to open the skill-request form →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)**
+
+The form will ask:
+
+- **System / vendor name** (the product you want a Skill for — e.g. "Autotask", "NinjaOne", "Datto BCDR")
+- **Category** (PSA, RMM, Backup, Security, M365, Other)
+- **One question you'd ask the AI** if this Skill existed (e.g. "Which clients have open tickets older than 30 days?")
+- **Link to the vendor's API docs**, if you know it — or just write "I don't know," that's fine
+- **MSP size** (number of techs / clients) — helps us prioritize
+- **Would you join a Build Session for this?** — yes/no
+
+That's it. Click **Submit new issue** at the bottom.
+
+## Step 3 — What happens next
+
+1. **You'll see your issue on the public list.** Other MSPs can vote on it.
+2. **We comment within a few days** with one of three responses:
+   - "Already on the roadmap — here's the ETA."
+   - "We need more votes — share with one MSP friend who'd want this."
+   - "Bring it to next Thursday's Build Session and we'll co-build it live."
+3. **If it gets enough demand**, it goes into the queue. The Servosity skill in this repo got built that way.
+
+## Step 4 — Boost the signal (optional)
+
+If you want this Skill built faster:
+
+- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment — the 👍 above the title). Issues with more 👍s move up.
+- **Share the issue URL** with one MSP friend who'd want the same Skill. One additional vote moves your issue notably up the list.
+- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) — bring your tenant, your questions, and we co-build with the cohort.
+
+## I have a question, not a Skill request
+
+That's fine too — open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
+
+---
+
+_Last updated: 2026-05-28._

--- a/docs/requesting-a-skill.md
+++ b/docs/requesting-a-skill.md
@@ -8,47 +8,47 @@ No code experience required. No terminal. No GitHub-fu. If you can fill in a web
 
 A GitHub "issue" is just a public note on the project. Anyone can read it, anyone can vote (👍) it. We use the votes to rank what to build next. Filing one takes about a minute.
 
-## Step 1 — Make sure you have a GitHub account
+## Step 1 - Make sure you have a GitHub account
 
 If you've never used GitHub, you'll need a free account. **[Sign up at github.com →](https://github.com/signup)**
 
-You can use any email. There's nothing to install — it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
+You can use any email. There's nothing to install - it's just a website login. (If you'd rather a teammate file the issue for you, that works too; the votes count the same.)
 
-## Step 2 — Open the request form
+## Step 2 - Open the request form
 
 **[Click here to open the skill-request form →](https://github.com/servosity/msp-skills/issues/new?template=skill-request.yml)**
 
 The form will ask:
 
-- **System / vendor name** (the product you want a Skill for — e.g. "Autotask", "NinjaOne", "Datto BCDR")
+- **System / vendor name** (the product you want a Skill for - e.g. "Autotask", "NinjaOne", "Datto BCDR")
 - **Category** (PSA, RMM, Backup, Security, M365, Other)
 - **One question you'd ask the AI** if this Skill existed (e.g. "Which clients have open tickets older than 30 days?")
-- **Link to the vendor's API docs**, if you know it — or just write "I don't know," that's fine
-- **MSP size** (number of techs / clients) — helps us prioritize
-- **Would you join a Build Session for this?** — yes/no
+- **Link to the vendor's API docs**, if you know it - or just write "I don't know," that's fine
+- **MSP size** (number of techs / clients) - helps us prioritize
+- **Would you join a Build Session for this?** - yes/no
 
 That's it. Click **Submit new issue** at the bottom.
 
-## Step 3 — What happens next
+## Step 3 - What happens next
 
 1. **You'll see your issue on the public list.** Other MSPs can vote on it.
 2. **We comment within a few days** with one of three responses:
-   - "Already on the roadmap — here's the ETA."
-   - "We need more votes — share with one MSP friend who'd want this."
+   - "Already on the roadmap - here's the ETA."
+   - "We need more votes - share with one MSP friend who'd want this."
    - "Bring it to next Thursday's Build Session and we'll co-build it live."
 3. **If it gets enough demand**, it goes into the queue. The Servosity skill in this repo got built that way.
 
-## Step 4 — Boost the signal (optional)
+## Step 4 - Boost the signal (optional)
 
 If you want this Skill built faster:
 
-- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment — the 👍 above the title). Issues with more 👍s move up.
+- **Vote on related issues** with the 👍 reaction at the top of any issue (not a comment - the 👍 above the title). Issues with more 👍s move up.
 - **Share the issue URL** with one MSP friend who'd want the same Skill. One additional vote moves your issue notably up the list.
-- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) — bring your tenant, your questions, and we co-build with the cohort.
+- **Join a Build Session** at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions) - bring your tenant, your questions, and we co-build with the cohort.
 
 ## I have a question, not a Skill request
 
-That's fine too — open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
+That's fine too - open a regular issue at [github.com/servosity/msp-skills/issues](https://github.com/servosity/msp-skills/issues) and skip the "skill-request" template. Or email a Build Session host directly via [compoundingteams.com](https://compoundingteams.com).
 
 ---
 

--- a/docs/skills/halopsa.md
+++ b/docs/skills/halopsa.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: "HaloPSA + AI - for Claude, ChatGPT, Codex, Cursor, and any MCP agent"
+description: "Free Claude Code skill and MCP server for HaloPSA tickets. Triage queues, pre-empt SLA breaches, build per-client cards, run cross-client analytics. Local SQLite mirror so QBR-time questions don't hit rate limits. Built for MSP owners."
+permalink: /skills/halopsa/
+skill_name: "HaloPSA MCP"
+---
+
+# HaloPSA + AI in 60 seconds
+
+> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA, HaloITSM, and HaloCRM APIs. Not affiliated with Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of Halo Service Solutions Ltd.
+
+Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A **local SQLite mirror** means your AI can answer cross-client questions the live HaloPSA API can't return in one shot - **no rate-limit hits during QBR prep**. Built for MSP owners. No code required.
+
+[Install in 60s →](#install){: .btn .btn-primary} &nbsp; [View on GitHub →](https://github.com/servosity/msp-skills/tree/main/skills/halopsa){: .btn}
+
+## What it does
+
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What's about to breach SLA in the next 24 hours? | `halopsa-cli sla breaching --within 24h` |
+| What's the dispatcher view across all agents and teams? | `halopsa-cli triage --team Support` |
+| Who's overloaded right now? | `halopsa-cli agent workload` |
+| What's the whole story for this client, on one screen? | `halopsa-cli client card "Acme Corp"` |
+| How much contract time is left across every contract? | `halopsa-cli contracts burn` |
+| Which clients have stale tickets aging out? | `halopsa-cli tickets age-out` |
+| What changed in Halo since this morning? | `halopsa-cli tickets changed-since 9:00` |
+| Which KB article should the tech link to? | `halopsa-cli kbarticle suggest <ticket>` |
+
+Full command reference at [github.com/servosity/msp-skills/blob/main/skills/halopsa/guide.md](https://github.com/servosity/msp-skills/blob/main/skills/halopsa/guide.md).
+
+## What makes this different
+
+Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* - that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
+
+This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets - work a stateless API wrapper can't do.
+
+It **complements** HaloPSA's built-in ChatGPT integration (which is great for per-ticket work like rewriting replies and sentiment-flagging). The two are non-overlapping.
+
+## The pain this closes
+
+Two pains MSP owners name repeatedly:
+
+- **Cost-to-serve is rising faster than contract value.** The squeeze is operational: queue overload, SLA fires, unpriced work eating margin on every ticket.
+- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head - and in a PSA nobody else triages quickly.
+
+This skill puts the PSA's cross-entity truth one sentence away from any team member or their agent: `triage` / `sla breaching` surface what will breach before it does; `client card` gives any teammate one situational-awareness panel on demand; `contracts burn` catches unpriced work early; `agent workload` makes the queue legible across the whole team.
+
+## Install
+
+Works in any of these agents - pick yours:
+
+| Agent | Quick install |
+| --- | --- |
+| **Claude Desktop** | [Step-by-step →](/integrations/claude-desktop/) |
+| **ChatGPT** (Plus/Pro+) | [Step-by-step →](/integrations/chatgpt/) |
+| **Claude Code** | [Step-by-step →](/integrations/claude-code/) |
+| **Codex CLI** | [Step-by-step →](/integrations/codex/) |
+| Cursor, Windsurf, Cline, Continue, Zed, Copilot, Gemini, Hermes, OpenClaw | [Which agent? →](/which-agent/) |
+
+**Quickest path** for everyone else (terminal):
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+After install: get HaloPSA API credentials from Configuration → Integrations → Halo PSA API (Authentication Method: Client ID and Secret, Services), then:
+
+```bash
+HALOPSA_TENANT=<yourtenant> halopsa-cli auth login --client-id <id> --client-secret <secret>
+halopsa-cli --version
+```
+
+## Safety model
+
+| Tier | Examples | Recommended agent policy |
+| --- | --- | --- |
+| Read | `triage`, `sla breaching`, `client card`, `contracts burn` | Allow |
+| Write (routine) | ticket updates, notes, assignment | Preview with `--dry-run`, then a reviewed write |
+| Destructive / config | deletes, configuration changes | Human-in-the-loop only |
+
+The strongest control is the **scope you grant the Halo OAuth application** - the CLI can only do what that application is permitted to do. Full details in [governance.md](https://github.com/servosity/msp-skills/blob/main/skills/halopsa/governance.md).
+
+## Status
+
+Beta. Validated against the HaloPSA API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).

--- a/docs/skills/servosity.md
+++ b/docs/skills/servosity.md
@@ -1,0 +1,101 @@
+---
+layout: default
+title: "Servosity + AI - for Claude, ChatGPT, Codex, Cursor, and any MCP agent"
+description: "Free Claude Code skill and MCP server for Servosity backups. Fleet-wide attention, stale-backup detection, overnight drift, per-client situational awareness, cross-engine analytics. Local fleet mirror - Friday-email-ready in seconds."
+permalink: /skills/servosity/
+skill_name: "Servosity MCP"
+---
+
+# Servosity + AI in 60 seconds
+
+> Published by Servosity Inc. for MSP partners. Servosity is a trademark of Servosity Inc. Apache-2.0 licensed.
+
+Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A **local fleet mirror** means your AI can answer cross-client questions the partner portal can't show on one screen - **Friday-email-ready in seconds**. Built for MSP partners. No code required.
+
+[Install in 60s →](#install){: .btn .btn-primary} &nbsp; [View on GitHub →](https://github.com/servosity/msp-skills/tree/main/skills/servosity){: .btn}
+
+## What it does
+
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What needs my attention across every client this morning? | `servosity-cli attention` |
+| Which backups went stale across all clients? | `servosity-cli stale-backups --days 7` |
+| What changed across my fleet overnight? | `servosity-cli drift --from yesterday --to now` |
+| What's the whole story for this client, on one screen? | `servosity-cli company show <id>` |
+| Search across companies, backups, and issues at once | `servosity-cli find "image manager"` |
+| Triage what's worth keeping in the alert queue | `servosity-cli triage` |
+| Clear known-safe alert noise so real failures show | `servosity-cli clear` |
+| List DR restores in flight | `servosity-cli restore-queue list` |
+
+Full command reference at [github.com/servosity/msp-skills/blob/main/skills/servosity/guide.md](https://github.com/servosity/msp-skills/blob/main/skills/servosity/guide.md).
+
+## What makes this different
+
+Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* - the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
+
+This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON.
+
+## The pain this closes
+
+Backup and DR is where "silent failure" hurts most:
+
+- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore - the worst possible moment to find out.
+- **No fleet-wide view.** Each client's backup state lives in its own portal view; there's no single screen that says "across my whole book, here's what's stale, failing, or in-flight right now."
+- **Alert-queue noise buries the real failure.** Dozens of repeat and known-safe issues pile up per client; the one that matters hides in the pile.
+- **Per-client questions mean portal archaeology.** Answering "is this client OK?" means clicking through metadata, three backup engines, contracts, and issues by hand.
+
+`attention` is one screen across every client. `stale-backups` is the Friday-email list, ready. `drift` opens Monday with situational awareness instead of a blank slate. `triage` / `clear` / `stale-issues` batch-suppress known-safe noise. `company show` / `find` answer per-client and cross-fleet questions in one command.
+
+## Install
+
+| Agent | Quick install |
+| --- | --- |
+| **Claude Desktop** | [Step-by-step →](/integrations/claude-desktop/) |
+| **ChatGPT** (Plus/Pro+) | [Step-by-step →](/integrations/chatgpt/) |
+| **Claude Code** | [Step-by-step →](/integrations/claude-code/) |
+| **Codex CLI** | [Step-by-step →](/integrations/codex/) |
+| Cursor, Windsurf, Cline, Continue, Zed, Copilot, Gemini, Hermes, OpenClaw | [Which agent? →](/which-agent/) |
+
+**Quickest path** (terminal):
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+After install: get your partner API token from the Servosity partner portal, then:
+
+```bash
+SERVOSITY_MSP_TOKEN=<token> servosity-cli doctor
+```
+
+`doctor` confirms the token works and the local mirror is reachable before you run anything that touches client data.
+
+## Safety model
+
+| Tier | Examples | Recommended agent policy |
+| --- | --- | --- |
+| Read | `attention`, `drift`, `stale-backups`, `backup-facts`, `find`, `company show`, `restore-queue list` | Allow |
+| Write (routine) | `triage`, `clear`, `stale-issues`, notes/comments | Allow with `--confirm`; log the plan first |
+| Credential / security | credentials rotate/delete, MFA, agent-install-token, encryption-key update | Human-in-the-loop only |
+| Destructive | `companies delete`, `backups delete`, restic-prune, `users delete` | Human-in-the-loop only |
+| Admin (hidden) | `admin ...` | Operator-only, not for agents |
+
+Token is scoped to **your reseller account only** (no cross-reseller access). Full matrix in [governance.md](https://github.com/servosity/msp-skills/blob/main/skills/servosity/governance.md).
+
+## Status
+
+Already used inside Servosity's own backup/DR operations; published here for MSP partners. The public surface is in beta and being validated with MSPs in live **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com). Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).

--- a/docs/which-agent.md
+++ b/docs/which-agent.md
@@ -1,33 +1,356 @@
-# Which agent do I have?
+# Which AI agent? Install MSP Skills in any of them.
 
-`msp-skills` works with two families of AI agents. Pick yours, follow the matching install link, and skip the rest.
+MSP Skills works with **any AI tool that speaks MCP** (Model Context Protocol). This page tells you which AI tools speak MCP today, how to install the HaloPSA and Servosity skills in each one, and the gotchas to watch for.
 
-## You typed `claude` in a terminal and got an interactive AI prompt
+Pick the row for your agent and follow that section. If you're not sure what you have, jump to ["I don't know what I have"](#i-dont-know-what-i-have-yet) at the bottom.
 
-You have **Claude Code** (or Codex CLI). Both are skill-capable agents. They read `SKILL.md` files directly and drive CLIs.
+> **All paths assume you already ran the installer** for at least one skill — see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
 
-Install path: [install-skill.md](./install-skill.md).
+## Quick lookup
 
-## You downloaded Claude Desktop from claude.ai
+**The 4 MSP-owner primaries — lead here:**
 
-You have **Claude Desktop**. It is a Mac / Windows app with a chat window. It does not load `SKILL.md` files; it talks to MCP servers instead.
+| AI agent | Supports MCP? | Config file or panel | Verified |
+| --- | --- | --- | --- |
+| [Claude Desktop](#claude-desktop-anthropic) | Yes | `claude_desktop_config.json` | 2026-05-28 |
+| [ChatGPT (Plus / Pro+)](#chatgpt-openai-plus-pro-team-business-enterprise-education) | Yes¹ | Settings → Connectors | 2026-05-28 |
+| [Claude Code](#claude-code-anthropic-cli) | Yes | `claude mcp add ...` | 2026-05-28 |
+| [Codex CLI](#codex-cli-openai) | Yes | `~/.codex/config.toml` | 2026-05-28 |
 
-Install path: [install-mcp.md](./install-mcp.md).
+**Long-tail and developer IDEs:**
 
-## You use ChatGPT in the desktop app, not the website
+| AI agent | Supports MCP? | Config file or panel | Verified |
+| --- | --- | --- | --- |
+| [Cursor](#cursor) | Yes | `.cursor/mcp.json` | 2026-05-28 |
+| [Windsurf](#windsurf) | Yes | Cascade → MCP Servers | 2026-05-28 |
+| [Cline](#cline-vs-code) | Yes | `Ctrl+Shift+M` / `⌘+Shift+M` | 2026-05-28 |
+| [Continue.dev](#continuedev-vs-code--jetbrains) | Yes (Agent mode) | `config.json` | 2026-05-28 |
+| [Gemini CLI](#gemini-cli-google) | Yes | `~/.gemini/config.json` | 2026-05-28 |
+| [GitHub Copilot in VS Code](#github-copilot-in-vs-code) | Yes (Agent mode) | `mcp.json` (key: `servers`) | 2026-05-28 |
+| [Zed](#zed) | Partial² | `context_servers` in `settings.json` | 2026-05-28 |
+| [JetBrains AI Assistant / Junie](#jetbrains-ai-assistant--junie) | _Verify_ | _verify_ | _pending_ |
 
-You have **ChatGPT Desktop**. Same story as Claude Desktop: it talks to MCP servers, not Skills.
+**Niche / pre-wired (advanced):**
 
-Install path: [install-mcp.md](./install-mcp.md).
+| AI agent | Status | Install path | Verified |
+| --- | --- | --- | --- |
+| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install servosity/msp-skills/skills/<name>` | 2026-05-28 (paper — install not yet end-to-end tested) |
+| [OpenClaw](#openclaw) | Pre-wired (awaiting launch) | `openclaw:` frontmatter block already in every SKILL.md | 2026-05-28 (frontmatter wiring; OpenClaw not yet GA) |
 
-## You only use ChatGPT or Claude on the web
+¹ ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education). Free tier does not yet expose Developer Mode. ChatGPT connects only to **remote** MCP servers; local stdio binaries like MSP Skills need an HTTPS bridge (e.g. `mcp-remote`).
+² Zed supports MCP Tools and Prompts today, not the full spec. Most MSP Skills functionality works; some advanced features may not.
 
-Web-only chat surfaces do not yet have a way to install MCP servers or Skills. There is nothing to install here for that path. When the web surfaces add MCP, we will document it.
+---
 
-## You use Cursor, Cline, Aider, Continue, or another agent
+## Claude Desktop (Anthropic)
 
-These agents are evolving fast. Some load Skills, some only use MCP, some have their own format. Check your agent's docs for "MCP server" or "Skill" support and pick the matching install path here.
+The Mac / Windows app with a chat window. First-class MCP host — the original.
 
-## Still not sure
+**Config file:**
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-If you are working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and do not remember: open whatever you call up to chat with the AI and look at the menu / settings. The presence of a "skills" or "MCP" section in the settings tells you which family.
+**Setup** (Settings → Developer → Edit Config), add the block for HaloPSA and / or Servosity:
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "<your-tenant>",
+        "HALOPSA_CLIENT_ID": "<your-client-id>",
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+      }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
+      }
+    }
+  }
+}
+```
+
+**Restart Claude Desktop fully** (quit and reopen). An MCP indicator appears in the bottom-right of the chat input once the server connects. Source: [modelcontextprotocol.io/quickstart/user](https://modelcontextprotocol.io/quickstart/user).
+
+---
+
+## Claude Code (Anthropic CLI)
+
+Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code — just install the skill normally — but you can register the MCP server too if you prefer that interface.
+
+**Skill path (recommended):** the install script symlinks the skill into `~/.claude/skills/`. Restart Claude Code; invoke with `use halopsa` or `use servosity`.
+
+**MCP path (alternative):**
+
+```bash
+claude mcp add halopsa -- halopsa-mcp
+claude mcp add servosity -- servosity-mcp
+claude mcp list   # confirm status
+```
+
+For HTTP / remote: `claude mcp add --transport http <name> <url>`. Source: [code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp).
+
+---
+
+## Codex CLI (OpenAI)
+
+Skill-capable CLI like Claude Code. Reads the same `SKILL.md`. Also supports MCP.
+
+**Skill path (recommended):** the install script registers the skill with Codex; invoke `use halopsa` or `use servosity`.
+
+**MCP path (alternative):** edit `~/.codex/config.toml` (global) or `.codex/config.toml` (project):
+
+```toml
+[mcp_servers.halopsa]
+command = "halopsa-mcp"
+env = { HALOPSA_TENANT = "<your-tenant>", HALOPSA_CLIENT_ID = "<id>", HALOPSA_CLIENT_SECRET = "<secret>" }
+
+[mcp_servers.servosity]
+command = "servosity-mcp"
+env = { SERVOSITY_MSP_TOKEN = "<token>" }
+```
+
+Codex supports stdio + Streamable HTTP, and runs concurrent read-only tools when advertised. Source: [developers.openai.com/codex/mcp](https://developers.openai.com/codex/mcp).
+
+---
+
+## ChatGPT (OpenAI) — Plus, Pro, Team, Business, Enterprise, Education
+
+**Free tier does not yet expose Developer Mode**; you need a paid plan. ChatGPT speaks MCP through "Developer Mode" connectors (beta as of Sept 2025).
+
+**Important transport caveat:** ChatGPT connects only to **remote** MCP servers (HTTPS). MSP Skills binaries are local (stdio). To use them with ChatGPT, expose them over HTTPS:
+
+**Option 1 — `mcp-remote` bridge (simplest):**
+
+```bash
+# In one terminal, expose halopsa-mcp over HTTPS via the bridge
+mcp-remote halopsa-mcp --port 7777
+# (Repeat for servosity-mcp on a different port)
+```
+
+Then in ChatGPT: Settings → Advanced → **enable Developer Mode** → Connectors tab → Add MCP server → URL = `https://<your-tunnel>:7777`. If your tunnel is local-only (e.g. ngrok), Developer Mode will refuse without HTTPS. Use a TLS tunnel (Cloudflare Tunnel, ngrok with HTTPS, your own reverse proxy).
+
+**Option 2 — run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
+
+```bash
+HALOPSA_TENANT=... halopsa-mcp --transport http --addr :7777
+```
+
+Then expose `https://<your-public-host>:7777` to ChatGPT via Developer Mode. Always behind a secure tunnel; never expose your MCP server bare on the internet.
+
+Sources: [InfoQ ChatGPT MCP](https://www.infoq.com/news/2025/10/chat-gpt-mcp/) · [OpenAI Connectors help](https://help.openai.com/en/articles/11487775-connectors-in-chatgpt) · [Developer Mode docs](https://platform.openai.com/docs/guides/developer-mode).
+
+---
+
+## Cursor
+
+AI-first code editor. Native MCP. Stdio, SSE, and Streamable HTTP.
+
+**Config:** `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global).
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  }
+}
+```
+
+Or use the Settings → MCP UI to add it via the panel. Cursor supports config interpolation for env vars. Source: [cursor.com/docs/mcp](https://cursor.com/docs/mcp).
+
+---
+
+## Windsurf
+
+The Cascade panel speaks MCP. Stdio, Streamable HTTP, and SSE. OAuth supported.
+
+**Setup:** Click the **MCP Marketplace** icon in the Cascade panel, or Settings → Cascade → MCP Servers → Add. Use the same `command` / `env` block shape as Claude Desktop.
+
+April 2026 update: OAuth fixes; Streamable HTTP replacing SSE. Source: [docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp).
+
+---
+
+## Cline (VS Code)
+
+VS Code extension. Built-in MCP Marketplace.
+
+**Setup:** `Ctrl+Shift+M` (Windows / Linux) or `⌘+Shift+M` (macOS) opens the marketplace. Or click the **MCP Servers** icon → **Configure** tab → add `halopsa` / `servosity` with the `command` + `env` block.
+
+**Windows gotcha:** if Cline reports `spawn npx ENOENT`, wrap the command as `cmd` + `npx` per Cline's docs. MSP Skills' own binaries don't use `npx`, so this only matters if you're also installing Node-based MCP servers alongside.
+
+Source: [docs.cline.bot/mcp/adding-and-configuring-servers](https://docs.cline.bot/mcp/adding-and-configuring-servers).
+
+---
+
+## Continue.dev (VS Code / JetBrains)
+
+Open-source AI assistant. **MCP tools only work in Agent mode.** Stdio, SSE, Streamable HTTP. OAuth + env-var templating.
+
+**Setup:** edit Continue's `config.json` (per-IDE path varies; see Continue docs) and add:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "halopsa",
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    {
+      "name": "servosity",
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  ]
+}
+```
+
+**Switch Continue to Agent mode** in the chat panel for tools to fire. Source: [docs.continue.dev/customize/deep-dives/mcp](https://docs.continue.dev/customize/deep-dives/mcp).
+
+---
+
+## Gemini CLI (Google)
+
+Google's CLI agent. Native MCP — Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
+
+**Setup:** edit `~/.gemini/config.json` (or the path Gemini CLI prints with `gemini config path`) and add an `mcpServers` block with the same shape as Claude Desktop. Gemini CLI's tool list will include the MCP tools after restart.
+
+Google Cloud also offers fully-managed remote MCP servers for Google services — not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog — official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
+
+---
+
+## GitHub Copilot in VS Code
+
+GA in VS Code 1.102 (July 2025). Most enterprise-ready MCP client by reputation: sandboxing, OAuth, Settings Sync, curated marketplace.
+
+**Critical gotchas:**
+
+1. **Config file is `mcp.json`** (not `settings.json`).
+2. **Root key is `servers`** (NOT `mcpServers` like Claude). Easy to miss.
+3. **Works only in Copilot Agent mode** — pick "Agent" in the Copilot Chat mode dropdown.
+
+```json
+{
+  "servers": {
+    "halopsa": {
+      "type": "stdio",
+      "command": "halopsa-mcp",
+      "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" }
+    },
+    "servosity": {
+      "type": "stdio",
+      "command": "servosity-mcp",
+      "env": { "SERVOSITY_MSP_TOKEN": "<token>" }
+    }
+  }
+}
+```
+
+Or install through the Extensions view: search `@mcp` and install from the gallery. Source: [code.visualstudio.com/docs/copilot/customization/mcp-servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+
+---
+
+## Zed
+
+Calls them "context servers." **Partial MCP support** — Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
+
+**Setup:** open the Agent Panel (`Cmd+Shift+A`) → top-right menu → install server extensions. Or edit `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "halopsa": {
+      "command": { "path": "halopsa-mcp", "env": { "HALOPSA_TENANT": "<tenant>", "HALOPSA_CLIENT_ID": "<id>", "HALOPSA_CLIENT_SECRET": "<secret>" } }
+    },
+    "servosity": {
+      "command": { "path": "servosity-mcp", "env": { "SERVOSITY_MSP_TOKEN": "<token>" } }
+    }
+  }
+}
+```
+
+Most MSP Skills tools will appear in Zed's tool list; some advanced features that depend on full-spec MCP may not work yet. Source: [zed.dev/docs/ai/mcp](https://zed.dev/docs/ai/mcp).
+
+---
+
+## JetBrains AI Assistant / Junie
+
+JetBrains reportedly added MCP support in late 2025; we have not yet verified the install path against primary docs. If you use JetBrains AI Assistant or Junie and want MSP Skills support documented here, open an issue with the path you used and we'll add it.
+
+---
+
+## Hermes (Nous Research)
+
+Hermes is Nous Research's autonomous research agent. It speaks MCP natively per the [Nous Research docs](https://hermes-agent.nousresearch.com/docs) and has its own SKILL.md installer for Claude-Code-compatible skills.
+
+**MSP Skills works two ways under Hermes:**
+
+1. **Via MCP** (preferred — same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
+
+2. **Via Skill install** (uses the upstream cli-printing-press template). From the Hermes CLI:
+
+   ```bash
+   hermes skills install servosity/msp-skills/skills/halopsa --force
+   hermes skills install servosity/msp-skills/skills/servosity --force
+   ```
+
+   Inside a Hermes chat session:
+
+   ```
+   /skills install servosity/msp-skills/skills/halopsa --force
+   ```
+
+**Honest status:** the cli-printing-press alignment work for Hermes (PR #655) ships the frontmatter + README install sections, but end-to-end install of a printed CLI from a non-canonical path (i.e. `servosity/msp-skills/...` instead of `mvanhorn/printing-press-library/cli-skills/...`) has not been verified end-to-end by upstream. The MCP path (#1) is the more reliable route until Hermes confirms arbitrary GitHub-path resolution.
+
+---
+
+## OpenClaw
+
+OpenClaw is a browser-based Claude Code fork in active development. It's not yet generally available — but cli-printing-press wires every generated SKILL.md with an `openclaw:` metadata block that OpenClaw will recognize on launch.
+
+```yaml
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - halopsa-cli
+```
+
+That block is already in `skills/halopsa/SKILL.md` and `skills/servosity/SKILL.md`. When OpenClaw ships, the user-side install will be:
+
+> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI can be installed.
+
+(Same pattern for the servosity skill.) No action required from the MSP owner today; the wiring is forward-looking.
+
+---
+
+## I don't know what I have yet
+
+A 30-second triage:
+
+| You typed this and got an AI prompt | You have | Install path |
+| --- | --- | --- |
+| `claude` in a terminal | **Claude Code** | Skill or MCP — see above |
+| `codex` in a terminal | **Codex CLI** | Skill or MCP — see above |
+| `gemini` in a terminal | **Gemini CLI** | MCP — see above |
+| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP — see above |
+| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) — see above |
+| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP — see above |
+| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet — web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
+| You're not sure | — | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
+
+If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" — whichever has an app is what you have.
+
+---
+
+_All "Verified" dates reflect the date this document was last confirmed against primary sources. If you find a step that no longer works, please open an issue or send a PR. Last updated: 2026-05-28._

--- a/docs/which-agent.md
+++ b/docs/which-agent.md
@@ -4,11 +4,11 @@ MSP Skills works with **any AI tool that speaks MCP** (Model Context Protocol). 
 
 Pick the row for your agent and follow that section. If you're not sure what you have, jump to ["I don't know what I have"](#i-dont-know-what-i-have-yet) at the bottom.
 
-> **All paths assume you already ran the installer** for at least one skill — see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
+> **All paths assume you already ran the installer** for at least one skill - see the [main README](../README.md#install-in-60-seconds) for the one-liners. The installer drops `halopsa-cli` + `halopsa-mcp` (and / or `servosity-cli` + `servosity-mcp`) into your user `bin` path. After that, this page is purely about pointing your AI agent at those binaries.
 
 ## Quick lookup
 
-**The 4 MSP-owner primaries — lead here:**
+**The 4 MSP-owner primaries - lead here:**
 
 | AI agent | Supports MCP? | Config file or panel | Verified |
 | --- | --- | --- | --- |
@@ -30,12 +30,12 @@ Pick the row for your agent and follow that section. If you're not sure what you
 | [Zed](#zed) | Partial² | `context_servers` in `settings.json` | 2026-05-28 |
 | [JetBrains AI Assistant / Junie](#jetbrains-ai-assistant--junie) | _Verify_ | _verify_ | _pending_ |
 
-**Niche / pre-wired (advanced):**
+**Other agents:**
 
 | AI agent | Status | Install path | Verified |
 | --- | --- | --- | --- |
-| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install servosity/msp-skills/skills/<name>` | 2026-05-28 (paper — install not yet end-to-end tested) |
-| [OpenClaw](#openclaw) | Pre-wired (awaiting launch) | `openclaw:` frontmatter block already in every SKILL.md | 2026-05-28 (frontmatter wiring; OpenClaw not yet GA) |
+| [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install Servosity/msp-skills/skills/<name>` | 2026-05-29 (paper - install not yet end-to-end tested) |
+| [OpenClaw](#openclaw) | Yes (GA) | `openclaw skills install git:Servosity/msp-skills/skills/<name>@main` | 2026-05-29 (frontmatter spec match; subdir install path needs final dogfood) |
 
 ¹ ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education). Free tier does not yet expose Developer Mode. ChatGPT connects only to **remote** MCP servers; local stdio binaries like MSP Skills need an HTTPS bridge (e.g. `mcp-remote`).
 ² Zed supports MCP Tools and Prompts today, not the full spec. Most MSP Skills functionality works; some advanced features may not.
@@ -44,7 +44,7 @@ Pick the row for your agent and follow that section. If you're not sure what you
 
 ## Claude Desktop (Anthropic)
 
-The Mac / Windows app with a chat window. First-class MCP host — the original.
+The Mac / Windows app with a chat window. First-class MCP host - the original.
 
 **Config file:**
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -79,7 +79,7 @@ The Mac / Windows app with a chat window. First-class MCP host — the original.
 
 ## Claude Code (Anthropic CLI)
 
-Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code — just install the skill normally — but you can register the MCP server too if you prefer that interface.
+Skill-capable CLI. Reads `SKILL.md` directly and drives `halopsa-cli` / `servosity-cli`. You don't actually need MCP for Claude Code - just install the skill normally - but you can register the MCP server too if you prefer that interface.
 
 **Skill path (recommended):** the install script symlinks the skill into `~/.claude/skills/`. Restart Claude Code; invoke with `use halopsa` or `use servosity`.
 
@@ -117,13 +117,13 @@ Codex supports stdio + Streamable HTTP, and runs concurrent read-only tools when
 
 ---
 
-## ChatGPT (OpenAI) — Plus, Pro, Team, Business, Enterprise, Education
+## ChatGPT (OpenAI) - Plus, Pro, Team, Business, Enterprise, Education
 
 **Free tier does not yet expose Developer Mode**; you need a paid plan. ChatGPT speaks MCP through "Developer Mode" connectors (beta as of Sept 2025).
 
 **Important transport caveat:** ChatGPT connects only to **remote** MCP servers (HTTPS). MSP Skills binaries are local (stdio). To use them with ChatGPT, expose them over HTTPS:
 
-**Option 1 — `mcp-remote` bridge (simplest):**
+**Option 1 - `mcp-remote` bridge (simplest):**
 
 ```bash
 # In one terminal, expose halopsa-mcp over HTTPS via the bridge
@@ -133,7 +133,7 @@ mcp-remote halopsa-mcp --port 7777
 
 Then in ChatGPT: Settings → Advanced → **enable Developer Mode** → Connectors tab → Add MCP server → URL = `https://<your-tunnel>:7777`. If your tunnel is local-only (e.g. ngrok), Developer Mode will refuse without HTTPS. Use a TLS tunnel (Cloudflare Tunnel, ngrok with HTTPS, your own reverse proxy).
 
-**Option 2 — run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
+**Option 2 - run `halopsa-mcp` / `servosity-mcp` in HTTP mode** (no bridge):
 
 ```bash
 HALOPSA_TENANT=... halopsa-mcp --transport http --addr :7777
@@ -221,11 +221,11 @@ Open-source AI assistant. **MCP tools only work in Agent mode.** Stdio, SSE, Str
 
 ## Gemini CLI (Google)
 
-Google's CLI agent. Native MCP — Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
+Google's CLI agent. Native MCP - Gemini API + SDK + CLI all speak it as of Mar–Apr 2026.
 
 **Setup:** edit `~/.gemini/config.json` (or the path Gemini CLI prints with `gemini config path`) and add an `mcpServers` block with the same shape as Claude Desktop. Gemini CLI's tool list will include the MCP tools after restart.
 
-Google Cloud also offers fully-managed remote MCP servers for Google services — not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog — official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
+Google Cloud also offers fully-managed remote MCP servers for Google services - not relevant to MSP Skills, but worth knowing about. Source: [Google Cloud Blog - official MCP support](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services).
 
 ---
 
@@ -237,7 +237,7 @@ GA in VS Code 1.102 (July 2025). Most enterprise-ready MCP client by reputation:
 
 1. **Config file is `mcp.json`** (not `settings.json`).
 2. **Root key is `servers`** (NOT `mcpServers` like Claude). Easy to miss.
-3. **Works only in Copilot Agent mode** — pick "Agent" in the Copilot Chat mode dropdown.
+3. **Works only in Copilot Agent mode** - pick "Agent" in the Copilot Chat mode dropdown.
 
 ```json
 {
@@ -262,7 +262,7 @@ Or install through the Extensions view: search `@mcp` and install from the galle
 
 ## Zed
 
-Calls them "context servers." **Partial MCP support** — Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
+Calls them "context servers." **Partial MCP support** - Tools and Prompts work today; the full spec is in progress (Zed 1.0 ships agentic editing as first-class).
 
 **Setup:** open the Agent Panel (`Cmd+Shift+A`) → top-right menu → install server extensions. Or edit `settings.json`:
 
@@ -295,7 +295,7 @@ Hermes is Nous Research's autonomous research agent. It speaks MCP natively per 
 
 **MSP Skills works two ways under Hermes:**
 
-1. **Via MCP** (preferred — same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
+1. **Via MCP** (preferred - same path as Claude Desktop / Cursor). Hermes loads `halopsa-mcp` and `servosity-mcp` as MCP servers via its `mcp_servers:` config. Same env vars (`HALOPSA_TENANT`/`CLIENT_ID`/`CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
 
 2. **Via Skill install** (uses the upstream cli-printing-press template). From the Hermes CLI:
 
@@ -316,21 +316,42 @@ Hermes is Nous Research's autonomous research agent. It speaks MCP natively per 
 
 ## OpenClaw
 
-OpenClaw is a browser-based Claude Code fork in active development. It's not yet generally available — but cli-printing-press wires every generated SKILL.md with an `openclaw:` metadata block that OpenClaw will recognize on launch.
+[OpenClaw](https://docs.openclaw.ai) is GA (latest stable as of May 2026). Browser-controlled AI agent with native Skill support (SKILL.md superset of Anthropic's spec) and native MCP. Public skill registry at [ClawHub](https://clawhub.ai).
 
-```yaml
-metadata:
-  openclaw:
-    requires:
-      bins:
-        - halopsa-cli
+**One-time setup:** install OpenClaw itself ([install docs](https://docs.openclaw.ai/install)).
+
+```bash
+# macOS / Linux / WSL2
+curl -fsSL https://openclaw.ai/install.sh | bash
+
+# Windows (PowerShell)
+iwr -useb https://openclaw.ai/install.ps1 | iex
 ```
 
-That block is already in `skills/halopsa/SKILL.md` and `skills/servosity/SKILL.md`. When OpenClaw ships, the user-side install will be:
+**Install MSP Skills' HaloPSA skill:**
 
-> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI can be installed.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/halopsa@main
+```
 
-(Same pattern for the servosity skill.) No action required from the MSP owner today; the wiring is forward-looking.
+**Install the Servosity skill:**
+
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/servosity@main
+```
+
+OpenClaw reads each skill's `SKILL.md`, sees the `metadata.openclaw.requires.bins` block (already in our frontmatter via cli-printing-press), and installs the required CLI. Run `openclaw doctor` to confirm the install + env vars.
+
+**Register the MCP servers too** (optional - the Skill path already gives you most of the value):
+
+```bash
+openclaw mcp set halopsa '{"command":"halopsa-mcp"}'
+openclaw mcp set servosity '{"command":"servosity-mcp"}'
+```
+
+See the [OpenClaw MCP CLI docs](https://docs.openclaw.ai/cli/mcp) for the canonical command shape.
+
+**Note on subdirectory install path.** OpenClaw's monorepo subdirectory `git:` syntax for `skills install` is documented in the ClawHub skill-format spec; if `git:Servosity/msp-skills/skills/halopsa@main` does not resolve in your build, fall back to cloning the repo locally and running `openclaw skills install ./msp-skills/skills/halopsa`. We are updating the dogfood receipt in the next release.
 
 ---
 
@@ -340,16 +361,16 @@ A 30-second triage:
 
 | You typed this and got an AI prompt | You have | Install path |
 | --- | --- | --- |
-| `claude` in a terminal | **Claude Code** | Skill or MCP — see above |
-| `codex` in a terminal | **Codex CLI** | Skill or MCP — see above |
-| `gemini` in a terminal | **Gemini CLI** | MCP — see above |
-| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP — see above |
-| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) — see above |
-| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP — see above |
-| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet — web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
-| You're not sure | — | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
+| `claude` in a terminal | **Claude Code** | Skill or MCP - see above |
+| `codex` in a terminal | **Codex CLI** | Skill or MCP - see above |
+| `gemini` in a terminal | **Gemini CLI** | MCP - see above |
+| You downloaded Claude Desktop from claude.ai | **Claude Desktop** | MCP - see above |
+| You're chatting with ChatGPT in a desktop app or browser | **ChatGPT** | MCP (paid plan only) - see above |
+| You opened Cursor / Windsurf / Cline / VS Code with Copilot | The IDE name above | MCP - see above |
+| You only chat in `claude.ai` or `chatgpt.com` and don't use any of the above | Web-only chat | No install yet - web-only surfaces don't expose MCP. Claude Desktop or one of the paid ChatGPT plans is the closest. |
+| You're not sure | - | Open whatever you call up to chat. Check the menu / settings for "MCP" or "Skills." That tells you which family. |
 
-If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" — whichever has an app is what you have.
+If you're working with an MSP-internal team that set up your AI environment, ask them. If you set it up yourself and don't remember, search your applications folder for "Claude" or "Cursor" or "ChatGPT" - whichever has an app is what you have.
 
 ---
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["dstevens"]
+}

--- a/skills/halopsa/.claude-plugin/plugin.json
+++ b/skills/halopsa/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "halopsa",
+  "version": "0.1.0",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners. No code required.",
+  "author": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "homepage": "https://github.com/servosity/msp-skills/tree/main/skills/halopsa",
+  "repository": "https://github.com/servosity/msp-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "halopsa",
+    "halo",
+    "psa",
+    "msp",
+    "ticket-triage",
+    "sla-breach",
+    "client-card",
+    "contracts-burn",
+    "mcp",
+    "claude-code",
+    "claude-mcp"
+  ]
+}

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -1,15 +1,33 @@
-# HaloPSA Claude Code Skill and MCP Server - install, commands, examples
+# HaloPSA + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA,
-> HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by
-> Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of
-> Halo Service Solutions Ltd.
+> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA, HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of Halo Service Solutions Ltd.
 
-A HaloPSA Claude Code Skill and HaloPSA MCP server in one package, so your AI agent (Claude Code, Codex, Claude Desktop, or ChatGPT Desktop) can triage your queue, audit SLA breaches, build a per-client situational-awareness card, and reconcile contract hours without anyone clicking through five tabs in the Halo UI.
+Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot — no rate-limit hits during QBR prep. Built for MSP owners. No code required.
 
-The CLI wraps the full Halo REST API (952 endpoints across tickets, clients, assets, contracts, time, KB, and workflows) and stores a local SQLite mirror so cross-entity queries like `triage`, `client card`, and `contracts burn` are instant and answer questions the live API alone cannot.
+## Works with your agent
 
-## Install as a Claude Code Skill (also works for Codex)
+The four agents MSP owners actually use:
+
+| Your AI agent | How to install the HaloPSA skill |
+| --- | --- |
+| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
+| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The HaloPSA MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+
+### Path B — run the installer yourself
 
 **macOS / Linux:**
 
@@ -23,17 +41,17 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
 ```
 
-The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex will discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
+The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
 
-After install, verify:
+Verify:
 
 ```bash
 halopsa-cli --version
 ```
 
-## Install as an MCP server (Claude Desktop, ChatGPT Desktop)
+### Add to Claude Desktop
 
-Same install command as above also installs `halopsa-mcp`. Then wire it into your desktop agent. Full per-agent instructions in [mcp-install.md](./mcp-install.md). The TL;DR Claude Desktop config:
+After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
 
 ```json
 {
@@ -50,9 +68,36 @@ Same install command as above also installs `halopsa-mcp`. Then wire it into you
 }
 ```
 
-## Authenticate
+Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
 
-HaloPSA uses OAuth2 client_credentials. Create an API application in your tenant under Configuration > Integrations > Halo PSA API (Authentication Method: Client ID and Secret, Services), then run:
+<!-- pp-hermes-install-anchor -->
+### Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install servosity/msp-skills/skills/halopsa --force
+```
+
+Inside a Hermes chat session:
+
+```
+/skills install servosity/msp-skills/skills/halopsa --force
+```
+
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly — same install path, same env vars.
+
+### Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI (`halopsa-cli`) can be installed via the `openclaw:` frontmatter block.
+
+OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+
+### Authenticate
+
+HaloPSA uses OAuth2 client_credentials. Create an API application in your tenant under **Configuration → Integrations → Halo PSA API** (Authentication Method: Client ID and Secret, Services), then:
 
 ```bash
 HALOPSA_TENANT=<yourtenant> halopsa-cli auth login \
@@ -61,31 +106,79 @@ HALOPSA_TENANT=<yourtenant> halopsa-cli auth login \
 
 The CLI caches the access token and auto-refreshes before expiry.
 
-## First command
+## What this skill does
 
-```bash
-halopsa-cli triage --team Support --json
-```
+Outcome-first, with the single command that answers each question:
 
-Per-agent open ticket load, stale tickets, and 24-hour SLA-breach count in one table. The dispatcher view Halo's UI scatters across five tabs.
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What's about to breach SLA in the next 24 hours? | `halopsa-cli sla breaching --within 24h` |
+| What's the dispatcher view across all agents and teams? | `halopsa-cli triage --team Support` |
+| Who's overloaded right now? | `halopsa-cli agent workload` |
+| What's the whole story for this client, on one screen? | `halopsa-cli client card "Acme Corp"` |
+| How much contract time is left across every contract? | `halopsa-cli contracts burn` |
+| Which clients have stale tickets aging out? | `halopsa-cli tickets age-out` |
+| What changed in Halo since this morning? | `halopsa-cli tickets changed-since 9:00` |
+| What's the asset history for this device? | `halopsa-cli asset history <id>` |
+| Which KB article should the tech link to? | `halopsa-cli kbarticle suggest <ticket>` |
+| First-time hydration of the local SQLite mirror | `halopsa-cli sync --full` |
 
-## All commands
+Full command reference: [guide.md](./guide.md). For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), see [AGENTS.md](./AGENTS.md).
 
-Full reference: [guide.md](./guide.md). Highlights:
+## What makes this different
 
-- `halopsa-cli triage` - dispatcher view
-- `halopsa-cli sla breaching --within 24h` - pre-empt SLA breaches before a hand-off
-- `halopsa-cli client card "Acme Corp"` - one-panel client situational awareness
-- `halopsa-cli contracts burn` - contract hours remaining
-- `halopsa-cli agent workload` - per-agent open load, billable hours, oldest ticket
-- `halopsa-cli sync --full` - first-time hydration of the local SQLite mirror
+Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* — that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
 
-For the AI-agent operating contract (when to use `--agent` flag, `--dry-run`, etc.), read [AGENTS.md](./AGENTS.md).
+This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets — work a stateless API wrapper can't do.
+
+It complements HaloPSA's built-in ChatGPT integration (which is great for per-ticket work like rewriting replies and sentiment-flagging). The two are non-overlapping.
+
+## The pain this closes
+
+Two pains MSP owners name repeatedly:
+
+- **Cost-to-serve is rising faster than contract value.** The squeeze is operational: queue overload, SLA fires, unpriced work eating margin on every ticket.
+- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head — and in a PSA nobody else triages quickly.
+
+This skill puts the PSA's cross-entity truth one sentence away from any team member or their agent: `triage` / `sla breaching` surface what will breach before it does; `client card` gives any teammate one situational-awareness panel on demand; `contracts burn` catches unpriced work early; `agent workload` makes the queue legible across the whole team. The knowledge of how to read the PSA moves from a person into a Skill any teammate (or their agent) can run.
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not local stdio binaries. The HaloPSA MCP server is local, so for ChatGPT you expose it via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step in [mcp-install.md](./mcp-install.md).
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+
+### Do I need to know how to code?
+
+No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
+
+### Is my HaloPSA data safe?
+
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
+
+### Will this hit my HaloPSA API rate limits?
+
+Almost never. HaloPSA's rate limits aren't publicly documented and vary between cloud-hosted and self-hosted instances. This skill syncs once with `sync --full`, then incrementally; subsequent triage, SLA, client-card, and cross-client analytics queries run against the local mirror, not the live API. The big-batch queries that get you 429'd with API-passthrough tools become one SQL join here.
+
+### How is this different from HaloPSA's built-in ChatGPT integration?
+
+HaloPSA's built-in ChatGPT integration is great for **single-ticket** work — rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries are native Windows builds. Cline users on Windows may need a small `npx` workaround documented in [docs/which-agent.md](../../docs/which-agent.md).
+
+### What does it cost?
+
+Free. Apache-2.0 licensed. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), and that's billed by your AI provider, not by us.
 
 ## Safety model
 
-The skill authenticates to **your own Halo tenant** with an OAuth application you
-create and scope. It defaults to discovery and dry-run before any mutation.
+The skill authenticates to **your own Halo tenant** with an OAuth application you create and scope. It defaults to discovery and dry-run before any mutation.
 
 | Tier | Examples | Recommended agent policy |
 | --- | --- | --- |
@@ -93,6 +186,14 @@ create and scope. It defaults to discovery and dry-run before any mutation.
 | Write (routine) | ticket updates, notes, assignment | Preview with `--dry-run`, then a reviewed write |
 | Destructive / config | deletes, configuration changes | Human-in-the-loop only |
 
-The strongest control is the **scope you grant the Halo OAuth application** - the
-CLI can only do what that application is permitted to do. Full details, including
-how to lock it down, are in [governance.md](./governance.md).
+The strongest control is the **scope you grant the Halo OAuth application** — the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
+
+## Status
+
+Beta. Validated against the HaloPSA API surface and being validated with MSPs running it live against their own production tenant in our weekly Build Sessions. RSVP at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions).
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). See [TRADEMARKS.md](../../TRADEMARKS.md) for vendor non-affiliation. _Last updated: 2026-05-28._

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -1,8 +1,8 @@
-# HaloPSA + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
+# HaloPSA + AI - for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
 > Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA, HaloITSM, and HaloCRM APIs. Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd. HaloPSA, HaloITSM, and HaloCRM are trademarks of Halo Service Solutions Ltd.
 
-Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot — no rate-limit hits during QBR prep. Built for MSP owners. No code required.
+Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awareness, and cross-client analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local SQLite mirror means your AI can answer cross-client questions the live Halo API can't return in one shot - no rate-limit hits during QBR prep. Built for MSP owners. No code required.
 
 ## Works with your agent
 
@@ -10,35 +10,35 @@ The four agents MSP owners actually use:
 
 | Your AI agent | How to install the HaloPSA skill |
 | --- | --- |
-| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Desktop** | Run installer, then **Settings > Extensions** to register `halopsa-mcp` (no JSON editing). |
+| **ChatGPT** (paid plans) | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
 | **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
 
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The HaloPSA MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
-> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills — read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
 
-### Path B — run the installer yourself
-
-**macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
-```
+### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 ```
 
 The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
@@ -85,15 +85,21 @@ Inside a Hermes chat session:
 /skills install servosity/msp-skills/skills/halopsa --force
 ```
 
-Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly — same install path, same env vars.
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `halopsa-mcp` server directly - same install path, same env vars.
 
 ### Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+[OpenClaw](https://docs.openclaw.ai) is GA. Install the skill directly from this repo:
 
-> Install the halopsa skill from https://github.com/servosity/msp-skills/tree/main/skills/halopsa. The skill defines how its required CLI (`halopsa-cli`) can be installed via the `openclaw:` frontmatter block.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/halopsa@main
+```
 
-OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+Or tell your OpenClaw agent (copy this):
+
+> Install the halopsa skill from https://github.com/Servosity/msp-skills/tree/main/skills/halopsa. The `metadata.openclaw` frontmatter declares the required CLI (`halopsa-cli`) and env vars; run `openclaw doctor` if anything is missing.
+
+`openclaw` also speaks MCP natively (see `openclaw mcp set` in the [OpenClaw MCP docs](https://docs.openclaw.ai/cli/mcp)) so you can wire `halopsa-mcp` as an MCP server alongside the skill.
 
 ### Authenticate
 
@@ -127,9 +133,9 @@ Full command reference: [guide.md](./guide.md). For the AI-agent operating contr
 
 ## What makes this different
 
-Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* — that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
+Most HaloPSA MCP servers and AI integrations proxy each question into a live API call. That's fine for one ticket. It dies at QBR time, when you're asking *"how many backup-failure tickets across all 47 clients last quarter, grouped by contract type?"* - that's 47 paginated REST calls, HaloPSA rate-limit headaches (limits aren't publicly documented; they vary by hosting), and a context window full of raw JSON the model has to re-read.
 
-This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets — work a stateless API wrapper can't do.
+This skill syncs HaloPSA into a **local SQLite mirror** with full-text search. Aggregate questions become one local SQL join: instant, offline, and the AI sees the answer, not the raw data. Compound commands like `triage`, `client card`, and `contracts burn` join across tickets, clients, contracts, time, and assets - work a stateless API wrapper can't do.
 
 It complements HaloPSA's built-in ChatGPT integration (which is great for per-ticket work like rewriting replies and sentiment-flagging). The two are non-overlapping.
 
@@ -138,7 +144,7 @@ It complements HaloPSA's built-in ChatGPT integration (which is great for per-ti
 Two pains MSP owners name repeatedly:
 
 - **Cost-to-serve is rising faster than contract value.** The squeeze is operational: queue overload, SLA fires, unpriced work eating margin on every ticket.
-- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head — and in a PSA nobody else triages quickly.
+- **Key-person dependency.** "If your best technician left tomorrow, would your clients notice within 30 days?" For most MSPs the answer is yes, because situational awareness lives in one person's head - and in a PSA nobody else triages quickly.
 
 This skill puts the PSA's cross-entity truth one sentence away from any team member or their agent: `triage` / `sla breaching` surface what will breach before it does; `client card` gives any teammate one situational-awareness panel on demand; `contracts burn` catches unpriced work early; `agent workload` makes the queue legible across the whole team. The knowledge of how to read the PSA moves from a person into a Skill any teammate (or their agent) can run.
 
@@ -150,15 +156,15 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+Yes - all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
 
 ### Do I need to know how to code?
 
-No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
+No. The recommended install is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your HaloPSA API credentials once.
 
 ### Is my HaloPSA data safe?
 
-Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The SQLite mirror sits in a directory under your user account. The AI agent only sees what the CLI returns - typically a query result, not raw bulk data. Credentials are read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills.
 
 ### Will this hit my HaloPSA API rate limits?
 
@@ -166,7 +172,7 @@ Almost never. HaloPSA's rate limits aren't publicly documented and vary between 
 
 ### How is this different from HaloPSA's built-in ChatGPT integration?
 
-HaloPSA's built-in ChatGPT integration is great for **single-ticket** work — rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
+HaloPSA's built-in ChatGPT integration is great for **single-ticket** work - rewriting replies, summarizing one ticket, sentiment-flagging. MSP Skills is the **cross-client analytics + MSP-owner-on-the-couch** layer: questions across thousands of tickets, multi-system queries that join HaloPSA with Servosity, ad-hoc reports HaloPSA's UI doesn't surface. The two complement; you don't pick one.
 
 ### Can I run this on Windows?
 
@@ -186,7 +192,7 @@ The skill authenticates to **your own Halo tenant** with an OAuth application yo
 | Write (routine) | ticket updates, notes, assignment | Preview with `--dry-run`, then a reviewed write |
 | Destructive / config | deletes, configuration changes | Human-in-the-loop only |
 
-The strongest control is the **scope you grant the Halo OAuth application** — the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
+The strongest control is the **scope you grant the Halo OAuth application** - the CLI can only do what that application is permitted to do. Full details, including how to lock it down, are in [governance.md](./governance.md).
 
 ## Status
 
@@ -194,6 +200,6 @@ Beta. Validated against the HaloPSA API surface and being validated with MSPs ru
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works directly.
 
 Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). See [TRADEMARKS.md](../../TRADEMARKS.md) for vendor non-affiliation. _Last updated: 2026-05-28._

--- a/skills/halopsa/SKILL.md
+++ b/skills/halopsa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: halopsa
-description: "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return. Trigger phrases: `triage my Halo queue`, `check SLA breaches in HaloPSA`, `who's overloaded in Halo`, `client card for Acme`, `Halo contract burn-down`, `what changed in Halo since this morning`, `use halopsa`, `run halopsa`."
+description: "Use when the user asks to triage their HaloPSA queue, audit SLA breaches, build a per-client situational-awareness card, reconcile contract hours, check agent workload, or run any cross-client analytic question against HaloPSA, HaloITSM, or HaloCRM. Wraps the full HaloPSA REST API plus a local SQLite mirror so cross-entity queries the live API can't return in one shot are fast and offline. Trigger phrases: `triage my Halo queue`, `check SLA breaches in HaloPSA`, `who's overloaded in Halo`, `client card for Acme`, `Halo contract burn-down`, `what changed in Halo since this morning`, `HaloPSA + ChatGPT`, `HaloPSA + Claude`, `use halopsa`, `run halopsa`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "HaloPSA"

--- a/skills/halopsa/manifest.json
+++ b/skills/halopsa/manifest.json
@@ -3,7 +3,7 @@
   "name": "halopsa-mcp",
   "display_name": "Halo",
   "version": "0.1.0",
-  "description": "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return.",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
   "author": {
     "name": "Servosity Inc."
   },

--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.servosity/halopsa-mcp",
+  "title": "HaloPSA MCP",
+  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners.",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/servosity/msp-skills",
+    "source": "github",
+    "subfolder": "skills/halopsa"
+  },
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "halopsa-mcp",
+      "version": "0.1.0",
+      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-mcp-v0.1.0/halopsa-mcp.mcpb",
+      "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "HALOPSA_TENANT",
+          "description": "Your HaloPSA tenant identifier.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "HALOPSA_CLIENT_ID",
+          "description": "OAuth2 client_credentials ID from Configuration → Integrations → Halo PSA API.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "HALOPSA_CLIENT_SECRET",
+          "description": "OAuth2 client_credentials secret.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "HALOPSA_DOMAIN",
+          "description": "Domain template variable. Defaults to halopsa.com.",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "halopsa.com"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/servosity/.claude-plugin/plugin.json
+++ b/skills/servosity/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "servosity",
+  "version": "0.1.0",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
+  "author": {
+    "name": "Servosity",
+    "url": "https://www.servosity.com"
+  },
+  "homepage": "https://github.com/servosity/msp-skills/tree/main/skills/servosity",
+  "repository": "https://github.com/servosity/msp-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "servosity",
+    "backup",
+    "bcdr",
+    "disaster-recovery",
+    "msp",
+    "fleet-monitoring",
+    "stale-backup",
+    "cross-engine",
+    "mcp",
+    "claude-code",
+    "claude-mcp"
+  ]
+}

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -1,8 +1,8 @@
-# Servosity + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
+# Servosity + AI - for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
 > Published by Servosity Inc. for MSP partners. Servosity is a trademark of Servosity Inc. Apache-2.0 licensed.
 
-Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen — Friday-email-ready in seconds. Built for MSP partners. No code required.
+Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use - **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen - Friday-email-ready in seconds. Built for MSP partners. No code required.
 
 ## Works with your agent
 
@@ -10,35 +10,35 @@ The four agents MSP owners actually use:
 
 | Your AI agent | How to install the Servosity skill |
 | --- | --- |
-| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
-| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Desktop** | Run installer, then **Settings > Extensions** to register `servosity-mcp` (no JSON editing). |
+| **ChatGPT** (paid plans) | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
 | **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
 
-¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The Servosity MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
-> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
 ## Install in 60 seconds
 
-### Path A — let your AI install it (recommended)
+### Path A - let your AI install it (recommended)
 
 Paste this into **Claude Code** or **Codex CLI**:
 
-> Set up the **Servosity** skill from https://github.com/servosity/msp-skills — read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
+> Set up the **Servosity** skill from https://github.com/servosity/msp-skills - read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
 
-### Path B — run the installer yourself
-
-**macOS / Linux:**
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
-```
+### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
 ```
 
 The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory.
@@ -83,15 +83,21 @@ Inside a Hermes chat session:
 /skills install servosity/msp-skills/skills/servosity --force
 ```
 
-Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly — same install path, same env vars.
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly - same install path, same env vars.
 
 ### Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+[OpenClaw](https://docs.openclaw.ai) is GA. Install the skill directly from this repo:
 
-> Install the servosity skill from https://github.com/servosity/msp-skills/tree/main/skills/servosity. The skill defines how its required CLI (`servosity-cli`) can be installed via the `openclaw:` frontmatter block.
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/servosity@main
+```
 
-OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+Or tell your OpenClaw agent (copy this):
+
+> Install the servosity skill from https://github.com/Servosity/msp-skills/tree/main/skills/servosity. The `metadata.openclaw` frontmatter declares the required CLI (`servosity-cli`) and env vars; run `openclaw doctor` if anything is missing.
+
+`openclaw` also speaks MCP natively (see `openclaw mcp set` in the [OpenClaw MCP docs](https://docs.openclaw.ai/cli/mcp)) so you can wire `servosity-mcp` as an MCP server alongside the skill.
 
 ### Authenticate
 
@@ -123,15 +129,15 @@ Full command reference: [guide.md](./guide.md). For the AI-agent operating contr
 
 ## What makes this different
 
-Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* — the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
+Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* - the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
 
-This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events — work a stateless API wrapper can't do.
+This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events - work a stateless API wrapper can't do.
 
 ## The pain this closes
 
 Backup and DR is where "silent failure" hurts most. The pains MSP owners name:
 
-- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore — the worst possible moment to find out.
+- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore - the worst possible moment to find out.
 - **No fleet-wide view.** Each client's backup state lives in its own portal view; there is no single screen that says "across my whole book, here's what's stale, failing, or in-flight right now."
 - **Alert-queue noise buries the real failure.** Dozens of repeat and known-safe issues pile up per client; the one that matters hides in the pile.
 - **Per-client questions mean portal archaeology.** Answering "is this client OK?" means clicking through metadata, three backup engines, contracts, and issues by hand.
@@ -146,7 +152,7 @@ Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tie
 
 ### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
 
-Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+Yes - all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
 
 ### Do I need to be a Servosity MSP partner?
 
@@ -154,15 +160,15 @@ Yes. The Servosity API surface this skill wraps is the one available to **authen
 
 ### Will this replace my Servosity partner portal?
 
-No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI — so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
+No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI - so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
 
 ### Do I need to know how to code?
 
-No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
+No. The recommended install is to paste one sentence into Claude Code or Codex - your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
 
 ### Is my Servosity / client data safe?
 
-Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns - typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
 
 ### Can I run this on Windows?
 
@@ -170,7 +176,7 @@ Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries ar
 
 ### What does it cost?
 
-Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill — the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
+Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill - the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
 
 ## Safety model
 
@@ -192,6 +198,6 @@ Already used inside Servosity's own backup / DR operations; published here for M
 
 ---
 
-**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible - works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](https://docs.openclaw.ai), with `metadata.openclaw` frontmatter pre-wired so `openclaw skills install` works directly.
 
 Maintained by [Servosity](https://www.servosity.com). Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). _Last updated: 2026-05-28._

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -1,13 +1,33 @@
-# Servosity Claude Code Skill and MCP Server - install, commands, examples
+# Servosity + AI — for Claude, ChatGPT, Codex, Cursor, and any agent that speaks MCP
 
-> Published by Servosity Inc. for MSP partners. Servosity is a trademark of
-> Servosity Inc. Apache-2.0 licensed.
+> Published by Servosity Inc. for MSP partners. Servosity is a trademark of Servosity Inc. Apache-2.0 licensed.
 
-A Servosity Claude Code Skill and Servosity MCP server in one package, so your AI agent (Claude Code, Codex, Claude Desktop, or ChatGPT Desktop) can triage your backup fleet, surface stale backup sets, diff yesterday's snapshot against today, and answer cross-engine questions without anyone clicking through the partner portal.
+Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per-client situational awareness, and cross-engine analytics** to the AI you already use — **Claude Code**, **Claude Desktop**, **ChatGPT** (Plus/Pro+), **Codex**, **Cursor**, **Windsurf**, **Cline**, **Continue**, **Gemini**, or **GitHub Copilot**. Free, open source, runs on your laptop. A local fleet mirror means your AI can answer cross-client questions the partner portal can't show on one screen — Friday-email-ready in seconds. Built for MSP partners. No code required.
 
-The CLI wraps the Servosity REST API surface available to authenticated MSP partners, with a local fleet mirror, snapshot history, and cross-engine rollups so commands like `attention`, `drift`, and `stale-backups` work offline once cached.
+## Works with your agent
 
-## Install as a Claude Code Skill (also works for Codex)
+The four agents MSP owners actually use:
+
+| Your AI agent | How to install the Servosity skill |
+| --- | --- |
+| **Claude Desktop** | Run installer, add the MCP block to `claude_desktop_config.json` (see "Add to Claude Desktop" below). |
+| **ChatGPT** (Plus, Pro, Team, Business, Enterprise, Education)¹ | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
+| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
+| **Codex CLI** | Same as Claude Code — paste the prompt or run the installer. |
+
+¹ ChatGPT requires a paid plan (Free tier does not yet expose Developer Mode). The Servosity MCP server is stdio — to use it with ChatGPT, expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
+
+> **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI — plus [Hermes](https://hermes-agent.nousresearch.com) via MCP and [OpenClaw](#install-for-openclaw) via the pre-wired frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
+
+## Install in 60 seconds
+
+### Path A — let your AI install it (recommended)
+
+Paste this into **Claude Code** or **Codex CLI**:
+
+> Set up the **Servosity** skill from https://github.com/servosity/msp-skills — read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
+
+### Path B — run the installer yourself
 
 **macOS / Linux:**
 
@@ -21,7 +41,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/sk
 iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
-The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex will discover the Skill via `SKILL.md` in this directory.
+The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory.
 
 Verify:
 
@@ -29,9 +49,9 @@ Verify:
 servosity-cli --version
 ```
 
-## Install as an MCP server (Claude Desktop, ChatGPT Desktop)
+### Add to Claude Desktop
 
-Same install command also installs `servosity-mcp`. Then wire it into your desktop agent. Full per-agent instructions in [mcp-install.md](./mcp-install.md). The TL;DR Claude Desktop config:
+After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
 
 ```json
 {
@@ -46,7 +66,34 @@ Same install command also installs `servosity-mcp`. Then wire it into your deskt
 }
 ```
 
-## Authenticate
+Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
+
+<!-- pp-hermes-install-anchor -->
+### Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install servosity/msp-skills/skills/servosity --force
+```
+
+Inside a Hermes chat session:
+
+```
+/skills install servosity/msp-skills/skills/servosity --force
+```
+
+Hermes [speaks MCP natively](https://hermes-agent.nousresearch.com), so it can also use the `servosity-mcp` server directly — same install path, same env vars.
+
+### Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+> Install the servosity skill from https://github.com/servosity/msp-skills/tree/main/skills/servosity. The skill defines how its required CLI (`servosity-cli`) can be installed via the `openclaw:` frontmatter block.
+
+OpenClaw isn't generally available yet; the frontmatter wiring is pre-shipped and will activate the moment OpenClaw launches.
+
+### Authenticate
 
 Get your partner API token from the Servosity partner portal, then:
 
@@ -56,32 +103,78 @@ SERVOSITY_MSP_TOKEN=<token> servosity-cli doctor
 
 `doctor` confirms the token works and the local mirror is reachable before you run anything that touches client data.
 
-## First command
+## What this skill does
 
-```bash
-servosity-cli attention --json
-```
+Outcome-first, with the single command that answers each question:
 
-One screen across your whole book of clients: merged open issues, stale backups, and in-flight DR events, ranked per company. Run this in the morning to triage what needs follow-up without clicking through the portal.
+| Question your MSP keeps asking | Command |
+| --- | --- |
+| What needs my attention across every client this morning? | `servosity-cli attention` |
+| Which backups went stale across all clients? | `servosity-cli stale-backups --days 7` |
+| What changed across my fleet overnight? | `servosity-cli drift --from yesterday --to now` |
+| What's the whole story for this client, on one screen? | `servosity-cli company show <id>` |
+| Search across companies, backups, and issues at once | `servosity-cli find "image manager"` |
+| Triage what's worth keeping in the alert queue | `servosity-cli triage` |
+| Clear known-safe alert noise so real failures show | `servosity-cli clear` |
+| List DR restores in flight | `servosity-cli restore-queue list` |
+| First-time hydration of the local fleet mirror | `servosity-cli sync --full` |
 
-## All commands
+Full command reference: [guide.md](./guide.md). For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), see [AGENTS.md](./AGENTS.md).
 
-Full reference: [guide.md](./guide.md). Highlights:
+## What makes this different
 
-- `servosity-cli attention` - cross-client morning triage
-- `servosity-cli drift --from yesterday --to now` - what changed overnight
-- `servosity-cli stale-backups` - stale-backup-sets by company, age, engine
-- `servosity-cli sync --full` - first-time hydration of the local fleet mirror
-- `servosity-cli company show 4421` - per-client situational awareness (metadata, contracts, backups across 3 engines, open issues)
-- `servosity-cli find "image manager"` - one FTS5 query across companies, issues, and backups
+Most AI integrations for backup and DR vendors proxy each question into a live API call against the partner portal. That's fine for one client. It fails when you're asking *"which of my 47 clients have a backup set that hasn't succeeded in 7 days, sliced by engine?"* — the partner portal scatters that across per-client pages, three engine views, and an alert queue full of noise.
 
-For the AI-agent operating contract (`--agent`, `--dry-run`, when to confirm before mutating), read [AGENTS.md](./AGENTS.md).
+This skill syncs Servosity into a **local fleet mirror** with snapshot history and FTS5 search. Cross-engine, cross-client questions become one local query: instant, offline, and the AI sees the answer, not a context window full of paginated JSON. Compound commands like `attention`, `drift`, `stale-backups`, and `company show` join across companies, three backup engines, issues, contracts, and DR events — work a stateless API wrapper can't do.
+
+## The pain this closes
+
+Backup and DR is where "silent failure" hurts most. The pains MSP owners name:
+
+- **Silent backup failures discovered too late.** A backup that quietly stopped succeeding is invisible until a client needs a restore — the worst possible moment to find out.
+- **No fleet-wide view.** Each client's backup state lives in its own portal view; there is no single screen that says "across my whole book, here's what's stale, failing, or in-flight right now."
+- **Alert-queue noise buries the real failure.** Dozens of repeat and known-safe issues pile up per client; the one that matters hides in the pile.
+- **Per-client questions mean portal archaeology.** Answering "is this client OK?" means clicking through metadata, three backup engines, contracts, and issues by hand.
+
+This skill turns per-client portal views into fleet-wide, offline-fast intelligence: `attention` is one screen across every client; `stale-backups` is the Friday-email list, ready; `drift` opens Monday with situational awareness instead of a blank slate; `triage` / `clear` / `stale-issues` batch-suppress known-safe noise so the queue shows only what's new; `company show` / `find` answer per-client and cross-fleet questions in one command.
+
+## Frequently asked questions
+
+### Does this work with ChatGPT?
+
+Yes, on **Plus, Pro, Team, Business, Enterprise, and Education** plans (Free tier does not yet expose Developer Mode). ChatGPT connects to **remote** MCP servers over HTTPS, not local stdio binaries. The Servosity MCP server is local, so for ChatGPT you expose it via the `mcp-remote` bridge or your own HTTPS endpoint. Step-by-step in [mcp-install.md](./mcp-install.md).
+
+### Does this work with Codex, Cursor, Windsurf, Cline, Copilot, or Gemini?
+
+Yes — all of them speak MCP. Cross-tool install commands are in the matrix above and the deep-dive in [docs/which-agent.md](../../docs/which-agent.md). Tool-specific gotchas (Copilot uses `servers` not `mcpServers`, Cline's Windows `npx` issue, ChatGPT's tier + bridge) are documented there.
+
+### Do I need to be a Servosity MSP partner?
+
+Yes. The Servosity API surface this skill wraps is the one available to **authenticated MSP partners**. You'll need a partner API token from the Servosity partner portal. The skill itself is free; the token is part of your Servosity partner agreement. Not a Servosity partner yet? Reach out via [servosity.com](https://www.servosity.com).
+
+### Will this replace my Servosity partner portal?
+
+No. The portal is still where you do administrative work, configure backups, and onboard clients. This skill makes the portal's **data** answerable by AI — so morning triage, Friday stale-backup reports, drift checks, and ad-hoc cross-client questions don't require portal archaeology. The portal is unchanged; you're adding a new way to ask the data questions.
+
+### Do I need to know how to code?
+
+No. The recommended install is to paste one sentence into Claude Code or Codex — your agent reads `SKILL.md` and does the install. The fallback is a one-line installer per OS (bash or PowerShell). Neither path requires writing code. You'll enter your Servosity partner token once.
+
+### Is my Servosity / client data safe?
+
+Your data stays on **your machine**. The CLI and MCP server are local binaries. The fleet mirror sits in a directory under your user account. The AI agent only sees what the CLI returns — typically a query result, not raw bulk data. The partner token is read from your environment or your agent's config; never bundled into this repo or transmitted anywhere by MSP Skills. The token is scoped to **your reseller account only** (no cross-reseller access).
+
+### Can I run this on Windows?
+
+Yes. The PowerShell installer above is the Windows path. CLI and MCP binaries are native Windows builds.
+
+### What does it cost?
+
+Free. Apache-2.0 licensed. Servosity does not charge for the API access required to run this skill — the partner-portal API is part of your existing partner agreement. You pay only for whichever AI agent you use (Claude, ChatGPT, Codex, etc.), billed by your AI provider.
 
 ## Safety model
 
-The skill authenticates with one partner token, scoped to **your reseller
-account only** (no cross-reseller access). Every mutating command plans by
-default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
+The skill authenticates with one partner token, scoped to **your reseller account only** (no cross-reseller access). Every mutating command plans by default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
 
 | Tier | Examples | Recommended agent policy |
 | --- | --- | --- |
@@ -91,6 +184,14 @@ default: it runs `--dry-run` until you drop `--dry-run` and pass `--confirm`.
 | Destructive | `companies delete`, `backups delete`, `restic-backups restic-prune`, `users delete` | Human-in-the-loop only |
 | Admin (hidden) | `admin ...` | Operator-only, not for agents |
 
-Keep autonomous agents to **Read plus planned writes**; gate everything below
-that behind a human. Full matrix and lock-down guidance in
-[governance.md](./governance.md).
+Keep autonomous agents to **Read plus planned writes**; gate everything below that behind a human. Full matrix and lock-down guidance in [governance.md](./governance.md).
+
+## Status
+
+Already used inside Servosity's own backup / DR operations; published here for MSP partners. The public surface is in beta and being validated with MSPs in live Build Sessions. RSVP at [compoundingteams.com/build-sessions](https://compoundingteams.com/build-sessions).
+
+---
+
+**Standards.** Conforms to the open [Agent Skills spec](https://agentskills.io) (Anthropic, Dec 2025; 40+ agents). MCP-compatible — works with any MCP-capable agent including [Hermes](https://hermes-agent.nousresearch.com). OpenClaw-ready (frontmatter pre-wired, awaiting OpenClaw launch).
+
+Maintained by [Servosity](https://www.servosity.com). Apache-2.0 licensed. Built with [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press). _Last updated: 2026-05-28._

--- a/skills/servosity/SKILL.md
+++ b/skills/servosity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: servosity
-description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query — offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
+description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query - offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "Servosity"
@@ -39,28 +39,28 @@ Servosity REST API surface available to authenticated MSP partners. All operatio
 These capabilities aren't available in any other tool for this API.
 
 ### Fleet-wide intelligence
-- **`attention`**  -  One screen across your whole book of clients. Merges open issues, stale backups, and in-flight DR events into a per-company ranked view, then persists the result so tomorrow's drift command can compare.
+- **`attention`** - One screen across your whole book of clients. Merges open issues, stale backups, and in-flight DR events into a per-company ranked view, then persists the result so tomorrow's drift command can compare.
 
   _Reach for this in the morning to triage what needs follow-up across every client without clicking through a portal._
 
   ```bash
   servosity-cli attention --json
   ```
-- **`drift`**  -  Diff two snapshots the CLI collected  -  show which companies got worse, which recovered, and which are new since a past anchor. Default compares yesterday-to-now on the attention metric.
+- **`drift`** - Diff two snapshots the CLI collected - show which companies got worse, which recovered, and which are new since a past anchor. Default compares yesterday-to-now on the attention metric.
 
   _Use Monday morning to start with situation awareness instead of treating every week as a fresh slate._
 
   ```bash
   servosity-cli drift --metric attention --from yesterday --to now --json
   ```
-- **`stale-backups`**  -  Slice the synced `/reports/stale-backup-sets/` snapshot by reseller, company, age window, and backup engine  -  entirely offline once synced. Use --refresh to re-pull freshness from the live report.
+- **`stale-backups`** - Slice the synced `/reports/stale-backup-sets/` snapshot by reseller, company, age window, and backup engine - entirely offline once synced. Use --refresh to re-pull freshness from the live report.
 
   _Run this Friday afternoon to compile the list of clients you need to email about a stalled backup._
 
   ```bash
   servosity-cli stale-backups --days 7 --engine restic --json
   ```
-- **`backup-facts`**  -  Unified view across Servosity's three backup engines (classic, restic, DR) for one company or all. Engine, ID, hostname, last_successful_at, status  -  joined from three local store tables into one table.
+- **`backup-facts`** - Unified view across Servosity's three backup engines (classic, restic, DR) for one company or all. Engine, ID, hostname, last_successful_at, status - joined from three local store tables into one table.
 
   _Reach for this when triaging a client who has multiple engines protecting different devices and you need to know which engine is failing where._
 
@@ -68,25 +68,25 @@ These capabilities aren't available in any other tool for this API.
   servosity-cli backup-facts --company 4421 --status fail --json
   ```
 
-- **`find`**  -  SQLite FTS5 across companies (name, billing notes), issues (title and comments), and backups (descriptive name, last error)  -  one query hits the whole fleet.
+- **`find`** - SQLite FTS5 across companies (name, billing notes), issues (title and comments), and backups (descriptive name, last error) - one query hits the whole fleet.
 
-  _Use when you remember a phrase but not which entity owned it  -  one call replaces hunting through three list pages._
+  _Use when you remember a phrase but not which entity owned it - one call replaces hunting through three list pages._
 
   ```bash
   servosity-cli find "image manager" --in issues,backups --json
   ```
 
 ### Per-company quick view
-- **`company show`**  -  One command pulls a company's metadata + addresses + contracts + all backups across three engines + open issues + agent sessions into one human or `--json` view.
+- **`company show`** - One command pulls a company's metadata + addresses + contracts + all backups across three engines + open issues + agent sessions into one human or `--json` view.
 
-  _Use when a customer asks "is my backup OK?"  -  one call, every relevant fact, ready to paste into a ticket._
+  _Use when a customer asks "is my backup OK?" - one call, every relevant fact, ready to paste into a ticket._
 
   ```bash
   servosity-cli company show 4421 --json
   ```
 
 ### Daily ops efficiency
-- **`triage`**  -  List open issues with filters, then batch ignore / archive / reactivate / comment in one invocation. Plans by default; pass --confirm to mutate. Typed exit codes.
+- **`triage`** - List open issues with filters, then batch ignore / archive / reactivate / comment in one invocation. Plans by default; pass --confirm to mutate. Typed exit codes.
 
   _Use when the issue queue is bursty or during a planned-outage window where many alerts cluster around one client._
 
@@ -96,7 +96,7 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Disaster recovery
-- **`restore-queue list`**  -  List per-company restore queues across the whole book; `--watch` repolls on an interval and prints diffs since the last tick.
+- **`restore-queue list`** - List per-company restore queues across the whole book; `--watch` repolls on an interval and prints diffs since the last tick.
 
   _Use during an active disaster recovery event when multiple clients have restores in flight._
 
@@ -106,15 +106,15 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Tier-One support workflows
-- **`clear`**  -  Resolve one or more names as companies (then resellers) and batch-ignore their active issues until a human-readable time. Defaults to --dry-run; pass --confirm to mutate.
+- **`clear`** - Resolve one or more names as companies (then resellers) and batch-ignore their active issues until a human-readable time. Defaults to --dry-run; pass --confirm to mutate.
 
-  _Use when a partner is doing planned maintenance and you want their alert noise paused until morning  -  one command instead of dozens of UI clicks._
+  _Use when a partner is doing planned maintenance and you want their alert noise paused until morning - one command instead of dozens of UI clicks._
 
   ```bash
   servosity-cli clear "ACME Corp" --until "6am tomorrow"
   servosity-cli clear "ACME Corp" --until "6am tomorrow" --confirm
   ```
-- **`stale-issues`**  -  Pull your FMDB companies, fetch active issues, classify known-safe-to-archive patterns from a shipped rule table, auto-archive the safe ones, ignore non-dashboard noise, and print unknowns for review. Defaults to --dry-run.
+- **`stale-issues`** - Pull your FMDB companies, fetch active issues, classify known-safe-to-archive patterns from a shipped rule table, auto-archive the safe ones, ignore non-dashboard noise, and print unknowns for review. Defaults to --dry-run.
 
   _Run this every weekday before standup to clear the obvious stale noise off your dashboard so triage focuses on what's actually new._
 
@@ -125,200 +125,200 @@ These capabilities aren't available in any other tool for this API.
 
 ## Command Reference
 
-**agent-login**  -  Manage agent login
+**agent-login** - Manage agent login
 
-- `servosity-cli agent-login create`  -  Create
-- `servosity-cli agent-login list`  -  List
+- `servosity-cli agent-login create` - Create
+- `servosity-cli agent-login list` - List
 
-**agent-sessions**  -  Manage agent sessions
+**agent-sessions** - Manage agent sessions
 
-- `servosity-cli agent-sessions <agent_session_id>`  -  Read
+- `servosity-cli agent-sessions <agent_session_id>` - Read
 
-**backup-job-report**  -  Manage backup job report
+**backup-job-report** - Manage backup job report
 
-- `servosity-cli backup-job-report <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>`  -  View detailed backup report for a backup job and destination.
+- `servosity-cli backup-job-report <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>` - View detailed backup report for a backup job and destination.
 
-**backup-job-report-summary**  -  Manage backup job report summary
+**backup-job-report-summary** - Manage backup job report summary
 
-- `servosity-cli backup-job-report-summary <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>`  -  View summary backup report for a backup job and destination.
+- `servosity-cli backup-job-report-summary <backup_destination_id> <backup_id> <backup_job_id> <backup_set_id>` - View summary backup report for a backup job and destination.
 
-**backup-job-status**  -  Manage backup job status
+**backup-job-status** - Manage backup job status
 
-- `servosity-cli backup-job-status <backup_id>`  -  List backup job status for a backup account on a specific date.
+- `servosity-cli backup-job-status <backup_id>` - List backup job status for a backup account on a specific date.
 
-**backup-jobs**  -  Manage backup jobs
+**backup-jobs** - Manage backup jobs
 
-- `servosity-cli backup-jobs <backup_id>`  -  List backup jobs for a backup account.
+- `servosity-cli backup-jobs <backup_id>` - List backup jobs for a backup account.
 
-**backup-plans**  -  Manage backup plans
+**backup-plans** - Manage backup plans
 
-- `servosity-cli backup-plans list`  -  List backup plans.
-- `servosity-cli backup-plans read`  -  View a backup plan.
+- `servosity-cli backup-plans list` - List backup plans.
+- `servosity-cli backup-plans read` - View a backup plan.
 
-**backup-search**  -  Manage backup search
+**backup-search** - Manage backup search
 
-- `servosity-cli backup-search`  -  List
+- `servosity-cli backup-search` - List
 
-**backup-sets**  -  Manage backup sets
+**backup-sets** - Manage backup sets
 
-- `servosity-cli backup-sets create`  -  Create a backup-set for a backup account.
-- `servosity-cli backup-sets delete`  -  Delete a backup-set for a backup account.
-- `servosity-cli backup-sets list`  -  List backup-sets for a backup account.
-- `servosity-cli backup-sets read`  -  View a backup-set for a backup account.
-- `servosity-cli backup-sets update`  -  Accepts a json body with the following optional parameters.
+- `servosity-cli backup-sets create` - Create a backup-set for a backup account.
+- `servosity-cli backup-sets delete` - Delete a backup-set for a backup account.
+- `servosity-cli backup-sets list` - List backup-sets for a backup account.
+- `servosity-cli backup-sets read` - View a backup-set for a backup account.
+- `servosity-cli backup-sets update` - Accepts a json body with the following optional parameters.
 
-**backups**  -  Manage backups
+**backups** - Manage backups
 
-- `servosity-cli backups create`  -  Create a backup account.
-- `servosity-cli backups delete`  -  Delete a backup account, also deleting all backup data.
-- `servosity-cli backups list`  -  List backup accounts.
-- `servosity-cli backups mfa-codes`  -  Mfa codes
-- `servosity-cli backups partial-update`  -  Partial update
-- `servosity-cli backups read`  -  View a backup account.
-- `servosity-cli backups update`  -  Update a backup account.
+- `servosity-cli backups create` - Create a backup account.
+- `servosity-cli backups delete` - Delete a backup account, also deleting all backup data.
+- `servosity-cli backups list` - List backup accounts.
+- `servosity-cli backups mfa-codes` - Mfa codes
+- `servosity-cli backups partial-update` - Partial update
+- `servosity-cli backups read` - View a backup account.
+- `servosity-cli backups update` - Update a backup account.
 
-**companies**  -  Manage companies
+**companies** - Manage companies
 
-- `servosity-cli companies create`  -  Create a company.
-- `servosity-cli companies delete`  -  Delete a company, also deleting all backup accounts and backup data.
-- `servosity-cli companies fully-managed`  -  List fully-managed companies.
-- `servosity-cli companies fully-managed-ng`  -  List fully-managed companies.
-- `servosity-cli companies list`  -  List companies.
-- `servosity-cli companies partial-update`  -  Partial update
-- `servosity-cli companies read`  -  View a company.
-- `servosity-cli companies summary`  -  List companies with account summaries.
-- `servosity-cli companies summary-ng`  -  Summary ng
-- `servosity-cli companies update`  -  Update a company.
+- `servosity-cli companies create` - Create a company.
+- `servosity-cli companies delete` - Delete a company, also deleting all backup accounts and backup data.
+- `servosity-cli companies fully-managed` - List fully-managed companies.
+- `servosity-cli companies fully-managed-ng` - List fully-managed companies.
+- `servosity-cli companies list` - List companies.
+- `servosity-cli companies partial-update` - Partial update
+- `servosity-cli companies read` - View a company.
+- `servosity-cli companies summary` - List companies with account summaries.
+- `servosity-cli companies summary-ng` - Summary ng
+- `servosity-cli companies update` - Update a company.
 
-**company-notes**  -  Manage company notes
+**company-notes** - Manage company notes
 
-- `servosity-cli company-notes create`  -  Create
-- `servosity-cli company-notes delete`  -  Delete
-- `servosity-cli company-notes list`  -  List
-- `servosity-cli company-notes partial-update`  -  Partial update
-- `servosity-cli company-notes read`  -  Read
-- `servosity-cli company-notes update`  -  Update
+- `servosity-cli company-notes create` - Create
+- `servosity-cli company-notes delete` - Delete
+- `servosity-cli company-notes list` - List
+- `servosity-cli company-notes partial-update` - Partial update
+- `servosity-cli company-notes read` - Read
+- `servosity-cli company-notes update` - Update
 
-**components**  -  Manage components
+**components** - Manage components
 
-- `servosity-cli components`  -  List
+- `servosity-cli components` - List
 
-**contracts**  -  Manage contracts
+**contracts** - Manage contracts
 
-- `servosity-cli contracts create`  -  Create
-- `servosity-cli contracts get-by-token`  -  Get by token
-- `servosity-cli contracts list`  -  List
-- `servosity-cli contracts partial-update`  -  Partial update
-- `servosity-cli contracts read`  -  Read
-- `servosity-cli contracts signatures`  -  Signatures
-- `servosity-cli contracts update`  -  Update
+- `servosity-cli contracts create` - Create
+- `servosity-cli contracts get-by-token` - Get by token
+- `servosity-cli contracts list` - List
+- `servosity-cli contracts partial-update` - Partial update
+- `servosity-cli contracts read` - Read
+- `servosity-cli contracts signatures` - Signatures
+- `servosity-cli contracts update` - Update
 
-**credentials**  -  Manage credentials
+**credentials** - Manage credentials
 
-- `servosity-cli credentials create`  -  Create
-- `servosity-cli credentials delete`  -  Delete
-- `servosity-cli credentials list`  -  List
-- `servosity-cli credentials partial-update`  -  Partial update
-- `servosity-cli credentials read`  -  Read
-- `servosity-cli credentials update`  -  Update
+- `servosity-cli credentials create` - Create
+- `servosity-cli credentials delete` - Delete
+- `servosity-cli credentials list` - List
+- `servosity-cli credentials partial-update` - Partial update
+- `servosity-cli credentials read` - Read
+- `servosity-cli credentials update` - Update
 
-**current-user**  -  Manage current user
+**current-user** - Manage current user
 
-- `servosity-cli current-user api-token-delete`  -  Delete the current user's API token. A new one will be generated when requested.
-- `servosity-cli current-user api-token-list`  -  You will receive JSON response with `token`.
-- `servosity-cli current-user create`  -  Change the password of the current logged in user.
-- `servosity-cli current-user groups-list`  -  Groups list
-- `servosity-cli current-user helpjuice-sso-create`  -  Helpjuice sso create
-- `servosity-cli current-user hubspot-sso-create`  -  Hubspot sso create
-- `servosity-cli current-user list`  -  Get information about the current logged in user.
-- `servosity-cli current-user mfa-backup-codes-list`  -  Get unused backup codes. If no unused codes are left, remove all and generate new codes.
-- `servosity-cli current-user mfa-backup-codes-update`  -  Remove all backup codes and generate new codes.
-- `servosity-cli current-user notifications-delete`  -  Notifications delete
-- `servosity-cli current-user notifications-list`  -  Get current user notifications
-- `servosity-cli current-user profile-create`  -  Profile create
-- `servosity-cli current-user profile-list`  -  Profile list
-- `servosity-cli current-user start-mfa-create`  -  Start mfa create
-- `servosity-cli current-user start-mfa-list`  -  Start mfa list
-- `servosity-cli current-user start-mfa-verify-create`  -  Start mfa verify create
-- `servosity-cli current-user verified-mfa-delete`  -  Verified mfa delete
-- `servosity-cli current-user verified-mfa-list`  -  Verified mfa list
-- `servosity-cli current-user verified-mfa-send-code-create`  -  Verified mfa send code create
+- `servosity-cli current-user api-token-delete` - Delete the current user's API token. A new one will be generated when requested.
+- `servosity-cli current-user api-token-list` - You will receive JSON response with `token`.
+- `servosity-cli current-user create` - Change the password of the current logged in user.
+- `servosity-cli current-user groups-list` - Groups list
+- `servosity-cli current-user helpjuice-sso-create` - Helpjuice sso create
+- `servosity-cli current-user hubspot-sso-create` - Hubspot sso create
+- `servosity-cli current-user list` - Get information about the current logged in user.
+- `servosity-cli current-user mfa-backup-codes-list` - Get unused backup codes. If no unused codes are left, remove all and generate new codes.
+- `servosity-cli current-user mfa-backup-codes-update` - Remove all backup codes and generate new codes.
+- `servosity-cli current-user notifications-delete` - Notifications delete
+- `servosity-cli current-user notifications-list` - Get current user notifications
+- `servosity-cli current-user profile-create` - Profile create
+- `servosity-cli current-user profile-list` - Profile list
+- `servosity-cli current-user start-mfa-create` - Start mfa create
+- `servosity-cli current-user start-mfa-list` - Start mfa list
+- `servosity-cli current-user start-mfa-verify-create` - Start mfa verify create
+- `servosity-cli current-user verified-mfa-delete` - Verified mfa delete
+- `servosity-cli current-user verified-mfa-list` - Verified mfa list
+- `servosity-cli current-user verified-mfa-send-code-create` - Verified mfa send code create
 
-**download**  -  Manage download
+**download** - Manage download
 
-- `servosity-cli download`  -  Servosity one windows list
+- `servosity-cli download` - Servosity one windows list
 
-**dr-backups**  -  Manage dr backups
+**dr-backups** - Manage dr backups
 
-- `servosity-cli dr-backups create`  -  Create a DR backup account.
-- `servosity-cli dr-backups delete`  -  Delete a DR backup account.
-- `servosity-cli dr-backups list`  -  List
-- `servosity-cli dr-backups partial-update`  -  Update a DR backup account.
-- `servosity-cli dr-backups read`  -  Read
-- `servosity-cli dr-backups update`  -  Update a DR backup account.
+- `servosity-cli dr-backups create` - Create a DR backup account.
+- `servosity-cli dr-backups delete` - Delete a DR backup account.
+- `servosity-cli dr-backups list` - List
+- `servosity-cli dr-backups partial-update` - Update a DR backup account.
+- `servosity-cli dr-backups read` - Read
+- `servosity-cli dr-backups update` - Update a DR backup account.
 
-**issue-comments**  -  Manage issue comments
+**issue-comments** - Manage issue comments
 
-- `servosity-cli issue-comments delete`  -  Delete
-- `servosity-cli issue-comments update`  -  Update
+- `servosity-cli issue-comments delete` - Delete
+- `servosity-cli issue-comments update` - Update
 
-**issues**  -  Manage issues
+**issues** - Manage issues
 
-- `servosity-cli issues archived`  -  Archived
-- `servosity-cli issues ignored`  -  Ignored
-- `servosity-cli issues list`  -  List
-- `servosity-cli issues read`  -  Read
+- `servosity-cli issues archived` - Archived
+- `servosity-cli issues ignored` - Ignored
+- `servosity-cli issues list` - List
+- `servosity-cli issues read` - Read
 
-**report-subscriptions**  -  Manage report subscriptions
+**report-subscriptions** - Manage report subscriptions
 
-- `servosity-cli report-subscriptions read`  -  Read
-- `servosity-cli report-subscriptions unsubscribe`  -  Unsubscribe
-- `servosity-cli report-subscriptions verify`  -  Verify
+- `servosity-cli report-subscriptions read` - Read
+- `servosity-cli report-subscriptions unsubscribe` - Unsubscribe
+- `servosity-cli report-subscriptions verify` - Verify
 
-**reports**  -  Manage reports
+**reports** - Manage reports
 
-- `servosity-cli reports account-list`  -  Get a report of backup account types for each company and reseller in CSV format.
-- `servosity-cli reports classic-usage-list`  -  Get a usage report for all backup accounts in CSV format.
-- `servosity-cli reports clients-list`  -  Get a report of backup account client versions.
-- `servosity-cli reports dr-from-email-list`  -  Get a report of user profiles.
-- `servosity-cli reports maxio-price-points-list`  -  Get CSV with all Maxio price points.
-- `servosity-cli reports product-list`  -  Product list
-- `servosity-cli reports stale-backup-sets-list`  -  Get a report of all backup set last backup complete times.
-- `servosity-cli reports usage-list`  -  Usage list
-- `servosity-cli reports user-profiles-list`  -  Get a report of user profiles.
+- `servosity-cli reports account-list` - Get a report of backup account types for each company and reseller in CSV format.
+- `servosity-cli reports classic-usage-list` - Get a usage report for all backup accounts in CSV format.
+- `servosity-cli reports clients-list` - Get a report of backup account client versions.
+- `servosity-cli reports dr-from-email-list` - Get a report of user profiles.
+- `servosity-cli reports maxio-price-points-list` - Get CSV with all Maxio price points.
+- `servosity-cli reports product-list` - Product list
+- `servosity-cli reports stale-backup-sets-list` - Get a report of all backup set last backup complete times.
+- `servosity-cli reports usage-list` - Usage list
+- `servosity-cli reports user-profiles-list` - Get a report of user profiles.
 
-**resellers**  -  Manage resellers
+**resellers** - Manage resellers
 
-- `servosity-cli resellers partial-update`  -  Partial update
-- `servosity-cli resellers read`  -  View a reseller.
-- `servosity-cli resellers update`  -  Update a reseller.
+- `servosity-cli resellers partial-update` - Partial update
+- `servosity-cli resellers read` - View a reseller.
+- `servosity-cli resellers update` - Update a reseller.
 
-**restic-backups**  -  Manage restic backups
+**restic-backups** - Manage restic backups
 
-- `servosity-cli restic-backups create`  -  Create a restic backup account.
-- `servosity-cli restic-backups delete`  -  Delete a restic backup account.
-- `servosity-cli restic-backups list`  -  List
-- `servosity-cli restic-backups partial-update`  -  Update a restic backup account.
-- `servosity-cli restic-backups read`  -  Read
-- `servosity-cli restic-backups update`  -  Update a restic backup account.
+- `servosity-cli restic-backups create` - Create a restic backup account.
+- `servosity-cli restic-backups delete` - Delete a restic backup account.
+- `servosity-cli restic-backups list` - List
+- `servosity-cli restic-backups partial-update` - Update a restic backup account.
+- `servosity-cli restic-backups read` - Read
+- `servosity-cli restic-backups update` - Update a restic backup account.
 
-**screenshot**  -  Manage screenshot
+**screenshot** - Manage screenshot
 
-- `servosity-cli screenshot <key>`  -  Read
+- `servosity-cli screenshot <key>` - Read
 
-**stats**  -  Manage stats
+**stats** - Manage stats
 
-- `servosity-cli stats list`  -  List
-- `servosity-cli stats live-list`  -  Live list
-- `servosity-cli stats user-list`  -  User list
+- `servosity-cli stats list` - List
+- `servosity-cli stats live-list` - Live list
+- `servosity-cli stats user-list` - User list
 
-**users**  -  Manage users
+**users** - Manage users
 
-- `servosity-cli users create`  -  Create
-- `servosity-cli users delete`  -  Remove a user from a reseller or company group.
-- `servosity-cli users list`  -  List
-- `servosity-cli users request-password-recovery-create`  -  Request password recovery for a user.
-- `servosity-cli users reset-password-create`  -  Pass only `token` to confirm the token is valid. Pass `token` and `password` to set the user's password.
+- `servosity-cli users create` - Create
+- `servosity-cli users delete` - Remove a user from a reseller or company group.
+- `servosity-cli users list` - List
+- `servosity-cli users request-password-recovery-create` - Request password recovery for a user.
+- `servosity-cli users reset-password-create` - Pass only `token` to confirm the token is valid. Pass `token` and `password` to set the user's password.
 
 
 ### Finding the right command
@@ -329,7 +329,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 servosity-cli which "<capability in your own words>"
 ```
 
-`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match  -  fall back to `--help` or use a narrower query.
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match - fall back to `--help` or use a narrower query.
 
 ## Auth Setup
 Run `servosity-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
@@ -346,16 +346,16 @@ Run `servosity-cli doctor` to verify setup.
 
 Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
 
-- **Pipeable**  -  JSON on stdout, errors on stderr
-- **Filterable**  -  `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+- **Pipeable** - JSON on stdout, errors on stderr
+- **Filterable** - `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
 
   ```bash
   servosity-cli agent-login list --agent --select id,name,status
   ```
-- **Previewable**  -  `--dry-run` shows the request without sending
-- **Offline-friendly**  -  sync/search commands can use the local SQLite store when available
-- **Non-interactive**  -  never prompts, every input is a flag
-- **Explicit retries**  -  use `--idempotent` only when an already-existing create should count as success, and `--ignore-missing` only when a missing delete target should count as success
+- **Previewable** - `--dry-run` shows the request without sending
+- **Offline-friendly** - sync/search commands can use the local SQLite store when available
+- **Non-interactive** - never prompts, every input is a flag
+- **Explicit retries** - use `--idempotent` only when an already-existing create should count as success, and `--ignore-missing` only when a missing delete target should count as success
 
 ### Response envelope
 
@@ -368,7 +368,7 @@ Commands that read from the local store or the API wrap output in a provenance e
 }
 ```
 
-Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set  -  piped/agent consumers and explicit-format runs get pure JSON on stdout.
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set - piped/agent consumers and explicit-format runs get pure JSON on stdout.
 
 ## Agent Feedback
 

--- a/skills/servosity/SKILL.md
+++ b/skills/servosity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: servosity
-description: "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `use servosity`, `run servosity`."
+description: "Use when the user asks what needs attention across their Servosity backup fleet, which backups are stale, what changed overnight, the full backup picture for one client, or any cross-client / cross-engine backup-and-DR question. Wraps the Servosity MSP-partner REST API plus a local fleet mirror with snapshot history and FTS5 search, so fleet-wide questions the partner portal scatters across pages become one local query — offline once cached. Trigger phrases: `what needs my attention across clients`, `which backups are stale`, `what changed in my fleet overnight`, `show a client's backup status`, `find backups failing across engines`, `triage backup issues`, `Servosity + ChatGPT`, `Servosity + Claude`, `use servosity`, `run servosity`."
 author: "Damien Stevens"
 license: "Apache-2.0"
 vendor: "Servosity"

--- a/skills/servosity/manifest.json
+++ b/skills/servosity/manifest.json
@@ -3,7 +3,7 @@
   "name": "servosity-mcp",
   "display_name": "Servosity",
   "version": "0.1.0",
-  "description": "Every Servosity backup and DR feature for MSP partners, plus a local fleet mirror, snapshot history, and cross-engine rollups the partner portal can't show.",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
   "author": {
     "name": "Servosity Inc."
   },

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.servosity/servosity-mcp",
+  "title": "Servosity MCP",
+  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/servosity/msp-skills",
+    "source": "github",
+    "subfolder": "skills/servosity"
+  },
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "servosity-mcp",
+      "version": "0.1.0",
+      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-mcp-v0.1.0/servosity-mcp.mcpb",
+      "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SERVOSITY_MSP_TOKEN",
+          "description": "Servosity partner API token from the partner portal. Scoped to your reseller account only.",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -72,16 +72,30 @@ def build_entry(skill_dir: Path) -> dict:
     }
 
 
+def status_badge(status: str) -> str:
+    """Map a skill's status to a shields.io badge URL.
+
+    'tested' / 'beta' (the launch state for halopsa + servosity, where MSPs
+    have run the skill against a real production tenant): green Tested badge.
+    Anything else ('untested', etc.) for a skill that shipped but has not
+    been driven against live data yet: yellow Untested badge. Feedback on
+    untested skills is the high-leverage signal we want from MSPs.
+    """
+    if status in ("tested", "beta"):
+        return "![Tested](https://img.shields.io/badge/Tested-by_MSPs-2E7D32)"
+    return "![Untested](https://img.shields.io/badge/Untested-feedback_welcome-EAB308)"
+
+
 def render_catalog_table(skills: list[dict]) -> str:
     rows = [
-        "| Skill | System | Install (Skill) | Install (MCP) |",
+        "| Skill | System | Status | Install |",
         "| --- | --- | --- | --- |",
     ]
     for s in skills:
         rows.append(
             f"| [{s['name']}](./skills/{s['name']}) | {s['system']} | "
-            f"`bash skills/{s['name']}/install.sh` | "
-            f"[mcp-install](./{s['install_mcp_doc']}) |"
+            f"{status_badge(s['status'])} | "
+            f"[Install](./skills/{s['name']}/README.md) |"
         )
     return "\n".join(rows)
 

--- a/tools/maintainer/check_md_links.py
+++ b/tools/maintainer/check_md_links.py
@@ -25,8 +25,28 @@ def md_files() -> list[Path]:
         parts = p.relative_to(ROOT).parts
         if ".git" in parts:
             continue
+        # Skip local-only third-party skill installs (`.agents/` is gitignored
+        # so this only matters when running locally). Same for `node_modules`.
+        if parts[0] in (".agents", "node_modules", "vendor"):
+            continue
         # Skip vendored, generated module trees.
         if "cli" in parts and parts[0] == "skills":
+            continue
+        # Skip the Jekyll-rendered landing site under docs/. Those pages use
+        # Jekyll permalinks like /integrations/claude-desktop/ that only
+        # resolve at render time, not as raw filesystem paths. The Jekyll
+        # build itself is the right gate for those.
+        # The repo-doc files in docs/ (which-agent.md, requesting-a-skill.md,
+        # install-skill.md, install-mcp.md, contributing.md) ARE checked because
+        # they live at docs/ top level and link with relative paths that resolve
+        # on the filesystem too. The Jekyll-specific tree is docs/_layouts,
+        # docs/_includes, docs/integrations, docs/skills, docs/guides, and
+        # docs/index.md / docs/llms.txt.
+        if parts[:1] == ("docs",) and len(parts) > 1 and parts[1] in (
+            "_layouts", "_includes", "integrations", "skills", "guides"
+        ):
+            continue
+        if parts == ("docs", "index.md"):
             continue
         out.append(p)
     return out


### PR DESCRIPTION
Stacked on top of #3 (which is stacked on #2). Retarget to \`main\` after both merge.

## Summary

Adds a Jekyll-powered landing site under \`docs/\` for GitHub Pages publishing.
Target queries: \"ChatGPT HaloPSA\", \"Claude Servosity\", and the long-tail
\"[agent] HaloPSA\" / \"[agent] Servosity\" variants.

Domain target: \`msp-skills.compoundingteams.com\` (CNAME added once you've set the DNS).

## Files

- \`docs/_config.yml\` — Jekyll config (kramdown GFM, jekyll-seo-tag, jekyll-sitemap)
- \`docs/_layouts/default.html\` — minimal CSS, site nav, JSON-LD schema injection
- \`docs/_includes/schema.html\` — Organization + (SoftwareApplication / FAQPage / WebPage) JSON-LD per page
- \`docs/index.md\` — landing page with 40-80-word direct-answer hero, cross-tool matrix, FAQ in AEO H3 shape
- \`docs/llms.txt\` — AI search engine ingestion file (top crawl source for ChatGPT search, Claude search, Perplexity, Gemini)
- \`docs/integrations/{claude-desktop,chatgpt,claude-code,codex}.md\` — programmatic-SEO per-agent landing pages
- \`docs/skills/{halopsa,servosity}.md\` — per-skill landing pages with SoftwareApplication JSON-LD
- \`docs/guides/first-time-setup.md\` — beginner-friendly walkthrough for MSP business owners

## How to test

1. Local preview: \`cd docs && bundle exec jekyll serve\`. Visit http://localhost:4000.
2. Confirm Organization + SoftwareApplication + FAQPage JSON-LD validates at https://search.google.com/test/rich-results.
3. After merge: enable GitHub Pages in repo settings (Source = \`main\`, folder = \`/docs\`).
4. Wire CNAME for \`msp-skills.compoundingteams.com\` (or whichever subdomain you pick).

## Out of scope

- CNAME file (will add when DNS is set up)
- Social preview PNG (Damien handles separately; upload via \`gh repo edit --social-preview\`)
- Per-tool long-tail integration pages for Cursor / Windsurf / Cline / Gemini / Copilot (next pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)