### PR TITLE
fix(registry): use canonical-case io.github.Servosity namespace

### DIFF
--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.servosity/halopsa-mcp",
+  "name": "io.github.Servosity/halopsa-mcp",
   "title": "HaloPSA MCP",
   "description": "HaloPSA ticket triage, SLA-breach pre-emption, and cross-client analytics for any MCP agent.",
   "version": "0.1.1",

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.servosity/servosity-mcp",
+  "name": "io.github.Servosity/servosity-mcp",
   "title": "Servosity MCP",
   "description": "Fleet-wide backup triage, stale-backup detection, and cross-engine analytics for any MCP agent.",
   "version": "0.1.1",


### PR DESCRIPTION
## Why
`mcp-publisher publish` returned **403 Forbidden**: `You have permission to publish: io.github.Servosity/*. Attempting to publish: io.github.servosity/halopsa-mcp.` The official MCP Registry namespace is **case-sensitive** and must match GitHub's canonical org slug (`Servosity`, uppercase S). server.json declared lowercase.

This was the last layer behind two earlier publish bugs (#9 install URL, #10 description length) — the OIDC grant for `io.github.Servosity/*` is already in place, so casing was all that remained.

## Fix
- `skills/{halopsa,servosity}/server.json` `name` → `io.github.Servosity/<bin>`.
- Generator `onboard.py` (`render_server_json`) + `submit-to-marketplaces` LobeHub registry-URL + reference docs updated to the uppercase namespace.

(github.com URLs in the same files stay lowercase — they redirect; only the registry namespace is case-sensitive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration identifiers across multiple services to correct capitalization formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->