### PR TITLE
fix(release): serialize + isolate release ops (lock, worktree choreography, CI groups)

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -23,6 +23,20 @@ on:
 permissions:
   contents: write
 
+# Serialize every run that auto-commits derived files to main - this workflow's
+# push/tag runs AND live-verified.yml share the 'main-autocommit' group, because
+# both push to main and would otherwise race (non-fast-forward) when e.g. two
+# release tags land seconds apart. PR runs get a per-PR group instead: they only
+# read (drift gate), and a global group would wrongly serialize unrelated PR
+# checks (GitHub keeps at most ONE pending run per group, replacing older queued
+# runs). cancel-in-progress stays false: each writer run regenerates from the
+# LATEST tree+tags (idempotent, not delta-based), so a queued run is still
+# useful, and the one-pending-run replacement is harmless for the same reason -
+# whichever queued run survives produces the correct end state.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('catalog-pr-{0}', github.event.pull_request.number) || 'main-autocommit' }}
+  cancel-in-progress: false
+
 jobs:
   catalog:
     runs-on: ubuntu-latest
@@ -73,4 +87,28 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add catalog.json README.md docs/llms.txt docs/llms-full.txt docs/_data/pending.json
           git commit -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
-          git push origin main
+          # Push with a self-heal loop: the concurrency group serializes the
+          # common case, but a peer commit can still land between our checkout
+          # and our push (e.g. a release_batch push). Derived files are
+          # recomputable, so the conflict path is regenerate-on-top, never a
+          # textual merge.
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then
+              echo "pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt) - refetch and regenerate on top"
+            git fetch origin main
+            git reset --hard origin/main
+            python3 tools/maintainer/build-catalog.py
+            python3 tools/maintainer/build-llms.py
+            python3 tools/maintainer/release_state.py --json > docs/_data/pending.json
+            if git diff --quiet catalog.json README.md docs/llms.txt docs/llms-full.txt docs/_data/pending.json; then
+              echo "now in sync after peer commit - nothing left to push"
+              exit 0
+            fi
+            git add catalog.json README.md docs/llms.txt docs/llms-full.txt docs/_data/pending.json
+            git commit -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+          done
+          echo "::error::could not push derived files after 5 attempts"
+          exit 1

--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -17,6 +17,14 @@ permissions:
   contents: write
   issues: write
 
+# Same group as catalog.yml's main/tag writers: both workflows auto-commit to
+# main and would race each other (non-fast-forward) without serialization,
+# e.g. a badge flip landing while a release tag's catalog job is pushing.
+# cancel-in-progress false: a queued badge flip must still run.
+concurrency:
+  group: main-autocommit
+  cancel-in-progress: false
+
 jobs:
   flip:
     runs-on: ubuntu-latest
@@ -118,6 +126,7 @@ jobs:
         env:
           SLUG: ${{ steps.parse.outputs.slug }}
           ISSUE: ${{ github.event.issue.number }}
