### PR TITLE
fix(ci): scoped build matrices + CodeRabbit majors from #19

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -23,10 +23,13 @@ on:
 permissions:
   contents: write
 
-# Serialize every run that auto-commits derived files to main - this workflow's
-# push/tag runs AND live-verified.yml share the 'main-autocommit' group, because
-# both push to main and would otherwise race (non-fast-forward) when e.g. two
-# release tags land seconds apart. PR runs get a per-PR group instead: they only
+# Serialize this workflow's push/tag runs (the derived-file auto-committers)
+# under one group so two release tags landing seconds apart queue instead of
+# racing non-fast-forward. live-verified.yml deliberately does NOT share this
+# group: its runs are per-issue and NOT interchangeable (GitHub keeps only one
+# pending run per group and replaces older queued runs - fine for idempotent
+# full-regenerations like these, lossy for badge flips). Cross-workflow races
+# are handled by both sides' regenerate-on-top push-retry loops instead. PR runs get a per-PR group instead: they only
 # read (drift gate), and a global group would wrongly serialize unrelated PR
 # checks (GitHub keeps at most ONE pending run per group, replacing older queued
 # runs). cancel-in-progress stays false: each writer run regenerates from the
@@ -98,7 +101,11 @@ jobs:
               exit 0
             fi
             echo "push rejected (attempt $attempt) - refetch and regenerate on top"
-            git fetch origin main
+            # --tags matters: pending.json is DERIVED FROM TAGS, and the peer
+            # commit that beat us may have been a release whose tag we have not
+            # fetched yet - regenerating from stale tags would overwrite the
+            # newer state that just landed.
+            git fetch --force --tags origin main
             git reset --hard origin/main
             python3 tools/maintainer/build-catalog.py
             python3 tools/maintainer/build-llms.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,41 @@ jobs:
           done
 
   # Skill build matrix is computed from the repo, so a new skill is built+vetted
-  # with no edit here (mirrors the release workflow).
+  # with no edit here (mirrors the release workflow). On PRs the matrix is
+  # SCOPED to skills changed since the merge-base (a docs/tools PR builds zero
+  # skills; a one-skill PR builds one) - at fleet scale (50+ skills) an
+  # unscoped matrix would spawn 50+ build jobs on every PR. Pushes to main
+  # keep the FULL matrix as the post-merge safety net, and release_matrix.py
+  # fails open to the full matrix when build machinery itself changed.
   prepare:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
+      any: ${{ steps.gen.outputs.any }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need history for merge-base on PRs
       - name: Compute skill matrix
         id: gen
-        run: echo "matrix=$(python3 tools/maintainer/release_matrix.py --skills-only)" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "$BASE_SHA" ]; then
+            git fetch -q origin "$BASE_SHA"
+            matrix="$(python3 tools/maintainer/release_matrix.py --skills-only --changed-only "$BASE_SHA")"
+          else
+            matrix="$(python3 tools/maintainer/release_matrix.py --skills-only)"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "any=$(printf '%s' "$matrix" | python3 -c 'import json,sys; print(str(len(json.load(sys.stdin)["skill"])>0).lower())')" >> "$GITHUB_OUTPUT"
+          printf '%s' "$matrix" | python3 -c 'import json,sys; m=json.load(sys.stdin); print("matrix skills:", [s["name"] for s in m["skill"]] or "(none - build job will skip)")'
 
   build:
     needs: prepare
+    if: needs.prepare.outputs.any == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -17,12 +17,14 @@ permissions:
   contents: write
   issues: write
 
-# Same group as catalog.yml's main/tag writers: both workflows auto-commit to
-# main and would race each other (non-fast-forward) without serialization,
-# e.g. a badge flip landing while a release tag's catalog job is pushing.
-# cancel-in-progress false: a queued badge flip must still run.
+# Per-ISSUE group, deliberately NOT the shared 'main-autocommit' group: badge
+# flips are per-issue and not interchangeable, and GitHub keeps only ONE pending
+# run per group (an older queued flip would be silently replaced by a newer one
+# and that slug would never get badged). The per-issue group still dedupes
+# re-labels of the same issue; races against catalog.yml's pushes to main are
+# handled by the regenerate-on-top push-retry loop below.
 concurrency:
-  group: main-autocommit
+  group: live-verified-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -149,12 +151,18 @@ jobs:
               exit 0
             fi
             echo "push rejected (attempt $attempt) - recompute on top of new main"
