### PR TITLE
fix(registry): mcpb package identifier must be the .mcpb download URL

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -122,7 +122,7 @@ jobs:
           cd mcpb-build
           gh release upload "$TAG" "${SKILL}-mcp.mcpb" --clobber
 
-      - name: Patch server.json with SHA + version + download URL
+      - name: Patch server.json with SHA + version + identifier URL
         env:
           SKILL: ${{ needs.detect.outputs.skill }}
           VERSION: ${{ needs.detect.outputs.version }}
@@ -132,12 +132,15 @@ jobs:
           set -euo pipefail
           src=skills/$SKILL/server.json
           out=mcpb-build/server.json
-          download="https://github.com/${{ github.repository }}/releases/download/${TAG}/${SKILL}-mcp.mcpb"
+          # For registryType "mcpb" the registry reads the host from `identifier`,
+          # which MUST be the full .mcpb download URL (a bare name -> 400 "Host ''").
+          # There is no separate `download` field in the mcpb package schema.
+          identifier="https://github.com/${{ github.repository }}/releases/download/${TAG}/${SKILL}-mcp.mcpb"
           jq \
             --arg version "$VERSION" \
             --arg sha "$SHA" \
-            --arg download "$download" \
-            '.version = $version | .packages[0].version = $version | .packages[0].fileSha256 = $sha | .packages[0].download = $download' \
+            --arg identifier "$identifier" \
+            '.version = $version | .packages[0].version = $version | .packages[0].fileSha256 = $sha | .packages[0].identifier = $identifier | del(.packages[0].download)' \
             "$src" > "$out"
           echo "--- patched server.json ---"
           cat "$out"

--- a/skills/halopsa/server.json
+++ b/skills/halopsa/server.json
@@ -21,9 +21,8 @@
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "halopsa-mcp",
+      "identifier": "https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.1/halopsa-mcp.mcpb",
       "version": "0.1.1",
-      "download": "https://github.com/servosity/msp-skills/releases/download/halopsa-v0.1.1/halopsa-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"

--- a/skills/servosity/server.json
+++ b/skills/servosity/server.json
@@ -21,9 +21,8 @@
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "servosity-mcp",
+      "identifier": "https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.1/servosity-mcp.mcpb",
       "version": "0.1.1",
-      "download": "https://github.com/servosity/msp-skills/releases/download/servosity-v0.1.1/servosity-mcp.mcpb",
       "fileSha256": "PLACEHOLDER_SHA256_FILLED_BY_CI",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Why
`mcp-publisher publish` returned **400**: *"MCPB packages must be hosted on allowlisted providers (GitHub or GitLab). Host '' is not allowed."* For `registryType: "mcpb"` the registry derives the host from **`identifier`**, which must be the full GitHub-release `.mcpb` URL. Ours was `identifier: "<slug>-mcp"` (no host) plus a separate `download` field the registry doesn't read.

Confirmed against the official spec ([generic-server-json.md](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md)): an mcpb package is `{ registryType, identifier: <download-url>, fileSha256, transport }` — no `download`/`registryBaseUrl`.

This is the last layer behind #9 (install URL), #10 (description length), #11 (namespace case).

## Fix
- `skills/{halopsa,servosity}/server.json`: `identifier` = the `.mcpb` URL; remove `download`.
- `mcp-publish.yml` patch step: set `packages[0].identifier` (was `.download`) + `del(.download)`.
- `onboard.py` (`render_server_json`): generate `identifier` as the URL for future skills.
- `submit-to-marketplaces` MCP Market field + reference doc read `.identifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)