+          EVIDENCE: ${{ github.event.issue.html_url }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -125,10 +134,37 @@ jobs:
           git add tools/maintainer/skills.json catalog.json README.md docs/_data/pending.json 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes to commit (already live-verified?)."
-          else
-            git commit -m "badge: $SLUG live-verified via #$ISSUE"
-            git push origin HEAD:main
+            exit 0
           fi
+          git commit -m "badge: $SLUG live-verified via #$ISSUE"
+          # Self-heal push loop: the concurrency group serializes the common
+          # case, but a peer commit (release_batch push, catalog bot) can land
+          # between our checkout and our push. The badge flip is recomputable,
+          # so the conflict path is recompute-on-top: reset to the new main,
+          # re-run verify_live (idempotent for an already-verified slug),
+          # regenerate, re-commit.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              echo "pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt) - recompute on top of new main"
+            git fetch origin main
+            git reset --hard origin/main
+            python3 tools/maintainer/verify_live.py \
+              --slug "$SLUG" \
+              --source github \
+              --evidence "$EVIDENCE"
+            python3 tools/maintainer/build-catalog.py
+            git add tools/maintainer/skills.json catalog.json README.md docs/_data/pending.json 2>/dev/null || true
+            if git diff --cached --quiet; then
+              echo "now in sync after peer commit - nothing left to push"
+              exit 0
+            fi
+            git commit -m "badge: $SLUG live-verified via #$ISSUE"
+          done
+          echo "::error::could not push the badge flip after 5 attempts"
+          exit 1
 
       - name: Thank the reporter
         if: steps.parse.outputs.ok == 'true'

--- a/tools/maintainer/release.py
+++ b/tools/maintainer/release.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import cli_hash  # noqa: E402  (local tools/ module)
 import registry  # noqa: E402  (local tools/ module)
 import release_state  # noqa: E402  (local tools/ module)
+import repo_lock  # noqa: E402  (local tools/ module)
 
 ROOT = registry.ROOT
 SKILLS_DIR = registry.SKILLS_DIR
@@ -259,6 +260,32 @@ def parse_args(argv: list[str]) -> tuple[list[str], str, bool]:
 
 def main(argv: list[str]) -> int:
     slugs, bump, dry_run = parse_args(argv)
+
+    if dry_run:
+        # Read-only report: never blocked by (and never blocks) a real release.
+        return _run_batch(slugs, bump, dry_run=True)
+
+    # One release at a time, machine-wide: every invocation writes the two
+    # SHARED files (tools/maintainer/skills.json, .claude-plugin/
+    # marketplace.json), so even different-slug releases must serialize.
+    # The lock lives in the git common dir so worktree and main-checkout
+    # runs see the same lock (see repo_lock.py).
+    try:
+        repo_lock.acquire("release", holder_info={"slugs": slugs, "bump": bump})
+    except repo_lock.LockHeld as e:
+        print(f"release: {e}", file=sys.stderr)
+        print(
+            "release: another release is in flight. Wait for it to finish - "
+            "or, if you are certain it crashed, remove the lock file named "
+            "above and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return _run_batch(slugs, bump, dry_run=False)
+
+
+def _run_batch(slugs: list[str], bump: str, dry_run: bool) -> int:
     known = set(registry.skills())
     tag_commands: list[str] = []
 

--- a/tools/maintainer/release_batch.sh
+++ b/tools/maintainer/release_batch.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# release_batch.sh - the release choreography, isolated from the shared checkout.
+#
+# Releases used to run release.py directly in the main checkout. That left the
+# version/stamp edits sitting dirty in a working tree other agent sessions also
+# use - and a broad `git add` from any of them could sweep the release stamp
+# into an unrelated commit (it happened: de9b358). This script runs the whole
+# batch in a throwaway worktree, stages ONLY the version-bearing files, pushes
+# the release commit to main with a rebase-retry loop, and then PRINTS the tag
+# commands pinned to the pushed SHA. It never tags and never pushes tags -
+# cutting a release stays a deliberate, separate act.
+#
+# Usage:
+#   tools/maintainer/release_batch.sh --all-pending
+#   tools/maintainer/release_batch.sh --slug halopsa
+#   tools/maintainer/release_batch.sh --slugs halopsa,servosity --bump minor
+#   tools/maintainer/release_batch.sh --slug halopsa --dry-run   # rehearsal:
+#       worktree + release.py --dry-run + staged-set preview, then teardown.
+#
+# Concurrency: release.py itself holds a machine-wide lock (repo_lock.py,
+# anchored in the git common dir so it is shared across worktrees). This
+# script adds the isolation layer; the lock adds the serialization layer.
+#
+# Derived files (catalog.json, README catalog table, docs/llms*.txt,
+# docs/_data/pending.json) are deliberately NOT committed here - the catalog
+# CI job regenerates and auto-commits them on both the main push and the tag
+# push. Committing them locally is redundant at best and stale at worst.
+#
+# bash 3.2 compatible (macOS default shell) - no mapfile, no brace ranges.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WT="$(dirname "$REPO")/msp-skills-wt-release"
+BRANCH="release/batch-$(date +%Y%m%d-%H%M%S)"
+
+# The ONLY paths a release commit may contain (the de9b358 fix: narrow add,
+# never `git add -A`).
+RELEASE_PATHSPECS="skills/*/manifest.json skills/*/.claude-plugin/plugin.json skills/*/server.json skills/*/CHANGELOG.md .claude-plugin/marketplace.json tools/maintainer/skills.json"
+
+DRY_RUN=0
+for a in "$@"; do
+  [ "$a" = "--dry-run" ] && DRY_RUN=1
+done
+
+if [ -e "$WT" ]; then
+  echo "release_batch: worktree already exists: $WT" >&2
+  echo "release_batch: one release batch at a time. If a prior batch crashed:" >&2
+  echo "  git -C $REPO worktree remove --force $WT" >&2
+  exit 1
+fi
+
+echo "== release_batch: fresh worktree off origin/main =="
+git -C "$REPO" fetch origin main
+git -C "$REPO" worktree add -b "$BRANCH" "$WT" origin/main
+
+cleanup_worktree() {
+  git -C "$REPO" worktree remove --force "$WT" 2>/dev/null || true
+  git -C "$REPO" branch -D "$BRANCH" 2>/dev/null || true
+}
+
+echo "== release_batch: running release.py in the worktree =="
+RELOUT="$(mktemp)"
+if ! python3 "$WT/tools/maintainer/release.py" "$@" | tee "$RELOUT"; then
+  echo "release_batch: release.py failed - tearing down" >&2
+  rm -f "$RELOUT"
+  cleanup_worktree
+  exit 1
+fi
+
+# Tags release.py planned, e.g. "  TAG: git tag halopsa-v0.1.2 && git push ..."
+TAGS=""
+while IFS= read -r line; do
+  tag="$(printf '%s\n' "$line" | sed -n 's/^  TAG: git tag \([^ ]*\) .*/\1/p')"
+  [ -n "$tag" ] && TAGS="$TAGS $tag"
+done < "$RELOUT"
+rm -f "$RELOUT"
+TAGS="${TAGS# }"
+
+if [ -z "$TAGS" ]; then
+  echo "release_batch: release.py planned no tags (nothing pending?) - tearing down"
+  cleanup_worktree
+  exit 0
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "== release_batch: DRY-RUN rehearsal - what a real run would stage =="
+  # shellcheck disable=SC2086
+  git -C "$WT" add --dry-run $RELEASE_PATHSPECS || true
+  echo "== release_batch: derived files (must stay UNSTAGED in a real run) =="
+  git -C "$WT" status --short -- catalog.json README.md docs/llms.txt docs/llms-full.txt docs/_data/pending.json || true
+  echo "== release_batch: dry-run complete - tearing down =="
+  cleanup_worktree
+  echo "DRY-RUN tags that would be cut:"
+  for t in $TAGS; do echo "  $t"; done
+  exit 0
+fi
+
+echo "== release_batch: committing version files (narrow add) =="
+# shellcheck disable=SC2086
+git -C "$WT" add $RELEASE_PATHSPECS
+if git -C "$WT" diff --cached --quiet; then
+  echo "release_batch: nothing to commit (already stamped?) - tearing down"
+  cleanup_worktree
+  exit 1
+fi
+git -C "$WT" commit -s -m "chore(release): $TAGS"
+
+echo "== release_batch: pushing to main (rebase-retry) =="
+PUSHED=0
+for attempt in 1 2 3 4 5; do
+  if git -C "$WT" push origin HEAD:main; then
+    PUSHED=1
+    break
+  fi
+  echo "release_batch: push rejected (attempt $attempt) - fetch + rebase + retry"
+  git -C "$WT" fetch origin main
+  if ! git -C "$WT" rebase origin/main; then
+    git -C "$WT" rebase --abort || true
+    echo "release_batch: rebase conflict - resolve manually in $WT, then:" >&2
+    echo "  git -C $WT push origin HEAD:main" >&2
+    echo "  (then run the tag commands release.py printed, pinned to the pushed SHA)" >&2
+    exit 1
+  fi
+done
+if [ "$PUSHED" != "1" ]; then
+  echo "release_batch: push failed after 5 attempts - NOT tagging. Worktree kept at $WT" >&2
+  exit 1
+fi
+
+# Pin the SHA that actually landed. Tagging 'main' instead would race any
+# peer commit (e.g. the catalog bot) landing a second later.
+RELSHA="$(git -C "$WT" rev-parse HEAD)"
+
+echo "== release_batch: tearing down worktree =="
+cleanup_worktree
+
+echo
+echo "============================================================"
+echo "Release commit pushed to main: $RELSHA"
+echo "Copy-paste to tag + push (this script never runs these):"
+for t in $TAGS; do
+  echo "  git -C $REPO tag $t $RELSHA && git -C $REPO push origin $t"
+done
+echo
+echo "Each tag push fires release.yml (build) then mcp-publish.yml (registry)."
+echo "N tags -> N independent builds; that parallelism is safe."

--- a/tools/maintainer/repo_lock.py
+++ b/tools/maintainer/repo_lock.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Repo-level advisory lock for operations that write shared files.
+
+release.py (and any future batch tool) writes two files every invocation
+shares: tools/maintainer/skills.json and .claude-plugin/marketplace.json.
+Two concurrent releases - even of DIFFERENT skills - race on those files
+(read-modify-write, last-writer-wins). This module serializes them with a
+single named lock, machine-wide.
+
+Why the lock lives in the git COMMON dir, not the working tree: release
+operations run from throwaway worktrees (see release_batch.sh), and git
+worktrees have separate working trees but share one .git. A lock file under
+tools/maintainer/.locks/ would exist per-worktree and never collide - two
+releases in two worktrees would each see "their" lock free. Anchoring at
+`git rev-parse --git-common-dir` gives every checkout of this repo the same
+lock file. (The onboarding locks in msp-skills-publish's onboard.py keep the
+working-tree location because they are acquired in the primary checkout
+BEFORE the worktree exists; this module is a deliberate re-implementation of
+that pattern adapted for run-inside-a-worktree semantics. If the two ever
+converge, this repo-side copy is the canonical one.)
+
+Semantics (mirrors onboard.py's per-slug locks):
+  - atomic create via os.O_CREAT | os.O_EXCL
+  - JSON payload {pid, host, started, argv, ...} so a stuck lock is
+    self-documenting
+  - stale-lock reclaim: if the holder PID is dead on THIS host, the lock is
+    reclaimed; a lock from another host is never auto-reclaimed (a foreign
+    PID is meaningless locally) - the operator removes it manually
+  - released via atexit on normal or exceptional interpreter exit
+
+Pure stdlib. Not safe across NFS (O_EXCL caveats); this repo is a local
+checkout, which is the supported case.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/ module)
+
+
+class LockHeld(RuntimeError):
+    """Another process holds the lock. Message names the holder."""
+
+
+def _locks_dir() -> Path:
+    """Locks directory shared by every worktree of this repo.
+
+    `git rev-parse --git-common-dir` returns the shared .git directory even
+    when run inside a linked worktree. Fall back to the working-tree
+    .locks/ dir (onboard.py's location) only if git itself is unavailable -
+    degraded, but better than no lock at all.
+    """
+    try:
+        p = subprocess.run(
+            ["git", "-C", str(registry.ROOT), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if p.returncode == 0 and p.stdout.strip():
+            common = Path(p.stdout.strip())
+            if not common.is_absolute():
+                common = (registry.ROOT / common).resolve()
+            d = common / "msp-skills-locks"
+            d.mkdir(parents=True, exist_ok=True)
+            return d
+    except (OSError, subprocess.SubprocessError):
+        pass
+    d = registry.ROOT / "tools" / "maintainer" / ".locks"
+    d.mkdir(parents=True, exist_ok=True)
+    gi = d / ".gitignore"
+    if not gi.exists():
+        gi.write_text("*\n", encoding="utf-8")
+    return d
+
+
+def release(lock: Path) -> None:
+    try:
+        lock.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _holder(lock: Path) -> dict:
+    try:
+        return json.loads(lock.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _holder_alive(holder: dict) -> bool:
+    """True when the lock's holder may still be running.
+
+    A lock from another host is always treated as alive: we cannot probe a
+    remote PID, and reclaiming it would defeat the lock exactly when two
+    machines share a checkout.
+    """
+    if holder.get("host") and holder["host"] != socket.gethostname():
+        return True
+    pid = holder.get("pid")
+    if not isinstance(pid, int):
+        return True  # unreadable payload: be conservative
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    except OSError:
+        return True
+
+
+def acquire(name: str = "release", holder_info: dict | None = None) -> Path:
+    """Acquire the named repo lock or raise LockHeld.
+
+    Registers an atexit hook that releases the lock when this process exits,
+    so the caller has nothing to clean up on the happy path.
+    """
+    lock = _locks_dir() / f"{name}.lock"
+    payload = json.dumps({
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "started": datetime.now().isoformat(timespec="seconds"),
+        "argv": sys.argv[1:],
+        **(holder_info or {}),
+    }, indent=2) + "\n"
+
+    for _attempt in (1, 2):
+        try:
+            fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+            atexit.register(release, lock)
+            return lock
+        except FileExistsError:
+            holder = _holder(lock)
+            if _holder_alive(holder):
+                raise LockHeld(
+                    f"lock '{name}' held by pid {holder.get('pid', '?')} on "
+                    f"{holder.get('host', '?')} since {holder.get('started', '?')} "
+                    f"(argv: {' '.join(holder.get('argv', [])) or '?'}) - "
+                    f"lock file: {lock}"
+                )
+            # Holder is dead on this host: reclaim and retry once.
+            release(lock)
+    raise LockHeld(f"could not acquire lock '{name}' at {lock}")


### PR DESCRIPTION
Multiple panes will soon onboard + release skills simultaneously. Onboarding is already worktree+lock isolated; release ops were not — they write two SHARED files (`tools/maintainer/skills.json`, `.claude-plugin/marketplace.json`) from the shared main checkout with zero coordination. Real incident: `de9b358` swept an uncommitted release stamp into an unrelated docs commit.

## Three layers

1. **Machine-wide release lock** — `tools/maintainer/repo_lock.py` (new). Anchored in the **git common dir** (`<.git>/msp-skills-locks/`) so worktree and main-checkout runs share ONE lock (a working-tree lock would silently not collide across worktrees). O_EXCL create, pid-staleness reclaim (same host only — foreign-host locks are never auto-reclaimed), atexit release, self-documenting payload (pid/host/started/argv). `release.py` acquires it for real runs; `--dry-run` bypasses (read-only report must work during a live release).
2. **Worktree choreography** — `tools/maintainer/release_batch.sh` (new). Throwaway worktree off origin/main → `release.py` inside it → **narrow add of only the six version-bearing path globs** (never `git add -A` — the de9b358 fix) → push to main with 5-attempt rebase-retry → prints tag commands **pinned to the pushed SHA** (a peer commit landing later can't shift what gets tagged) → teardown. Still **never tags** — cutting a release stays a deliberate separate act. Derived files (catalog/llms/pending.json) deliberately NOT committed: CI auto-commits them on the main push and tag push. `--dry-run` rehearsal mode. bash 3.2 + shellcheck clean.
3. **CI serialization** — `catalog.yml` + `live-verified.yml` share a `main-autocommit` concurrency group (PR drift-gate runs get per-PR groups so unrelated PR checks don't serialize) + regenerate-on-top push-retry loops. Two tags seconds apart, or a badge flip racing a release, now queue instead of failing non-fast-forward. `release.yml`/`mcp-publish.yml` untouched (read-only on the tree; N parallel tag builds are intended).

**Simultaneous releases = one batch**: `release_batch.sh --slugs a,b,c` → N tag pushes → N independent builds. Two racing batch invocations: the second refuses with the holder's pid, by design.

## Receipts (all run locally)

- Lock collision: concurrent `release.py --slug halopsa` → LockHeld + exit 1; `--dry-run` unblocked; lock auto-removed on holder exit
- Cross-worktree: lock acquired in a worktree blocks a main-checkout-context acquire (proves common-git-dir anchoring — the naive location false-passes this)
- Dead-pid same-host lock reclaims; foreign-host lock refuses
- `release_batch.sh --slug halopsa --dry-run` end-to-end: worktree off origin/main, tag parsed (`halopsa-v0.1.2`), clean teardown
- actionlint clean on both workflows; shellcheck clean; `verify_all.sh` **PASS**

Doctrine updated alongside (outside this repo): msp-skills-publish SKILL.md release section + release-queue.md "Concurrency & isolation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of automated release and catalog update processes with enhanced concurrency control mechanisms that serialize concurrent operations to prevent conflicts.
  * Added resilient retry logic to automated workflows to recover gracefully from transient push failures and coordinate overlapping updates.
  * Strengthened the release orchestration process with isolated execution environments and improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->