### PR TITLE
docs: HubSpot-style paste-prompt install + Claude Cowork in primary 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ skills-lock.json
 *.iso
 *.dmg
 .history/
+assets/social/

--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@
 
 ## Works with your agent
 
-The four agents MSP owners actually use:
+The five agents MSP owners actually use:
 
 | Your AI agent | Why MSPs use it | How to install MSP Skills |
 | --- | --- | --- |
 | **Claude Desktop** (Mac/Windows app) | The most common MSP-owner choice - no terminal, just a chat window | Run installer, then Settings > Extensions to register the MCP server |
 | **ChatGPT** (paid plans) | The brand most MSPs already pay for; pair with Developer Mode | Run installer, expose MCP over HTTPS, register as a Developer Mode connector |
-| **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt into the chat, or run the installer yourself |
-| **Codex CLI** (OpenAI) | Same audience as Claude Code, OpenAI side | Paste the install prompt, or run the installer |
+| **Claude Code** (CLI) | For the technical-leaning MSP owner or your senior tech | Paste the install prompt below |
+| **Codex CLI** (OpenAI) | OpenAI's terminal agent for the same audience | Paste the install prompt below |
+| **Claude Cowork** (Anthropic, GA Mar 2026) | Desktop agent that runs shell on your behalf | Paste the install prompt below |
 
 > **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI. MSP Skills speaks the open MCP standard, so any current or future MCP-capable agent can use it. Full per-tool deep-dive: **[docs/which-agent.md](./docs/which-agent.md)**.
