### PR TITLE
docs: rich per-agent mcp-install + integration guides

### DIFF
--- a/docs/integrations/gemini.md
+++ b/docs/integrations/gemini.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Google Gemini (Gemini CLI + app)"
+description: "Use HaloPSA and Servosity in Google Gemini via MCP. Gemini CLI is local and self-serve; the Gemini app is remote (HTTPS). Step-by-step for both. Free MSP Skills, runs on your machine."
+permalink: /integrations/gemini/
+faqs:
+  - q: "Does Google Gemini support HaloPSA?"
+    a: "Yes, via MSP Skills' free HaloPSA MCP server. Gemini CLI runs it locally (add an mcpServers block to ~/.gemini/settings.json). The Gemini app connects to it over HTTPS, like ChatGPT."
+  - q: "Does Gemini support MCP?"
+    a: "Yes. Google's Gemini API, SDK, and CLI all speak MCP as of early-mid 2026. Gemini CLI runs local stdio MCP servers directly; the Gemini app uses remote HTTPS endpoints."
+  - q: "What's the difference between Gemini CLI and the Gemini app for MCP?"
+    a: "Gemini CLI is local - it launches the MSP Skills binary on your machine, no hosting, just like Claude Code. The Gemini app does not launch local binaries, so you host the MCP server over HTTPS and connect that URL, like ChatGPT's Developer Mode."
+---
+
+# HaloPSA and Servosity in Google Gemini
+
+Google's Gemini comes in two shapes that consume MCP differently. Pick the one you have.
+
+- **Gemini CLI** - local, self-serve, no hosting. Like Claude Code. **Start here if you can.**
+- **Gemini app / web** - remote-only. You host the MCP server over HTTPS, like ChatGPT.
+
+## What you need
+
+- **Gemini CLI** installed (for the local path) **or** a **Gemini app** account (for the remote path)
+- A **HaloPSA tenant + OAuth credentials** **or** a **Servosity MSP partner API token** - or both
+- A terminal once for install
+
+## Step 1 - Install MSP Skills binaries
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+## Gemini CLI (local - recommended)
+
+Edit `~/.gemini/settings.json` (or the path `gemini config path` prints) and add an `mcpServers` block - the same shape as Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_TENANT": "<your-tenant>",
+        "HALOPSA_CLIENT_ID": "<your-client-id>",
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+      }
+    },
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
+      }
+    }
+  }
+}
+```
+
+Restart Gemini CLI. Its tool list now includes the MSP Skills tools. Ask:
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+
+## Gemini app / web (remote)
+
+The Gemini app doesn't launch a local binary. Host the MCP server over HTTPS first:
+
+```bash
+HALOPSA_TENANT=<tenant> HALOPSA_CLIENT_ID=<id> HALOPSA_CLIENT_SECRET=<secret> \
+  halopsa-mcp --transport http --addr :7777
+```
+
+Expose `http://localhost:7777` as a public **HTTPS** URL via a secure tunnel (Cloudflare Tunnel, ngrok), then connect that endpoint in the Gemini app. Treat the URL as a credential. This is the same pattern as the [ChatGPT integration](/integrations/chatgpt/) - if you want a no-hosting path on Google, use Gemini CLI above instead.
+
+## Troubleshooting
+
+**Gemini CLI doesn't see the tools:** check the JSON in `~/.gemini/settings.json` (trailing commas, escaped backslashes on Windows) and restart. Confirm `halopsa-cli doctor` works first.
+
+**"command not found":** the binary isn't on your PATH - the installer prints the line to add.
+
+## What's next
+
+- **Try a real workflow** at a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Prefer a desktop chat app?** [Claude Desktop](/integrations/claude-desktop/) is the simplest local MCP host.
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Hermes (Nous Research)"
+description: "Install MSP Skills (HaloPSA tickets + Servosity backups) in Hermes, Nous Research's autonomous agent. Two paths: native Skill install or MCP server. Free, open source."
+permalink: /integrations/hermes/
+faqs:
+  - q: "Does Hermes support HaloPSA?"
+    a: "Yes. Hermes is Nous Research's autonomous agent. It speaks MCP natively and reads Claude-Code-compatible SKILL.md skills, so it runs MSP Skills' HaloPSA connector two ways - as a Skill install or as an MCP server."
+  - q: "How do I install MSP Skills in Hermes?"
+    a: "Either run 'hermes skills install Servosity/msp-skills/skills/halopsa --force' to install the Skill, or register the halopsa-mcp binary as an MCP server with 'hermes mcp add'. Both use the same HaloPSA / Servosity credentials."
+  - q: "Is the Hermes install fully tested?"
+    a: "The SKILL.md frontmatter and install sections ship today, and the MCP path is the reliable route. End-to-end Skill install from a monorepo subdirectory path is still being dogfooded upstream - if the Skill path fails, use the MCP path."
+---
+
+# HaloPSA and Servosity in Hermes
+
+[Hermes](https://hermes-agent.nousresearch.com) is Nous Research's autonomous research agent. It's one of two skill-native agents (besides Claude) that read MSP Skills' `SKILL.md` directly **and** speak MCP - so you have two install paths.
+
+## What you need
+
+- **Hermes** installed (see [Nous Research docs](https://hermes-agent.nousresearch.com/docs))
+- A **HaloPSA tenant + OAuth credentials** **or** a **Servosity MSP partner API token**
+- A terminal once for install
+
+## Step 1 - Install MSP Skills binaries
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+## Path A - install as a Skill (uses the cli-printing-press template)
+
+From the Hermes CLI:
+
+```bash
+hermes skills install Servosity/msp-skills/skills/halopsa --force
+hermes skills install Servosity/msp-skills/skills/servosity --force
+```
+
+Or inside a Hermes chat session:
+
+```
+/skills install Servosity/msp-skills/skills/halopsa --force
+```
+
+## Path B - register as an MCP server (most reliable)
+
+Hermes speaks MCP natively, so it can use the binaries directly:
+
+```bash
+hermes mcp add halopsa -- halopsa-mcp
+hermes mcp add servosity -- servosity-mcp
+```
+
+Set the same env vars the CLI needs (`HALOPSA_TENANT` / `HALOPSA_CLIENT_ID` / `HALOPSA_CLIENT_SECRET`, `SERVOSITY_MSP_TOKEN`).
+
+## Step 3 - Ask a real question
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+
+## Honest status
+
+The cli-printing-press frontmatter + README install sections ship today, and the **MCP path (B) is the reliable route**. End-to-end Skill install from a non-canonical monorepo subdirectory (`Servosity/msp-skills/...`) has not been fully verified upstream - if Path A doesn't resolve, use Path B.
+
+## What's next
+
+- **Try a real workflow** at a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Full per-tool wire-up:** [Which AI agent?](/which-agent/)
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/microsoft-365-copilot.md
+++ b/docs/integrations/microsoft-365-copilot.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: "HaloPSA + Servosity in Microsoft 365 Copilot / Copilot Studio"
+description: "How to use HaloPSA and Servosity in Microsoft 365 Copilot and Copilot Studio via MCP. Honest guide: remote Streamable-HTTP only, needs hosting + a Copilot Studio license + tenant admin. Free MSP Skills."
+permalink: /integrations/microsoft-365-copilot/
+faqs:
+  - q: "Does Microsoft 365 Copilot support HaloPSA?"
+    a: "Yes, but only via the remote path. Microsoft 365 Copilot and Copilot Studio consume MCP over remote Streamable-HTTP - they do not launch local binaries. You host MSP Skills' HaloPSA MCP server over HTTPS and wire it in through Copilot Studio or a declarative agent. A Copilot Studio license and tenant admin are required."
+  - q: "Does Microsoft Copilot support MCP?"
+    a: "It depends which Copilot. GitHub Copilot (VS Code) runs local MCP servers today. Microsoft 365 Copilot, Copilot Studio, and Security Copilot support MCP over remote HTTPS only. The free consumer Copilot (copilot.microsoft.com, Windows Copilot) does not support custom MCP servers at all."
+  - q: "Can I point Microsoft 365 Copilot at a local MCP binary?"
+    a: "No. There is no local-stdio path anywhere in the Microsoft 365 Copilot family. You must host the MCP server as a public HTTPS (Streamable-HTTP) endpoint first, then connect it via Copilot Studio (Server URL) or the Microsoft 365 Agents Toolkit."
+  - q: "What's the easiest Microsoft path to use HaloPSA with AI?"
+    a: "GitHub Copilot in VS Code - it runs MSP Skills' local binary today with no hosting or license. Microsoft 365 Copilot is the broader business assistant but requires hosting, a Copilot Studio license, and tenant admin, so it is not self-serve."
+---
+
+# HaloPSA and Servosity in Microsoft 365 Copilot / Copilot Studio
+
+Microsoft 365 Copilot is the Copilot most MSPs and their clients actually have - it's bundled into the Microsoft 365 stack you already resell. So it's worth knowing exactly how MSP Skills connects to it.
+
+**Honest heads-up first.** Microsoft 365 Copilot, Copilot Studio, and Security Copilot consume MCP over **remote Streamable-HTTP only**. There is **no local-stdio path** - the `halopsa-mcp` / `servosity-mcp` binary you install on your laptop is not enough on its own. You also need a **Copilot Studio license** and a **tenant admin** to enable it. This is a build-and-host task, not a 60-second install.
+
+**If that's a blocker:** [GitHub Copilot in VS Code](/integrations/github-copilot/) is the Microsoft surface that runs the local binary today, free, no hosting. Use it if you just want MSP Skills working inside a Microsoft tool quickly.
+
+## What you need
+
+- A **Microsoft 365 Copilot** license, plus a **Copilot Studio** license (for the low-code route)
+- **Tenant admin** access (to enable Copilot extensibility / custom app upload)
+- A place to **host** the MCP server over HTTPS (a small VM, container, or tunnel)
+- A **HaloPSA tenant + OAuth credentials** **or** a **Servosity MSP partner API token**
+
+## Step 1 - Install MSP Skills binaries
+
+**macOS / Linux:**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.ps1 | iex
+```
+
+## Step 2 - Host the MCP server over HTTPS
+
+The MSP Skills binaries serve the Streamable-HTTP transport Copilot expects. Run in HTTP mode with credentials in the environment:
+
+```bash
+HALOPSA_TENANT=<tenant> \
+HALOPSA_CLIENT_ID=<id> \
+HALOPSA_CLIENT_SECRET=<secret> \
+halopsa-mcp --transport http --addr :7777
+```
+
+Then expose `http://localhost:7777` as a public **HTTPS** URL via Cloudflare Tunnel, ngrok (HTTPS), or your own reverse proxy. (Repeat for `servosity-mcp` on another port.) **Treat the URL as a credential** - gate it behind SSO / Cloudflare Access; never expose it bare on the internet.
+
+For team / production use, host MSP Skills on a server inside your network and front it with an SSO-gated tunnel so only authenticated users reach it.
+
+## Step 3a - Wire it in Copilot Studio (lowest-code)
+
+In your Copilot Studio agent:
+
+1. Open **Tools → Add a tool → Model Context Protocol**.
+2. Enter a **Server name**, the **Server URL** (your HTTPS endpoint), and auth (**OAuth 2.0** or **API key**).
+3. Copilot Studio builds the Power Platform custom connector behind the scenes. **Generative orchestration must be on.**
+4. Publish the agent into Microsoft 365 Copilot.
+
+Source: [Microsoft Learn - Extend your agent with MCP](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp).
+
+## Step 3b - Or build a declarative agent (dev-ish)
+
+Use the **Microsoft 365 Agents Toolkit** in VS Code: **Add an Action → Start with an MCP Server**, point at the remote URL, configure OAuth, then provision / sideload. Requires admin-enabled **Custom App Upload** + **Copilot Access**.
+
+Source: [Microsoft Learn - Build MCP plugins for Microsoft 365 Copilot](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/build-mcp-plugins).
+
+## Step 4 - Ask a real question
+
+Once published, in Microsoft 365 Copilot:
+
+- *"Use the HaloPSA agent: triage what needs attention across all clients today."*
+- *"Use the Servosity agent: show me stale backups this week."*
+
+## Cost
+
+- **MSP Skills:** Free (Apache-2.0).
+- **Microsoft 365 Copilot + Copilot Studio:** your Microsoft licensing (see Microsoft's pricing).
+- **Hosting:** Cloudflare Tunnel is free; a small VM/container is a few dollars a month.
+- **HaloPSA / Servosity access:** your existing license / partner agreement.
+
+## Security
+
+- The HTTPS endpoint is a key to your MCP server. Authenticate it (OAuth 2.0) and gate it behind SSO.
+- HaloPSA + Servosity credentials live in the host's environment, never transmitted to MSP Skills or to Microsoft.
+- Apply your tenant's DLP / VNet governance to the connector.
+
+## Note: free / consumer Copilot
+
+The free consumer Copilot (copilot.microsoft.com, Windows Copilot) does **not** support user-supplied MCP servers. There is no MSP Skills path for it.
+
+## What's next
+
+- **Want it working today without hosting?** Use [GitHub Copilot](/integrations/github-copilot/) or [Claude Desktop](/integrations/claude-desktop/).
+- **Bring it to a Build Session.** Work your tenant + your hardest cross-client question live with the MSP cohort: [Build Sessions](https://compoundingteams.com/build-sessions).
+
+[← Back to main install](/#install-in-60-seconds)

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: "HaloPSA + Servosity in OpenClaw"
+description: "Install MSP Skills (HaloPSA tickets + Servosity backups) in OpenClaw, the browser-controlled AI agent with native Skill + MCP support. Free, open source."
+permalink: /integrations/openclaw/
+faqs:
+  - q: "Does OpenClaw support HaloPSA?"
+    a: "Yes. OpenClaw has native Skill support (a SKILL.md superset of Anthropic's spec) and native MCP, so it runs MSP Skills' HaloPSA connector either as a Skill or as an MCP server."
+  - q: "How do I install MSP Skills in OpenClaw?"
+    a: "Run 'openclaw skills install git:Servosity/msp-skills/skills/halopsa@main' to install the Skill, or register the binary with 'openclaw mcp set halopsa'. OpenClaw reads the skill's openclaw frontmatter and installs the required CLI; run 'openclaw doctor' to confirm."
+  - q: "Is OpenClaw generally available?"
+    a: "OpenClaw is GA as of May 2026 with a public skill registry (ClawHub). The MSP Skills frontmatter is pre-wired; if the monorepo subdirectory git: path doesn't resolve in your build, clone the repo locally and install from the path."
+---
+
+# HaloPSA and Servosity in OpenClaw
+
+[OpenClaw](https://docs.openclaw.ai) is a browser-controlled AI agent with native Skill support (a `SKILL.md` superset of Anthropic's spec) and native MCP. Like Hermes, it's skill-native - it reads MSP Skills' `SKILL.md` directly **and** speaks MCP.
+
+## What you need
+
+- **OpenClaw** installed ([install docs](https://docs.openclaw.ai/install))
+- A **HaloPSA tenant + OAuth credentials** **or** a **Servosity MSP partner API token**
+
+## Step 1 - Install OpenClaw (one time)
+
+```bash
+# macOS / Linux / WSL2
+curl -fsSL https://openclaw.ai/install.sh | bash
+
+# Windows (PowerShell)
+iwr -useb https://openclaw.ai/install.ps1 | iex
+```
+
+## Path A - install as a Skill (recommended)
+
+```bash
+openclaw skills install git:Servosity/msp-skills/skills/halopsa@main
+openclaw skills install git:Servosity/msp-skills/skills/servosity@main
+```
+
+OpenClaw reads each skill's `SKILL.md`, sees the `metadata.openclaw.requires.bins` block (already in the frontmatter), and installs the required CLI. Confirm with:
+
+```bash
+openclaw doctor
+```
+
+## Path B - register as an MCP server
+
+```bash
+openclaw mcp set halopsa '{"command":"halopsa-mcp"}'
+openclaw mcp set servosity '{"command":"servosity-mcp"}'
+```
+
+Set the same env vars the CLI needs. See the [OpenClaw MCP CLI docs](https://docs.openclaw.ai/cli/mcp) for the canonical command shape.
+
+## Step 2 - Ask a real question
+
+- *"Use halopsa: triage what needs attention across all clients today."*
+- *"Use servosity: show me stale backups across all clients this week."*
+
+## Note on the subdirectory install path
+
+OpenClaw's monorepo subdirectory `git:` syntax is documented in the ClawHub skill-format spec. If `git:Servosity/msp-skills/skills/halopsa@main` doesn't resolve in your build, clone the repo locally and run:
+
+```bash
+openclaw skills install ./msp-skills/skills/halopsa
+```
+
+## What's next
+
+- **Try a real workflow** at a free [Build Session](https://compoundingteams.com/build-sessions).
+- **Full per-tool wire-up:** [Which AI agent?](/which-agent/)
+
+[← Back to main install](/#install-in-60-seconds)

--- a/skills/halopsa/mcp-install.md
+++ b/skills/halopsa/mcp-install.md
@@ -1,30 +1,26 @@
-# HaloPSA MCP - install for Claude Desktop and ChatGPT Desktop
+# HaloPSA MCP - install for every agent that speaks MCP
 
-> Unofficial. Community-built MCP server for the HaloPSA, HaloITSM, and HaloCRM
-> APIs. Not affiliated with, endorsed by, or sponsored by Halo Service
-> Solutions Ltd.
+This page wires the HaloPSA MCP server into any MCP client. If you use Claude
+Code, Codex CLI, or Cowork, install the Skill instead (see [README.md](./README.md)) -
+it's simpler. Everyone else: pick your agent below.
 
-This page is for users who want the HaloPSA MCP server in a desktop AI like Claude Desktop or ChatGPT Desktop. If you use Claude Code or Codex CLI, install the Skill instead (see [README.md](./README.md)).
+**Two install classes.** *Local* agents (Claude Desktop, GitHub Copilot, Gemini CLI)
+launch `halopsa-mcp` directly on your machine - no hosting. *Remote* agents (ChatGPT,
+Microsoft 365 Copilot / Copilot Studio, the Gemini app) only talk to an HTTPS
+endpoint, so you expose `halopsa-mcp` over HTTPS first.
 
 ## Prerequisite: install the MCP binary
 
-Run the install command from [README.md](./README.md). It drops both `halopsa-cli` and `halopsa-mcp` on your PATH. `halopsa-mcp` is what the desktop agents talk to.
-
-Verify:
+Run the install command from [README.md](./README.md). It drops both `halopsa-cli`
+and `halopsa-mcp` on your PATH. `halopsa-mcp` is what the agents talk to.
 
 ```bash
 halopsa-mcp --help
 ```
 
-## Get HaloPSA API credentials
+---
 
-You need three values from your HaloPSA tenant:
-
-- `HALOPSA_TENANT` - your tenant subdomain (the `acme` part of `acme.halopsa.com`)
-- `HALOPSA_CLIENT_ID` - from Configuration > Integrations > Halo PSA API
-- `HALOPSA_CLIENT_SECRET` - generated alongside the client ID
-
-In your Halo tenant: Configuration > Integrations > Halo PSA API > New Application. Authentication Method: Client ID and Secret (Services). Save the client ID and secret somewhere safe before you leave the page; Halo will not show the secret again.
+# Local agents (launch the binary directly)
 
 ## Claude Desktop
 
@@ -41,44 +37,151 @@ Add (or merge with your existing `mcpServers` block):
     "halopsa": {
       "command": "halopsa-mcp",
       "env": {
-        "HALOPSA_TENANT": "<your-tenant>",
-        "HALOPSA_CLIENT_ID": "<your-client-id>",
-        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+        "HALOPSA_CLIENT_ID": "<your-halopsa_client_id>",
+        "HALOPSA_CLIENT_SECRET": "<your-halopsa_client_secret>",
+        "HALOPSA_DOMAIN": "<your-halopsa_domain>",
+        "HALOPSA_TENANT": "<your-halopsa_tenant>",
+        "HALOPSA_TOKEN": "<your-halopsa_token>"
       }
     }
   }
 }
 ```
 
-Quit Claude Desktop completely (Command-Q on macOS, right-click in tray on Windows) and reopen. Ask: "List my open HaloPSA tickets" - if the MCP is wired, Claude will use it.
+Quit Claude Desktop completely and reopen, then ask a question that needs the API.
+
+## GitHub Copilot (VS Code)
+
+GitHub Copilot supports MCP in **Agent mode** (GA since VS Code 1.102, July 2025).
+Two gotchas trip people up: the config file is `mcp.json` (not `settings.json`), and
+the root key is **`servers`** (not `mcpServers` like Claude).
+
+Create `.mcp.json` in your workspace (or open the Command Palette > **MCP: Open User
+Configuration**) and add:
+
+```json
+{
+  "servers": {
+    "halopsa": {
+      "type": "stdio",
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_CLIENT_ID": "<your-halopsa_client_id>",
+        "HALOPSA_CLIENT_SECRET": "<your-halopsa_client_secret>",
+        "HALOPSA_DOMAIN": "<your-halopsa_domain>",
+        "HALOPSA_TENANT": "<your-halopsa_tenant>",
+        "HALOPSA_TOKEN": "<your-halopsa_token>"
+      }
+    }
+  }
+}
+```
+
+Then open Copilot Chat and switch the mode dropdown to **Agent** - MCP tools are
+invisible in Ask/Edit mode.
+
+## Gemini CLI (Google)
+
+Edit `~/.gemini/settings.json` (Gemini CLI's config) and add the same shape as
+Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "halopsa": {
+      "command": "halopsa-mcp",
+      "env": {
+        "HALOPSA_CLIENT_ID": "<your-halopsa_client_id>",
+        "HALOPSA_CLIENT_SECRET": "<your-halopsa_client_secret>",
+        "HALOPSA_DOMAIN": "<your-halopsa_domain>",
+        "HALOPSA_TENANT": "<your-halopsa_tenant>",
+        "HALOPSA_TOKEN": "<your-halopsa_token>"
+      }
+    }
+  }
+}
+```
+
+Restart Gemini CLI; the HaloPSA tools appear in its tool list. (The **Gemini app /
+web** is remote-only - see the remote section below.)
+
+---
+
+# Remote agents (expose the binary over HTTPS first)
+
+All remote agents need `halopsa-mcp` reachable as a public **HTTPS** endpoint. Run it
+in HTTP mode with your credentials in the environment:
+
+```bash
+HALOPSA_CLIENT_ID=<value> HALOPSA_CLIENT_SECRET=<value> HALOPSA_DOMAIN=<value> HALOPSA_TENANT=<value> HALOPSA_TOKEN=<value> halopsa-mcp --transport http --addr :7777
+```
+
+Then expose `http://localhost:7777` as a public HTTPS URL via a secure tunnel
+(Cloudflare Tunnel, ngrok) or your own reverse proxy. **Treat that URL as
+sensitive** - it's a key to your MCP server. Never expose it bare on the internet;
+gate it behind SSO / Cloudflare Access for team use.
 
 ## ChatGPT (Developer Mode)
 
-ChatGPT connects to MCP servers differently than Claude Desktop. It does **not** launch a local binary - it connects to a **remote MCP server over HTTPS** through Developer Mode (beta; on Pro, Plus, Business, Enterprise, and Education plans). So this is not the same one-liner as Claude Desktop.
+In ChatGPT (Pro, Plus, Team, Business, Enterprise, or Education - **not** Free):
+Settings > Apps > Advanced > **Developer mode**, then create a custom connector
+pointing at your tunnel's HTTPS URL.
 
-The `halopsa-mcp` binary can serve the streamable-HTTP transport ChatGPT expects, so the path is:
+Official OpenAI guidance (beta, plan-dependent): https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta
 
-1. Run the MCP server in HTTP mode with your credentials in the environment:
+## Microsoft 365 Copilot / Copilot Studio
 
-   ```bash
-   HALOPSA_TENANT=<your-tenant> \
-   HALOPSA_CLIENT_ID=<your-client-id> \
-   HALOPSA_CLIENT_SECRET=<your-client-secret> \
-   halopsa-mcp --transport http --addr :7777
-   ```
+**Honest heads-up:** there is no local path. Microsoft 365 Copilot, Copilot Studio,
+and Security Copilot all consume MCP over **remote Streamable-HTTP only** - the local
+`halopsa-mcp` you installed is not enough on its own. You also need a **Copilot Studio
+license** and a **tenant admin** to enable it. This is a build-and-host task, not a
+self-serve install.
 
-2. Expose `http://localhost:7777` as a public **HTTPS** URL with a secure tunnel (for example Cloudflare Tunnel or ngrok). Treat that URL as sensitive: anyone who reaches it can drive your Halo tenant.
-3. In ChatGPT: Settings > Apps > Advanced > Developer mode, then create a custom connector pointing at your tunnel's HTTPS URL.
+Once `halopsa-mcp` is hosted over HTTPS (above), the lowest-code route:
 
-Official OpenAI guidance (beta, plan-dependent, subject to change): https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta
+1. In **Copilot Studio**, open your agent > **Tools** > **Add a tool** > **Model
+   Context Protocol**.
+2. Enter a **Server name**, the **Server URL** (your HTTPS endpoint), and auth
+   (OAuth 2.0 or API key). Copilot Studio builds the Power Platform connector behind
+   the scenes; generative orchestration must be **on**.
+3. Publish the agent into Microsoft 365 Copilot.
 
-For the simplest path, use Claude Desktop (above) or the Claude Code / Codex Skill.
+Alternative (dev-ish): build a **declarative agent** with the Microsoft 365 Agents
+Toolkit in VS Code (**Add an Action > Start with an MCP Server**, point at the remote
+URL), then sideload - requires admin-enabled Custom App Upload + Copilot Access.
+
+Microsoft docs: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
+
+## Gemini app / web (Google)
+
+Same remote pattern as ChatGPT - point Gemini's connector at your hosted HTTPS
+endpoint. For a local, no-hosting path on Google, use **Gemini CLI** (above) instead.
+
+---
+
+# Skill-native agents
+
+[Hermes](https://hermes-agent.nousresearch.com) and OpenClaw read this skill's
+`SKILL.md` directly, and both also speak MCP. Register the server directly:
+
+```bash
+# Hermes (also supports `hermes skills install ...` - see README.md)
+hermes mcp add halopsa -- halopsa-mcp
+
+# OpenClaw
+openclaw mcp set halopsa '{"command":"halopsa-mcp"}'
+```
+
+Same env vars as the blocks above. For the Skill-install path (no MCP wiring), see
+the "Install for Hermes" / "Install for OpenClaw" sections in [README.md](./README.md).
+
+For the simplest path overall, use Claude Desktop or the Claude Code / Codex Skill.
 
 ## Troubleshooting
 
-- `halopsa-mcp: command not found` after install: the install dir is not on your PATH. The installer prints the line you need to add to your shell rc file (macOS / Linux) or sets the user PATH (Windows; open a new terminal after install).
-- Claude Desktop does not see the MCP after restart: the JSON config has a syntax error. Run it through a JSON linter, fix, save, restart.
-- `401 Unauthorized` from the MCP: client ID or secret is wrong, or your tenant has the API integration disabled. Recheck Configuration > Integrations > Halo PSA API.
-- Need to update credentials: change the env block in the JSON config and restart Claude Desktop. There is no credential cache outside the MCP process.
+- `halopsa-mcp: command not found`: the install dir is not on your PATH (the
+  installer prints the line to add).
+- Claude Desktop does not see the MCP after restart: the JSON config has a syntax
+  error. Validate it, fix, restart.
 
-For the full CLI command reference (everything the MCP also exposes as tools), see [guide.md](./guide.md).
+For the full CLI command reference, see [guide.md](./guide.md).

--- a/skills/servosity/mcp-install.md
+++ b/skills/servosity/mcp-install.md
@@ -1,20 +1,26 @@
-# Servosity MCP - install for Claude Desktop and ChatGPT Desktop
+# Servosity MCP - install for every agent that speaks MCP
 
-This page is for users who want the Servosity MCP server in a desktop AI like Claude Desktop or ChatGPT Desktop. If you use Claude Code or Codex CLI, install the Skill instead (see [README.md](./README.md)).
+This page wires the Servosity MCP server into any MCP client. If you use Claude
+Code, Codex CLI, or Cowork, install the Skill instead (see [README.md](./README.md)) -
+it's simpler. Everyone else: pick your agent below.
+
+**Two install classes.** *Local* agents (Claude Desktop, GitHub Copilot, Gemini CLI)
+launch `servosity-mcp` directly on your machine - no hosting. *Remote* agents (ChatGPT,
+Microsoft 365 Copilot / Copilot Studio, the Gemini app) only talk to an HTTPS
+endpoint, so you expose `servosity-mcp` over HTTPS first.
 
 ## Prerequisite: install the MCP binary
 
-Run the install command from [README.md](./README.md). It drops both `servosity-cli` and `servosity-mcp` on your PATH. `servosity-mcp` is what the desktop agents talk to.
-
-Verify:
+Run the install command from [README.md](./README.md). It drops both `servosity-cli`
+and `servosity-mcp` on your PATH. `servosity-mcp` is what the agents talk to.
 
 ```bash
 servosity-mcp --help
 ```
 
-## Get a Servosity partner API token
+---
 
-Log into the Servosity partner portal and generate a partner API token. Save it somewhere safe.
+# Local agents (launch the binary directly)
 
 ## Claude Desktop
 
@@ -31,39 +37,139 @@ Add (or merge with your existing `mcpServers` block):
     "servosity": {
       "command": "servosity-mcp",
       "env": {
-        "SERVOSITY_MSP_TOKEN": "<your-partner-token>"
+        "SERVOSITY_MSP_TOKEN": "<your-servosity_msp_token>"
       }
     }
   }
 }
 ```
 
-Quit Claude Desktop completely and reopen. Ask: "Show me stale backups across all my Servosity clients" - if the MCP is wired, Claude will use it.
+Quit Claude Desktop completely and reopen, then ask a question that needs the API.
+
+## GitHub Copilot (VS Code)
+
+GitHub Copilot supports MCP in **Agent mode** (GA since VS Code 1.102, July 2025).
+Two gotchas trip people up: the config file is `mcp.json` (not `settings.json`), and
+the root key is **`servers`** (not `mcpServers` like Claude).
+
+Create `.mcp.json` in your workspace (or open the Command Palette > **MCP: Open User
+Configuration**) and add:
+
+```json
+{
+  "servers": {
+    "servosity": {
+      "type": "stdio",
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-servosity_msp_token>"
+      }
+    }
+  }
+}
+```
+
+Then open Copilot Chat and switch the mode dropdown to **Agent** - MCP tools are
+invisible in Ask/Edit mode.
+
+## Gemini CLI (Google)
+
+Edit `~/.gemini/settings.json` (Gemini CLI's config) and add the same shape as
+Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "servosity": {
+      "command": "servosity-mcp",
+      "env": {
+        "SERVOSITY_MSP_TOKEN": "<your-servosity_msp_token>"
+      }
+    }
+  }
+}
+```
+
+Restart Gemini CLI; the Servosity tools appear in its tool list. (The **Gemini app /
+web** is remote-only - see the remote section below.)
+
+---
+
+# Remote agents (expose the binary over HTTPS first)
+
+All remote agents need `servosity-mcp` reachable as a public **HTTPS** endpoint. Run it
+in HTTP mode with your credentials in the environment:
+
+```bash
+SERVOSITY_MSP_TOKEN=<value> servosity-mcp --transport http --addr :7777
+```
+
+Then expose `http://localhost:7777` as a public HTTPS URL via a secure tunnel
+(Cloudflare Tunnel, ngrok) or your own reverse proxy. **Treat that URL as
+sensitive** - it's a key to your MCP server. Never expose it bare on the internet;
+gate it behind SSO / Cloudflare Access for team use.
 
 ## ChatGPT (Developer Mode)
 
-ChatGPT connects to MCP servers differently than Claude Desktop. It does **not** launch a local binary - it connects to a **remote MCP server over HTTPS** through Developer Mode (beta; on Pro, Plus, Business, Enterprise, and Education plans). So this is not the same one-liner as Claude Desktop.
+In ChatGPT (Pro, Plus, Team, Business, Enterprise, or Education - **not** Free):
+Settings > Apps > Advanced > **Developer mode**, then create a custom connector
+pointing at your tunnel's HTTPS URL.
 
-The `servosity-mcp` binary can serve the streamable-HTTP transport ChatGPT expects, so the path is:
+Official OpenAI guidance (beta, plan-dependent): https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta
 
-1. Run the MCP server in HTTP mode with your token in the environment:
+## Microsoft 365 Copilot / Copilot Studio
 
-   ```bash
-   SERVOSITY_MSP_TOKEN=<your-partner-token> servosity-mcp --transport http --addr :7777
-   ```
+**Honest heads-up:** there is no local path. Microsoft 365 Copilot, Copilot Studio,
+and Security Copilot all consume MCP over **remote Streamable-HTTP only** - the local
+`servosity-mcp` you installed is not enough on its own. You also need a **Copilot Studio
+license** and a **tenant admin** to enable it. This is a build-and-host task, not a
+self-serve install.
 
-2. Expose `http://localhost:7777` as a public **HTTPS** URL with a secure tunnel (for example Cloudflare Tunnel or ngrok). Treat that URL as sensitive: anyone who reaches it can act on your Servosity partner account, including destructive operations.
-3. In ChatGPT: Settings > Apps > Advanced > Developer mode, then create a custom connector pointing at your tunnel's HTTPS URL.
+Once `servosity-mcp` is hosted over HTTPS (above), the lowest-code route:
 
-Official OpenAI guidance (beta, plan-dependent, subject to change): https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta
+1. In **Copilot Studio**, open your agent > **Tools** > **Add a tool** > **Model
+   Context Protocol**.
+2. Enter a **Server name**, the **Server URL** (your HTTPS endpoint), and auth
+   (OAuth 2.0 or API key). Copilot Studio builds the Power Platform connector behind
+   the scenes; generative orchestration must be **on**.
+3. Publish the agent into Microsoft 365 Copilot.
 
-For the simplest path, use Claude Desktop (above) or the Claude Code / Codex Skill.
+Alternative (dev-ish): build a **declarative agent** with the Microsoft 365 Agents
+Toolkit in VS Code (**Add an Action > Start with an MCP Server**, point at the remote
+URL), then sideload - requires admin-enabled Custom App Upload + Copilot Access.
+
+Microsoft docs: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
+
+## Gemini app / web (Google)
+
+Same remote pattern as ChatGPT - point Gemini's connector at your hosted HTTPS
+endpoint. For a local, no-hosting path on Google, use **Gemini CLI** (above) instead.
+
+---
+
+# Skill-native agents
+
+[Hermes](https://hermes-agent.nousresearch.com) and OpenClaw read this skill's
+`SKILL.md` directly, and both also speak MCP. Register the server directly:
+
+```bash
+# Hermes (also supports `hermes skills install ...` - see README.md)
+hermes mcp add servosity -- servosity-mcp
+
+# OpenClaw
+openclaw mcp set servosity '{"command":"servosity-mcp"}'
+```
+
+Same env vars as the blocks above. For the Skill-install path (no MCP wiring), see
+the "Install for Hermes" / "Install for OpenClaw" sections in [README.md](./README.md).
+
+For the simplest path overall, use Claude Desktop or the Claude Code / Codex Skill.
 
 ## Troubleshooting
 
-- `servosity-mcp: command not found` after install: the install dir is not on your PATH. The installer prints the line you need to add to your shell rc file (macOS / Linux) or sets the user PATH (Windows; open a new terminal after install).
-- Claude Desktop does not see the MCP after restart: the JSON config has a syntax error. Run it through a JSON linter, fix, save, restart.
-- `401 Unauthorized` from the MCP: the partner token is wrong or expired. Regenerate in the partner portal and update the env block.
-- Need to update credentials: change the env block in the JSON config and restart Claude Desktop.
+- `servosity-mcp: command not found`: the install dir is not on your PATH (the
+  installer prints the line to add).
+- Claude Desktop does not see the MCP after restart: the JSON config has a syntax
+  error. Validate it, fix, restart.
 
-For the full CLI command reference (everything the MCP also exposes as tools), see [guide.md](./guide.md).
+For the full CLI command reference, see [guide.md](./guide.md).


### PR DESCRIPTION
## Why
- `skills/{halopsa,servosity}/mcp-install.md` on main were the **old thin** version (Claude Desktop + ChatGPT only). main predated the `gen_mcp_install` expansion and was never re-onboarded. These refresh them to the current generator output (Local/Remote split + GitHub Copilot, Gemini CLI, M365 Copilot, Gemini app, Hermes, OpenClaw).
- `docs/integrations/{gemini,hermes,microsoft-365-copilot,openclaw}.md` — new repo-level per-agent guides (siblings of the existing `claude-desktop.md`/`chatgpt.md`).

Rescued from uncommitted WIP. **Idempotent:** these `mcp-install.md` files == what `onboard.py` now emits, so a future re-onboard regenerates them with no conflict — no generator change required. (The stale README WIP edits were discarded; main's PR #8 v0.1.1 READMEs are kept.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive integration guides for Google Gemini, Hermes, Microsoft 365 Copilot, and OpenClaw platforms.
  * Enhanced HaloPSA and Servosity installation documentation with clearer instructions for local and remote agent configurations.
  * Improved agent setup guidance with expanded environment variable requirements and troubleshooting information across multiple deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->