-            git fetch origin main
+            git fetch --force --tags origin main
             git reset --hard origin/main
+            # Tolerate exit 1 here: verify_live exits 1 for an already
+            # live-verified slug (e.g. the peer commit that beat us WAS this
+            # badge flip), and set -e would kill the loop before the staged-diff
+            # check below can conclude there is nothing left to push. The diff
+            # check is the real gate.
             python3 tools/maintainer/verify_live.py \
               --slug "$SLUG" \
               --source github \
-              --evidence "$EVIDENCE"
+              --evidence "$EVIDENCE" \
+              || echo "verify_live returned non-zero (already verified?) - continuing to diff check"
             python3 tools/maintainer/build-catalog.py
             git add tools/maintainer/skills.json catalog.json README.md docs/_data/pending.json 2>/dev/null || true
             if git diff --cached --quiet; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,29 @@ env:
 
 jobs:
   # The build matrix is COMPUTED from the repo (tools/maintainer/skills.json + introspection
-  # of each skills/<slug>/cli/). Adding a skill needs no edit here.
+  # of each skills/<slug>/cli/). Adding a skill needs no edit here. The matrix
+  # is scoped to THE SKILL THE TAG NAMES (one tag = one skill x 6 targets) -
+  # unscoped, every tag would spawn a no-op matrix job per skill x platform,
+  # which at fleet scale is hundreds of wasted checkouts per release. An
+  # unknown slug yields an empty matrix and the build job skips entirely; the
+  # per-row tag_skill guard below stays as second-layer defense.
   prepare:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
+      any: ${{ steps.gen.outputs.any }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Compute build matrix
         id: gen
-        run: echo "matrix=$(python3 tools/maintainer/release_matrix.py)" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/maintainer/release_matrix.py --tag "$TAG")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "any=$(printf '%s' "$matrix" | python3 -c 'import json,sys; print(str(len(json.load(sys.stdin)["skill"])>0).lower())')" >> "$GITHUB_OUTPUT"
 
   # Create the GitHub Release once, before the matrix build jobs upload to it.
   create-release:
@@ -47,6 +59,7 @@ jobs:
 
   build:
     needs: [prepare, create-release]
+    if: needs.prepare.outputs.any == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tools/maintainer/release_matrix.py
+++ b/tools/maintainer/release_matrix.py
@@ -8,6 +8,17 @@ the release pipeline can never drift from what is actually vendored.
 Usage:
     python3 tools/release_matrix.py              # full {skill, target} matrix (release.yml)
     python3 tools/release_matrix.py --skills-only # {skill} only (ci.yml build+vet)
+    python3 tools/release_matrix.py --tag <tag>  # only the skill the tag names
+                                                 # (release.yml: one tag = one skill,
+                                                 # not N no-op matrix rows)
+    python3 tools/release_matrix.py --skills-only --changed-only <base-ref>
+                                                 # only skills with changes under
+                                                 # skills/<slug>/ since merge-base
+                                                 # with <base-ref> (ci.yml PRs).
+                                                 # Falls back to the FULL matrix if
+                                                 # build machinery changed or git
+                                                 # diff fails (fail open, never
+                                                 # silently skip a needed build).
 
 Each skill entry carries everything the build step needs:
     name, dir, module, cli_cmd, mcp_cmd, cli_bin, mcp_bin
@@ -18,6 +29,7 @@ cmd paths are introspected, so they are correct whether the source is stripped
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -46,9 +58,74 @@ def skill_entries() -> list[dict]:
     return entries
 
 