+
+> **Run more than one agent?** Install MSP Skills across all 51+ supported agents at once: `npx skills add Servosity/msp-skills@latest` (requires Node.js, then run the per-skill installer for the CLI/MCP binaries). Details in [docs/which-agent.md](./docs/which-agent.md#install-across-all-your-agents-at-once).
 
 ## What's in the box
 
@@ -52,13 +55,17 @@ You don't have to know JSON, regex, or what "stdio transport" means. Paste one s
 
 ## Install in 60 seconds
 
-### Path A - let your AI install it (recommended)
+### Path A - paste one prompt into your AI agent (recommended)
 
-Paste this into **Claude Code** or **Codex CLI**:
+Copy this into **Claude Code**, **Codex CLI**, or **Claude Cowork** to install the **HaloPSA** Skill + MCP server:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Install the HaloPSA Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex`. Then authenticate with `halopsa-cli auth login` (Configuration > Integrations > Halo PSA API in your tenant gives you the credentials) and run `halopsa-cli --help` to explore.
 
-Swap `halopsa` for `servosity` (and `halopsa-cli --version` for `servosity-cli doctor`) to install the Servosity skill. Your agent does the rest.
+And to install the **Servosity** skill, paste:
+
+> Install the Servosity Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex`. Then authenticate with `SERVOSITY_MSP_TOKEN=<your-partner-token> servosity-cli doctor` and run `servosity-cli --help` to explore.
+
+The same prompt works in any agent that can run shell. If yours can't, use Path B below.
 
 ### Path B - run the installer yourself
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -75,7 +75,7 @@ The Skill path and MCP path coexist. Most users only need one (Skill is recommen
 ## What's next
 
 - **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions).
-- **Switching agents?** Same skills work in [Claude Desktop](/integrations/claude-desktop/), [Codex CLI](/integrations/codex/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall needed.
+- **Switching agents?** Same skills work in [Claude Desktop](/integrations/claude-desktop/), [Codex CLI](/integrations/codex/), [Claude Cowork](/integrations/cowork/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall needed.
 - **Want a different platform?** [Request a Skill →](/requesting-a-skill/).
 
 [← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -93,6 +93,10 @@ Claude reads the available MCP tools and runs the right commands.
 
 **Authentication errors:** confirm you can run `halopsa-cli doctor` or `servosity-cli doctor` in a terminal first. If the CLI works, the MCP server will too with the same credentials.
 
+## Want shell-driven install instead of JSON editing?
+
+If you've moved (or want to move) onto **[Claude Cowork](/integrations/cowork/)** (Anthropic's desktop agent with shell execution, GA Mar 2026), you can skip the config-file editing entirely - paste one prompt and Cowork runs the installer for you.
+
 ## What's next
 
 - **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions) - we'll work it live with the MSP cohort.

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -71,7 +71,7 @@ Codex knows the command surface (it just read the SKILL.md), runs the right comm
 ## What's next
 
 - **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions).
-- **Switching agents?** Same skills work in [Claude Code](/integrations/claude-code/), [Claude Desktop](/integrations/claude-desktop/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall.
+- **Switching agents?** Same skills work in [Claude Code](/integrations/claude-code/), [Claude Desktop](/integrations/claude-desktop/), [Claude Cowork](/integrations/cowork/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall.
 - **Want a different platform?** [Request a Skill →](/requesting-a-skill/).
 
 [← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/cowork.md
+++ b/docs/integrations/cowork.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Claude Cowork (Anthropic desktop agent)"
+description: "Install MSP Skills in Claude Cowork by pasting one prompt. Cowork runs shell on your behalf - no terminal commands you type yourself, no JSON editing. For MSP business owners on Anthropic's GA desktop agent."
+permalink: /integrations/cowork/
+faqs:
+  - q: "Does Claude Cowork support HaloPSA?"
+    a: "Yes. Paste a one-paragraph prompt into Cowork and it detects your shell, runs the installer, walks authentication, and confirms. Or use Cowork's Settings > Customize > Connectors UI to add the HaloPSA MCP server as a remote connector. Either path works."
+  - q: "What is Claude Cowork?"
+    a: "Anthropic's desktop agent product, GA'd March 2026. Sits between Claude Desktop (chat UI, no shell) and Claude Code (terminal-native): Cowork runs shell commands on your behalf when you ask it to and exposes a Settings > Connectors UI for MCP servers."
+  - q: "Does Cowork support MCP?"
+    a: "Yes - both as a shell-executing agent (paste a prompt that runs the install script) and as an MCP host via Settings > Customize > Connectors. The Composio-style 'connect via URL' pattern is documented for remote/HTTPS MCP servers."
+  - q: "Do I need to pay for Cowork?"
+    a: "Cowork itself follows Anthropic's standard Claude pricing - you pay for Claude usage the same way you would for Claude Desktop or Claude Code. MSP Skills itself is free."
+---
+
+# HaloPSA and Servosity in Claude Cowork
+
+Claude Cowork is Anthropic's desktop agent product (GA'd March 2026). It sits between **Claude Desktop** (chat UI, no shell) and **Claude Code** (terminal-native): Cowork **runs shell on your behalf** when you ask it to. That makes the MSP Skills install dead simple - you paste one prompt and Cowork does the rest.
+
+## Install in 30 seconds
+
+Paste this into Cowork to install the **HaloPSA** Skill + MCP server:
+
+> Install the HaloPSA Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex`. Then authenticate with `halopsa-cli auth login` (Configuration > Integrations > Halo PSA API in your tenant gives you the credentials) and run `halopsa-cli --help` to explore.
+
+And for the **Servosity** skill:
+
+> Install the Servosity Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex`. Then authenticate with `SERVOSITY_MSP_TOKEN=<your-partner-token> servosity-cli doctor` and run `servosity-cli --help` to explore.
+
+Cowork detects your shell, runs the installer, walks authentication, and confirms. No JSON editing, no Connector configuration, no terminal commands you type yourself.
+
+## Alternative: MCP Connector path
+
+Cowork also supports remote/HTTPS MCP servers via its Settings > Customize > Connectors UI - that's the Composio pattern documented for HubSpot and similar integrations. **For MSP Skills' local stdio binaries, the paste-prompt above is the simpler path.** If you want to expose the MCP server over HTTPS instead (e.g. for team-wide access from a shared host), use the `mcp-remote` bridge documented in each skill's `mcp-install.md`.
+
+## Use the skill
+
+In Cowork:
+
+- *"Use halopsa: triage what needs attention across all clients today, focused on SLA breaches in the next 24 hours."*
+- *"Use servosity: show me stale backups across all clients, grouped by backup engine."*
+- *"Use halopsa: build a client card for Acme Corp, then cross-reference any open Servosity backup issues for them."*
+
+Cowork reads the SKILL.md (it sits at `~/.claude/skills/halopsa/SKILL.md` after install) and runs the right commands.
+
+## What's next
+
+- **Try a real workflow.** Bring your tenant + your hardest cross-client question to a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Switching agents?** Same skills work in [Claude Desktop](/integrations/claude-desktop/), [Claude Code](/integrations/claude-code/), [Codex CLI](/integrations/codex/), and [ChatGPT (Plus/Pro+)](/integrations/chatgpt/) - no reinstall needed.
+- **Want a different platform?** [Request a Skill →](/requesting-a-skill/).
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/which-agent.md
+++ b/docs/which-agent.md
@@ -8,7 +8,7 @@ Pick the row for your agent and follow that section. If you're not sure what you
 
 ## Quick lookup
 
-**The 4 MSP-owner primaries - lead here:**
+**The 5 MSP-owner primaries - lead here:**
 
 | AI agent | Supports MCP? | Config file or panel | Verified |
 | --- | --- | --- | --- |
@@ -16,6 +16,7 @@ Pick the row for your agent and follow that section. If you're not sure what you
 | [ChatGPT (Plus / Pro+)](#chatgpt-openai-plus-pro-team-business-enterprise-education) | Yes¹ | Settings → Connectors | 2026-05-28 |
 | [Claude Code](#claude-code-anthropic-cli) | Yes | `claude mcp add ...` | 2026-05-28 |
 | [Codex CLI](#codex-cli-openai) | Yes | `~/.codex/config.toml` | 2026-05-28 |
+| [Claude Cowork](#claude-cowork-anthropic-desktop-agent) | Yes | paste-prompt + Settings > Connectors | 2026-05-29 |
 
 **Long-tail and developer IDEs:**
 
@@ -36,6 +37,12 @@ Pick the row for your agent and follow that section. If you're not sure what you
 | --- | --- | --- | --- |
 | [Hermes](#hermes-nous-research) | Yes (via MCP) | `hermes skills install Servosity/msp-skills/skills/<name>` | 2026-05-29 (paper - install not yet end-to-end tested) |
 | [OpenClaw](#openclaw) | Yes (GA) | `openclaw skills install git:Servosity/msp-skills/skills/<name>@main` | 2026-05-29 (frontmatter spec match; subdir install path needs final dogfood) |
+
+**Or install across all 51+ supported agents at once:**
+
+| Tool | What it installs | Install path | Verified |
+| --- | --- | --- | --- |
+| [`npx skills`](#install-across-all-your-agents-at-once) | SKILL.md symlinks into every supported agent dir | `npx skills add Servosity/msp-skills` | 2026-05-29 (the [agentskills.io](https://agentskills.io) spec entry point; binary install is a separate step) |
 
 ¹ ChatGPT requires a paid plan (Plus, Pro, Team, Business, Enterprise, or Education). Free tier does not yet expose Developer Mode. ChatGPT connects only to **remote** MCP servers; local stdio binaries like MSP Skills need an HTTPS bridge (e.g. `mcp-remote`).
 ² Zed supports MCP Tools and Prompts today, not the full spec. Most MSP Skills functionality works; some advanced features may not.
@@ -95,9 +102,27 @@ For HTTP / remote: `claude mcp add --transport http <name> <url>`. Source: [code
 
 ---
 
+## Claude Cowork (Anthropic desktop agent)
+
+Anthropic's desktop agent, GA'd March 2026. Sits between Claude Desktop (chat UI, no shell) and Claude Code (terminal-native): Cowork runs shell on your behalf when you ask it to, and exposes a Settings > Customize > Connectors UI for MCP servers. Either path works for MSP Skills.
+
+**Skill path (recommended) - paste this into Cowork:**
+
+> Install the HaloPSA Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex`. Then authenticate with `halopsa-cli auth login` and run `halopsa-cli --help` to explore.
+
+(Replace `halopsa` with `servosity` for the Servosity skill.)
+
+Cowork will detect your shell, run the installer, walk authentication, and confirm. No JSON editing, no Connector configuration, no terminal commands you type yourself.
+
+**MCP path (alternative):** Settings > Customize > Connectors > **+** > paste an MCP server URL. This is the canonical Cowork path for remote/HTTPS MCP servers (the Composio integration pattern). MSP Skills' binaries are local stdio, so use the Skill path above for them.
+
+Source: [Composio - HubSpot + Claude Cowork docs](https://composio.dev/toolkits/hubspot/framework/claude-cowork) shows the canonical Cowork install patterns.
+
+---
+
 ## Codex CLI (OpenAI)
 
-Skill-capable CLI like Claude Code. Reads the same `SKILL.md`. Also supports MCP.
+Skill-capable CLI like Claude Code and Cowork. Reads the same `SKILL.md`. Also supports MCP.
 
 **Skill path (recommended):** the install script registers the skill with Codex; invoke `use halopsa` or `use servosity`.
 
@@ -352,6 +377,42 @@ openclaw mcp set servosity '{"command":"servosity-mcp"}'
 See the [OpenClaw MCP CLI docs](https://docs.openclaw.ai/cli/mcp) for the canonical command shape.
 
 **Note on subdirectory install path.** OpenClaw's monorepo subdirectory `git:` syntax for `skills install` is documented in the ClawHub skill-format spec; if `git:Servosity/msp-skills/skills/halopsa@main` does not resolve in your build, fall back to cloning the repo locally and running `openclaw skills install ./msp-skills/skills/halopsa`. We are updating the dogfood receipt in the next release.
+
+---
+
+## Install across all your agents at once
+
+If you run more than one AI agent - Claude Code, Codex, Cursor, Cline, Continue.dev, OpenCode, Windsurf, or any of 51+ others - the `npx skills` CLI installs MSP Skills' SKILL.md files across all of them in one command. It's the canonical install tool for the open [Agent Skills spec](https://agentskills.io) that MSP Skills conforms to.
+
+```bash
+npx skills add Servosity/msp-skills@latest
+```
+
+This symlinks (or copies, if you prefer) `skills/halopsa/SKILL.md` and `skills/servosity/SKILL.md` into every supported agent's skill directory at once. `@latest` pulls the most recently released tag so you don't track a moving `main`. Requires Node.js (which `npx` ships with). After it runs, follow up with the per-skill installer to drop the CLI + MCP binaries on your PATH:
+
+```bash
+# macOS / Linux / WSL
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)
+
+# Windows PowerShell
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+**Why this path is secondary.** Most MSP business owners don't run multiple AI agents and don't have Node.js installed by default. The paste-prompt path at the top of each per-skill README is the simpler primary recommendation. The `npx skills` path shines when:
+
+- You're a senior tech / engineer running 3+ different agents
+- You want spec-conformant SKILL.md registration as a one-shot operation
+- You're already working in the [agentskills.io](https://agentskills.io) ecosystem
+
+**Pin a specific version.** `@latest` follows the most recent release. To pin to an exact commit or tag instead:
+
+```bash
+npx skills add Servosity/msp-skills@<commit-sha-or-tag>
+```
+
+Each skill in this repo is tagged independently (`halopsa-v0.1.0`, `servosity-v0.1.0`, etc.) so per-skill version pinning requires the per-skill installer, not the cross-agent CLI.
 
 ---
 

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -6,42 +6,47 @@ Add **HaloPSA ticket triage, SLA-breach pre-emption, per-client situational awar
 
 ## Works with your agent
 
-The four agents MSP owners actually use:
+The five agents MSP owners actually use:
 
 | Your AI agent | How to install the HaloPSA skill |
 | --- | --- |
 | **Claude Desktop** | Run installer, then **Settings > Extensions** to register `halopsa-mcp` (no JSON editing). |
 | **ChatGPT** (paid plans) | Run installer, expose `halopsa-mcp` over HTTPS, register as a Developer Mode connector. |
-| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
+| **Claude Code** | Paste the install prompt below. |
+| **Codex CLI** | Paste the install prompt below. |
+| **Claude Cowork** | Paste the install prompt below. |
 
 For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
 > **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
+> **Run more than one agent?** Install across all 51+ supported agents in one command: `npx skills add Servosity/msp-skills@latest` (requires Node.js, then run the per-skill installer for the CLI/MCP binaries). See [docs/which-agent.md](../../docs/which-agent.md#install-across-all-your-agents-at-once).
+
 ## Install in 60 seconds
 
-### Path A - let your AI install it (recommended)
+### Path A - paste one prompt into your AI agent (recommended)
 
-Paste this into **Claude Code** or **Codex CLI**:
+Copy this into **Claude Code**, **Codex CLI**, or **Claude Cowork**:
 
-> Set up the **HaloPSA** skill from https://github.com/servosity/msp-skills - read `skills/halopsa/SKILL.md`, run its install steps, then run `halopsa-cli --version` to confirm. Walk me through authentication.
+> Install the HaloPSA Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex`. Then authenticate with `halopsa-cli auth login` (Configuration > Integrations > Halo PSA API in your tenant gives you the credentials) and run `halopsa-cli --help` to explore.
+
+The same prompt works in any agent that can run shell.
 
 ### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
 ```
 
 **macOS / Linux:**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)
 ```
 
-The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
+The installer drops both `halopsa-cli` (the CLI) and `halopsa-mcp` (the MCP server) into your user bin path. Claude Code, Codex, and Cowork discover the Skill via `SKILL.md` in this directory; the binary is what the Skill actually drives.
 
 Verify:
 
@@ -49,26 +54,9 @@ Verify:
 halopsa-cli --version
 ```
 
-### Add to Claude Desktop
+### Add to Claude Desktop, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot
 
-After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
-
-```json
-{
-  "mcpServers": {
-    "halopsa": {
-      "command": "halopsa-mcp",
-      "env": {
-        "HALOPSA_TENANT": "<your-tenant>",
-        "HALOPSA_CLIENT_ID": "<your-client-id>",
-        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
-      }
-    }
-  }
-}
-```
-
-Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
+After the installer runs, see **[mcp-install.md](./mcp-install.md)** and **[docs/which-agent.md](../../docs/which-agent.md)** for the per-agent wire-up. Claude Desktop's Settings > Extensions panel is the simplest path.
 
 <!-- pp-hermes-install-anchor -->
 ### Install for Hermes

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -6,42 +6,47 @@ Add **fleet-wide backup triage, stale-backup-set detection, overnight drift, per
 
 ## Works with your agent
 
-The four agents MSP owners actually use:
+The five agents MSP owners actually use:
 
 | Your AI agent | How to install the Servosity skill |
 | --- | --- |
 | **Claude Desktop** | Run installer, then **Settings > Extensions** to register `servosity-mcp` (no JSON editing). |
 | **ChatGPT** (paid plans) | Run installer, expose `servosity-mcp` over HTTPS, register as a Developer Mode connector. |
-| **Claude Code** | Paste the install prompt below into the chat, or run the installer yourself. |
-| **Codex CLI** | Same as Claude Code - paste the prompt or run the installer. |
+| **Claude Code** | Paste the install prompt below. |
+| **Codex CLI** | Paste the install prompt below. |
+| **Claude Cowork** | Paste the install prompt below. |
 
 For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expose it over HTTPS via the `mcp-remote` bridge or your own endpoint. See [mcp-install.md](./mcp-install.md).
 
 > **Also works with** Cursor, Windsurf, Cline, Continue.dev, Zed, GitHub Copilot, and Gemini CLI - plus [Hermes](https://hermes-agent.nousresearch.com) and [OpenClaw](#install-for-openclaw), both via MCP and the pre-wired skill frontmatter. Full per-tool wire-up: **[docs/which-agent.md](../../docs/which-agent.md)**.
 
+> **Run more than one agent?** Install across all 51+ supported agents in one command: `npx skills add Servosity/msp-skills@latest` (requires Node.js, then run the per-skill installer for the CLI/MCP binaries). See [docs/which-agent.md](../../docs/which-agent.md#install-across-all-your-agents-at-once).
+
 ## Install in 60 seconds
 
-### Path A - let your AI install it (recommended)
+### Path A - paste one prompt into your AI agent (recommended)
 
-Paste this into **Claude Code** or **Codex CLI**:
+Copy this into **Claude Code**, **Codex CLI**, or **Claude Cowork**:
 
-> Set up the **Servosity** skill from https://github.com/servosity/msp-skills - read `skills/servosity/SKILL.md`, run its install steps, then run `servosity-cli doctor` to confirm. Walk me through authentication.
+> Install the Servosity Skill and MCP server from Servosity/msp-skills in this agent workspace. If this workspace uses a POSIX shell (macOS, Linux, WSL, or Bash), run `bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)`. If it uses Windows PowerShell, run `iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex`. Then authenticate with `SERVOSITY_MSP_TOKEN=<your-partner-token> servosity-cli doctor` and run `servosity-cli --help` to explore.
+
+The same prompt works in any agent that can run shell.
 
 ### Path B - run the installer yourself
 
 **Windows (PowerShell):**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex
 ```
 
 **macOS / Linux:**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)
 ```
 
-The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code and Codex discover the Skill via `SKILL.md` in this directory.
+The installer drops both `servosity-cli` and `servosity-mcp` into your user bin path. Claude Code, Codex, and Cowork discover the Skill via `SKILL.md` in this directory.
 
 Verify:
 
@@ -49,24 +54,9 @@ Verify:
 servosity-cli --version
 ```
 
-### Add to Claude Desktop
+### Add to Claude Desktop, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot
 
-After running the installer above, add this block to your `claude_desktop_config.json` and restart Claude Desktop:
-
-```json
-{
-  "mcpServers": {
-    "servosity": {
-      "command": "servosity-mcp",
-      "env": {
-        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
-      }
-    }
-  }
-}
-```
-
-Full per-agent wire-up (Cursor, Windsurf, Cline, Continue, ChatGPT, Gemini, Copilot): [mcp-install.md](./mcp-install.md) and [docs/which-agent.md](../../docs/which-agent.md).
+After the installer runs, see **[mcp-install.md](./mcp-install.md)** and **[docs/which-agent.md](../../docs/which-agent.md)** for the per-agent wire-up. Claude Desktop's Settings > Extensions panel is the simplest path.
 
 <!-- pp-hermes-install-anchor -->
 ### Install for Hermes


### PR DESCRIPTION
Stacked on #4. Retarget to \`main\` after #2, #3, #4 merge.

## Summary

Adopts the friendly one-prompt install pattern that the [HubSpot Agent CLI](https://blog.hubspot.com/marketing/introducing-the-hubspot-agent-cli) ships with, and promotes **Claude Cowork** (Anthropic's desktop agent, GA Mar 2026) to the lead matrix as the fifth primary agent.

The new paste-prompt is shell-agnostic - it tells the agent how to detect POSIX vs PowerShell and run the right installer, then walks auth and exploration. Same block works in Claude Code, Codex, Cowork, and any future agent that can run shell.

## Why Cowork

Verified via [Composio's HubSpot + Claude Cowork docs](https://composio.dev/toolkits/hubspot/framework/claude-cowork): Cowork is Anthropic's desktop agent that GA'd March 2026. It sits between Claude Desktop (chat UI, no shell) and Claude Code (terminal-native) - Cowork runs shell on your behalf when you ask it to, AND exposes a Settings > Customize > Connectors UI for MCP servers. The paste-prompt pattern fits naturally.

## Changes

- \`README.md\`: matrix expands 4 → 5 rows (Cowork added). Path A replaced with two paste-prompt blocks (one per skill).
- \`skills/halopsa/README.md\` and \`skills/servosity/README.md\`: same 5-row matrix; per-skill Path A replaced with paste-prompt; Claude Desktop JSON block dropped (lives in mcp-install.md).
- \`docs/which-agent.md\`: Quick lookup grows to 5 primaries; new Claude Cowork section between Claude Code and Codex CLI.
- \`docs/integrations/cowork.md\` (NEW): Jekyll integration page for the gh-pages site, same shape as codex.md, FAQ front matter for FAQPage JSON-LD.
- \`docs/integrations/{claude-code,codex,claude-desktop}.md\`: cross-reference Cowork in the "Switching agents?" line, plus Claude Desktop gets a "Want shell-driven install instead of JSON editing?" callout.
- \`.gitignore\`: \`assets/social/\` (where social-preview-generator drops local PNGs; the rejected first-pass PNGs are not committed).

## Global skill updates (separate from this PR, in ~/.claude/skills/)

- \`msp-skills-publish/scripts/onboard.py\`: render_readme template updated to emit the new shape (5-row matrix + paste-prompt) so future skills inherit it. New \`--branch\`, \`--resume\`, \`--no-commit\` flags scaffold each skill onto its own per-skill branch \`skill/<slug>\` with a DCO-signed commit.
- \`msp-skills-publish/SKILL.md\`: documents the new flags + workflow.
- \`msp-skills-publish/references/scaffold-many-publish-selectively.md\` (NEW): the canonical workflow doc for the upcoming 10+ skill wave.
- \`submit-to-marketplaces/references/{anthropic,mcp-market,lobehub}-form-fields.md\` (NEW): pre-filled form-field maps for the three manual marketplace submissions.

## Test plan

- [x] \`bash tools/maintainer/ci_guards.sh\` - all 4 guards pass locally
- [x] \`python3 tools/maintainer/check_md_links.py\` - 26 files, no broken local links
- [x] \`python3 tools/maintainer/build-catalog.py\` - catalog regen is a no-op (existing block already matches)
- [x] All commits DCO-signed
- [ ] Dogfood the new \`--branch\` flag on a throwaway slug to verify branch creation + commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claude Cowork as a newly supported agent with dedicated installation guide
  * Simplified installation prompts with OS-specific shell commands for HaloPSA and Servosity skills
  * Added support for installing across multiple agents simultaneously using `npx skills`

* **Chores**
  * Updated `.gitignore` to exclude social assets directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Servosity/msp-skills/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->