### PR TITLE
fix(ci): correct mcp-publisher download URL (tarball, not bare binary)

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -145,7 +145,11 @@ jobs:
       - name: Install mcp-publisher
         run: |
           set -euo pipefail
-          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher-linux-amd64 -o mcp-publisher
+          # Upstream ships a tarball (mcp-publisher_<os>_<arch>.tar.gz), not a bare
+          # binary. The old mcp-publisher-linux-amd64 URL 404'd, failing every
+          # registry publish (the .mcpb build + GH release still succeeded).
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz -o mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
           ./mcp-publisher --version
 


### PR DESCRIPTION
## Why
`mcp-publish.yml`'s **Install mcp-publisher** step fetched `releases/latest/download/mcp-publisher-linux-amd64` → **404** (upstream `modelcontextprotocol/registry` ships `mcp-publisher_<os>_<arch>.tar.gz`, not a bare binary). Every registry publish failed there — including on `halopsa-v0.1.1`.

The `.mcpb` build + GitHub release steps run *before* this, so bundles/releases were fine; only the **official MCP Registry fan-out** (PulseMCP / Glama / mcp.so / Smithery / **LobeHub**) was broken.

## Fix
Download + extract the tarball (`mcp-publisher_linux_amd64.tar.gz` → `mcp-publisher`). Verified the linux/amd64 tarball contains the binary at root.

## Verification
Tested the URL + tarball layout locally (`tar -tzf` → `LICENSE  README.md  mcp-publisher`). The publish path itself runs only on a `<slug>-v*` tag push, so it's exercised the next time a release tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)