+# Changes to these paths can alter WHICH skills need building or HOW they are
+# built/verified - when one of them changes, scoping is unsafe and we fall back
+# to the full matrix.
+MACHINERY = (
+    ".github/workflows/",
+    "tools/maintainer/release_matrix.py",
+    "tools/maintainer/registry.py",
+    "tools/maintainer/check_cli_claims.py",
+    "tools/maintainer/cli_hash.py",
+)
+
+
+def changed_slugs(base_ref: str, entries: list[dict]) -> list[dict] | None:
+    """Filter entries to skills changed since merge-base with base_ref.
+
+    Returns None to mean "use the full matrix" (machinery changed, or git
+    failed - fail open). The filter is skills/<slug>/** (not just cli/**):
+    the ci.yml matrix job also runs check_cli_claims, which validates the
+    skill's DOCS against the built binary, so a docs-only edit to a skill
+    still needs that skill's row. Non-skill changes produce an empty matrix.
+    """
+    try:
+        mb = subprocess.run(
+            ["git", "merge-base", base_ref, "HEAD"],
+            capture_output=True, text=True, check=True, timeout=30,
+        ).stdout.strip()
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", mb, "HEAD"],
+            capture_output=True, text=True, check=True, timeout=60,
+        ).stdout
+    except (subprocess.SubprocessError, OSError) as e:
+        print(f"release_matrix: --changed-only diff failed ({e}); "
+              "falling back to FULL matrix", file=sys.stderr)
+        return None
+    files = [f for f in diff.splitlines() if f.strip()]
+    for f in files:
+        if any(f == m or f.startswith(m) for m in MACHINERY):
+            print(f"release_matrix: machinery changed ({f}); FULL matrix",
+                  file=sys.stderr)
+            return None
+    touched = {f.split("/", 2)[1] for f in files
+               if f.startswith("skills/") and f.count("/") >= 2}
+    return [e for e in entries if e["name"] in touched]
+
+
 def main(argv: list[str]) -> int:
     skills_only = "--skills-only" in argv
-    matrix: dict = {"skill": skill_entries()}
+    tag = ""
+    base_ref = ""
+    if "--tag" in argv:
+        tag = argv[argv.index("--tag") + 1]
+    if "--changed-only" in argv:
+        base_ref = argv[argv.index("--changed-only") + 1]
+
+    entries = skill_entries()
+
+    if tag:
+        # <slug>-v<semver> -> <slug>; unknown slug -> empty matrix (the
+        # workflow's `any` guard turns that into "no build jobs at all").
+        slug = tag.rsplit("-v", 1)[0]
+        entries = [e for e in entries if e["name"] == slug]
+
+    if base_ref:
+        filtered = changed_slugs(base_ref, entries)
+        if filtered is not None:
+            entries = filtered
+
+    matrix: dict = {"skill": entries}
     if not skills_only:
         matrix["target"] = registry.TARGETS
     print(json.dumps(matrix))


### PR DESCRIPTION
Two things, both for fleet scale (50+ skills):

## 1. Build matrices are now scoped (the "we can't afford to rebuild every time" fix)
- **ci.yml (PRs)**: matrix contains only skills changed since the PR's merge-base. Docs/tools PR → **zero** build jobs; one-skill PR → **one**. Filter is `skills/<slug>/**` (not just `cli/**`) because the matrix job also runs `check_cli_claims` (docs-vs-binary). **Fails open** to the full matrix when build machinery (`.github/workflows/`, `release_matrix.py`, `registry.py`, `check_cli_claims.py`, `cli_hash.py`) changed or the git diff fails. Pushes to main keep the full matrix as the post-merge safety net.
- **release.yml (tags)**: matrix contains only the skill the tag names — 1 skill × 6 targets instead of N skills × 6 mostly-no-op rows (at 50 skills: 6 jobs instead of ~300 checkouts per release). The per-row `tag_skill` guard stays as second-layer defense; unknown slug → empty matrix → build job skips.
- Note: this PR itself touches workflow machinery, so its own CI run correctly takes the fail-open full matrix — the scoping kicks in for the next PR.

## 2. The three CodeRabbit Major findings from #19 (all valid, all fixed)
- **catalog.yml retry**: `git fetch --force --tags` — `pending.json` is tag-derived; regenerating from stale tags in the retry path could overwrite newer peer state.
- **live-verified.yml**: per-**issue** concurrency group replaces the shared `main-autocommit` group. Badge flips are per-issue and not interchangeable; GitHub keeps one pending run per group and would silently drop an older queued flip. Cross-workflow races stay covered by the regenerate-on-top retry loops (comment in catalog.yml updated to match).
- **live-verified.yml retry**: tolerate `verify_live.py` exit 1 (already-verified after a peer commit beat us) so `set -e` can't kill the loop before the staged-diff check concludes nothing is left to push.

## Receipts
- `release_matrix.py` filter tested: clean tree → `[]`; one-skill change → `['halopsa']`; machinery change → FULL (fail-open, logged to stderr)
- `--tag halopsa-v0.1.2` → halopsa × 6 targets; unknown tag → `[]`
- actionlint clean on all four workflows; `verify_all.sh` **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)