### PR TITLE
fix: unblock marketplace submission + add plugin-validate gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
       "name": "servosity",
       "source": "./skills/servosity",
       "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "backup-dr",
       "tags": [
         "servosity",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "halopsa",
       "source": "./skills/halopsa",
       "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "psa",
       "tags": [
         "halopsa",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           /tmp/gitleaks detect --no-git --source . --config .gitleaks.toml --redact --no-banner
 
+      - name: Plugin manifest validation (claude plugin validate --strict)
+        env:
+          CI: "true"
+        run: |
+          set -euo pipefail
+          npm install -g @anthropic-ai/claude-code
+          # Marketplace manifest + every per-skill plugin manifest. --strict
+          # fails on unknown fields (e.g. a stray `vendor`) and missing metadata.
+          claude plugin validate . --strict
+          for d in skills/*/; do
+            [ -f "${d}.claude-plugin/plugin.json" ] || continue
+            claude plugin validate "skills/$(basename "$d")" --strict
+          done
+
   # Skill build matrix is computed from the repo, so a new skill is built+vetted
   # with no edit here (mirrors the release workflow).
   prepare:

--- a/catalog.json
+++ b/catalog.json
@@ -25,7 +25,7 @@
       "skill_path": "skills/servosity",
       "cli_binary": "servosity-cli",
       "mcp_binary": "servosity-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "vendor": "Servosity",
       "vendor_trademark_owner": "Servosity Inc.",

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-29",
+  "generated_at": "2026-06-02",
   "skills": [
     {
       "name": "halopsa",
@@ -9,7 +9,7 @@
       "skill_path": "skills/halopsa",
       "cli_binary": "halopsa-cli",
       "mcp_binary": "halopsa-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "vendor": "HaloPSA",
       "vendor_trademark_owner": "Halo Service Solutions Ltd.",

--- a/skills/halopsa/.claude-plugin/plugin.json
+++ b/skills/halopsa/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "halopsa",
   "version": "0.1.0",
-  "vendor": "HaloPSA",
   "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners. No code required.",
   "author": {
     "name": "Servosity",

--- a/skills/halopsa/.claude-plugin/plugin.json
+++ b/skills/halopsa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "halopsa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners. No code required.",
   "author": {
     "name": "Servosity",

--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.1] - 2026-06-02
+
+### Fixed
+- OAuth2 client-credentials tokens now send the `scope` parameter (defaulting to
+  `all`), fixing HTTP 401 on every authenticated HaloPSA API call (refs #7).
+
+### Changed
+- First marketplace-ready release: one-click `.mcpb` install, validated plugin
+  manifest, and registry metadata aligned for submission.
+
 ## [0.1.0] - 2026-05-26
 
 ### Added

--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this skill are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[semantic versioning](https://semver.org/).
+
+## [0.1.0] - 2026-05-26
+
+### Added
+- Initial msp-skills release: HaloPSA CLI (`halopsa-cli`) + MCP server
+  (`halopsa-mcp`).
+- Ticket triage, SLA-breach pre-emption, and cross-client analytics.
+- Local SQLite mirror with full-text search for fast, offline cross-entity
+  queries the live API can't return in one shot.
+- Cross-agent install: Claude Desktop `.mcpb`, Claude Code / Codex / Cowork,
+  GitHub Copilot, Gemini CLI, ChatGPT (remote), Microsoft 365 Copilot (remote),
+  Hermes, and OpenClaw.

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -26,7 +26,7 @@ For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download HaloPSA MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.0/halopsa-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every HaloPSA release on the [releases page](https://github.com/servosity/msp-skills/releases?q=halopsa).)
+[**Download HaloPSA MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.1/halopsa-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every HaloPSA release on the [releases page](https://github.com/servosity/msp-skills/releases?q=halopsa).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -24,6 +24,17 @@ For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose
 
 ## Install in 60 seconds
 
+### Fastest for Claude Desktop - one-click `.mcpb`
+
+[**Download HaloPSA MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.0/halopsa-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every HaloPSA release on the [releases page](https://github.com/servosity/msp-skills/releases?q=halopsa).)
+
+Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
+
+```
+/plugin marketplace add Servosity/msp-skills
+/plugin install halopsa@msp-skills
+```
+
 ### Path A - paste one prompt into your AI agent (recommended)
 
 Copy this into **Claude Code**, **Codex CLI**, or **Claude Cowork**:
@@ -53,6 +64,24 @@ Verify:
 ```bash
 halopsa-cli --version
 ```
+
+### Upgrade to the latest version
+
+The installer always fetches the current release - re-run it to upgrade:
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+```
+
+Claude Desktop `.mcpb` users: download the latest `.mcpb` (top of this section) and re-select it in **Settings > Extensions**. Claude Code plugin users: `/plugin update halopsa@msp-skills`.
 
 ### Add to Claude Desktop, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot
 

--- a/skills/halopsa/manifest.json
+++ b/skills/halopsa/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "halopsa-mcp",
   "display_name": "Halo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live API can't return are fast and offline.",
   "author": {
     "name": "Servosity Inc."

--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.servosity/halopsa-mcp",
   "title": "HaloPSA MCP",
   "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/servosity/msp-skills/main/docs/assets/social/halopsa/halopsa-512x512.png",
@@ -22,8 +22,8 @@
     {
       "registryType": "mcpb",
       "identifier": "halopsa-mcp",
-      "version": "0.1.0",
-      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.0/halopsa-mcp.mcpb",
+      "version": "0.1.1",
+      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.1/halopsa-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"

--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -23,7 +23,7 @@
       "registryType": "mcpb",
       "identifier": "halopsa-mcp",
       "version": "0.1.0",
-      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-mcp-v0.1.0/halopsa-mcp.mcpb",
+      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.0/halopsa-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"

--- a/skills/servosity/.claude-plugin/plugin.json
+++ b/skills/servosity/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "servosity",
   "version": "0.1.0",
-  "vendor": "Servosity",
   "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
   "author": {
     "name": "Servosity",

--- a/skills/servosity/.claude-plugin/plugin.json
+++ b/skills/servosity/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "servosity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
   "author": {
     "name": "Servosity",

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this skill are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[semantic versioning](https://semver.org/).
+
+## [0.1.0] - 2026-05-26
+
+### Added
+- Initial msp-skills release: Servosity CLI (`servosity-cli`) + MCP server
+  (`servosity-mcp`).
+- Fleet-wide backup triage, stale-backup detection, and cross-engine analytics.
+- Local fleet mirror with snapshot history so the partner portal's per-page
+  views become one query.
+- Cross-agent install: Claude Desktop `.mcpb`, Claude Code / Codex / Cowork,
+  GitHub Copilot, Gemini CLI, ChatGPT (remote), Microsoft 365 Copilot (remote),
+  Hermes, and OpenClaw.

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.1] - 2026-06-02
+
+### Changed
+- First marketplace-ready release: one-click `.mcpb` install, validated plugin
+  manifest, and registry metadata aligned for submission. No CLI/behavior change
+  from 0.1.0.
+
 ## [0.1.0] - 2026-05-26
 
 ### Added

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -24,6 +24,17 @@ For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expo
 
 ## Install in 60 seconds
 
+### Fastest for Claude Desktop - one-click `.mcpb`
+
+[**Download Servosity MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.0/servosity-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Servosity release on the [releases page](https://github.com/servosity/msp-skills/releases?q=servosity).)
+
+Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
+
+```
+/plugin marketplace add Servosity/msp-skills
+/plugin install servosity@msp-skills
+```
+
 ### Path A - paste one prompt into your AI agent (recommended)
 
 Copy this into **Claude Code**, **Codex CLI**, or **Claude Cowork**:
@@ -53,6 +64,24 @@ Verify:
 ```bash
 servosity-cli --version
 ```
+
+### Upgrade to the latest version
+
+The installer always fetches the current release - re-run it to upgrade:
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/Servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+Claude Desktop `.mcpb` users: download the latest `.mcpb` (top of this section) and re-select it in **Settings > Extensions**. Claude Code plugin users: `/plugin update servosity@msp-skills`.
 
 ### Add to Claude Desktop, Cursor, Windsurf, Cline, Continue, Gemini, or Copilot
 

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -26,7 +26,7 @@ For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expo
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Servosity MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.0/servosity-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Servosity release on the [releases page](https://github.com/servosity/msp-skills/releases?q=servosity).)
+[**Download Servosity MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.1/servosity-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Servosity release on the [releases page](https://github.com/servosity/msp-skills/releases?q=servosity).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/servosity/manifest.json
+++ b/skills/servosity/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "servosity-mcp",
   "display_name": "Servosity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query.",
   "author": {
     "name": "Servosity Inc."

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.servosity/servosity-mcp",
   "title": "Servosity MCP",
   "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/servosity/msp-skills/main/docs/assets/social/servosity/servosity-512x512.png",
@@ -22,8 +22,8 @@
     {
       "registryType": "mcpb",
       "identifier": "servosity-mcp",
-      "version": "0.1.0",
-      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.0/servosity-mcp.mcpb",
+      "version": "0.1.1",
+      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.1/servosity-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -23,7 +23,7 @@
       "registryType": "mcpb",
       "identifier": "servosity-mcp",
       "version": "0.1.0",
-      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-mcp-v0.1.0/servosity-mcp.mcpb",
+      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.0/servosity-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -117,9 +117,23 @@ def main() -> int:
     skill_dirs = sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir())
     skills = [build_entry(d) for d in skill_dirs]
 
+    # Preserve the existing generated_at when the substantive content is
+    # unchanged, so re-running build-catalog.py is a TRUE no-op. The CI drift
+    # gate (catalog.yml) compares the regenerated file byte-for-byte; a live
+    # `dt.date.today()` stamp made every PR fail on any day other than the one
+    # the catalog was last committed. Bump the date only when skills change.
+    generated_at = dt.date.today().isoformat()
+    if CATALOG.exists():
+        try:
+            prev = json.loads(CATALOG.read_text())
+            if prev.get("schema_version") == 1 and prev.get("skills") == skills:
+                generated_at = prev.get("generated_at", generated_at)
+        except Exception:
+            pass
+
     catalog = {
         "schema_version": 1,
-        "generated_at": dt.date.today().isoformat(),
+        "generated_at": generated_at,
         "skills": skills,
     }
     CATALOG.write_text(json.dumps(catalog, indent=2) + "\n")

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -6,7 +6,9 @@
 # markdown links, release contract, catalog idempotency, release matrix sanity,
 # install dry-run resolves cleanly.
 # Best-effort gates (warn if the tool is absent locally; CI installs them):
-# shell linting, secret scanning, and workflow linting.
+# shell linting, secret scanning, workflow linting, and plugin manifest
+# validation (`claude plugin validate --strict` for the marketplace + each skill;
+# hard-fails when the claude CLI is present).
 #
 # Run locally:  bash tools/maintainer/verify_all.sh
 # Exit code is non-zero if any hard gate fails.
@@ -36,6 +38,18 @@ if run python3 tools/maintainer/check_md_links.py;        then pass "markdown li
 if run python3 tools/maintainer/check_release_contract.py; then pass "release contract";   else fail "release contract";    fi
 if run python3 tools/maintainer/check_social_assets.py;   then pass "social assets";       else fail "social assets";       fi
 if run bash    tools/maintainer/ci_guards.sh;             then pass "repo hygiene guards"; else fail "repo hygiene guards"; fi
+
+echo "== Plugin manifest validation (claude plugin validate --strict) =="
+if command -v claude >/dev/null 2>&1; then
+  if run claude plugin validate . --strict; then pass "marketplace manifest"; else fail "marketplace manifest"; fi
+  for d in skills/*/; do
+    slug="$(basename "$d")"
+    [ -f "$d/.claude-plugin/plugin.json" ] || continue
+    if run claude plugin validate "skills/$slug" --strict; then pass "plugin $slug"; else fail "plugin $slug"; fi
+  done
+else
+  warn "claude CLI not installed - skipped plugin validate (install Claude Code to run it)"
+fi
 
 echo "== Release matrix sanity =="
 if python3 tools/maintainer/release_matrix.py | python3 -c 'import json,sys; m=json.load(sys.stdin); assert m["skill"] and m["target"]' 2>/tmp/va.out; then


### PR DESCRIPTION
## Why
Unblock submitting **halopsa** + **servosity** to the Anthropic plugin directory (`clau.de/plugin-directory-submission`) and the other human-form marketplaces, and add a CI gate that catches plugin-manifest schema violations before submission.

## Changes
- **plugin.json** (both skills): drop the `vendor` field — it fails `claude plugin validate --strict` ("unknown field"). Vendor display name stays in SKILL.md frontmatter.
- **server.json**: fix the `.mcpb` download URL tag prefix (`<slug>-mcp-v<v>` → `<slug>-v<v>`) so it resolves against the real release tag.
- **README**: lead with the one-click `.mcpb` download + Claude Code plugin install (works before directory approval); add an **Upgrade** section.
- **CHANGELOG.md** (new, both skills): the Anthropic pre-submit checklist requires one whose top entry matches the manifest version.
- **verify_all.sh**: add `claude plugin validate --strict` for the marketplace manifest + each skill (warns if the `claude` CLI is absent, hard-fails if present).
- **build-catalog.py**: preserve `generated_at` when skills content is unchanged → re-running is a true no-op. The live date stamp made `catalog.yml` fail on any day other than the last catalog commit (pre-existing bug).

## Verification
- `claude plugin validate . --strict` + per-skill → all pass.
- `tools/maintainer/verify_all.sh` → all hard gates green (incl. the new validate gate + catalog idempotency).
- `submit-to-marketplaces --dry-run` lists halopsa + servosity for all 3 marketplaces.

Generator-side fixes (so future skills come out correct) live in the `msp-skills-publish` + `social-preview-generator` skills; this PR carries the back-patched output for the two already-shipped skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guides and upgrade instructions to HaloPSA and Servosity READMEs, including Claude Desktop one-click setup paths.
  * Added CHANGELOG entries for both HaloPSA and Servosity with initial release notes documenting available features.

* **Bug Fixes**
  * Corrected package download URLs in server configurations for HaloPSA and Servosity to reference correct release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->