### PR TITLE
fix(registry): trim server.json description to <=100 chars

### DIFF
--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.servosity/halopsa-mcp",
   "title": "HaloPSA MCP",
-  "description": "Add HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local SQLite mirror so cross-entity queries the live HaloPSA API can't return in one shot are fast and offline. For MSP owners.",
+  "description": "HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics for any MCP agent.",
   "version": "0.1.1",
   "icons": [
     {

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.servosity/servosity-mcp",
   "title": "Servosity MCP",
-  "description": "Add fleet-wide backup triage, stale-backup detection, and cross-engine analytics to Claude, ChatGPT, Codex, or any AI that speaks MCP. Local fleet mirror with snapshot history so the partner portal's per-page views become one query. For MSP partners.",
+  "description": "Fleet-wide backup triage, stale-backup detection, and cross-engine analytics for any MCP agent.",
   "version": "0.1.1",
   "icons": [
     {


### PR DESCRIPTION
## Why
`mcp-publisher publish` returns **HTTP 422 "expected length <= 100"** on `body.description`. halopsa/servosity server.json carried the full ~250-char marketing copy, so the official-registry publish failed validation on every release (the install-URL fix in #9 was what let it finally reach this step and surface the real error).

## Fix
- `skills/{halopsa,servosity}/server.json`: concise ≤100-char registry taglines (92 / 95 chars). The long marketing copy stays in `plugin.json` (Anthropic detail page) — unaffected.
- `msp-skills-publish/onboard.py` (`render_server_json`): caps future skills' descriptions at 100 chars (word-boundary trim; prefers a manifest `short_description`).

## Impact
Unblocks the official MCP Registry publish → the fan-out (PulseMCP / Glama / mcp.so / Smithery / **LobeHub**). Does not affect the Anthropic / MCP Market human-form submissions (already working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)