### PR TITLE
fix(install): honor GITHUB_TOKEN/GH_TOKEN in install.sh API calls

### DIFF
--- a/skills/cipp/install.sh
+++ b/skills/cipp/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/connectwise-manage/install.sh
+++ b/skills/connectwise-manage/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/halopsa/install.sh
+++ b/skills/halopsa/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/hubspot/install.sh
+++ b/skills/hubspot/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/mspbots/install.sh
+++ b/skills/mspbots/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/n-central/install.sh
+++ b/skills/n-central/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/pax8/install.sh
+++ b/skills/pax8/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/servosity/install.sh
+++ b/skills/servosity/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/superops/install.sh
+++ b/skills/superops/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1

--- a/skills/threatlocker/install.sh
+++ b/skills/threatlocker/install.sh
@@ -20,10 +20,21 @@ REPO="${MSP_SKILLS_REPO:-msp-skills}"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 fetch_stdout() {
+  # GITHUB_TOKEN/GH_TOKEN (optional) authenticates GitHub API calls - lifts the
+  # 60/hr unauthenticated rate limit that bites shared/corporate IPs and CI.
+  _tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1"
+    if [ -n "${_tok}" ]; then
+      curl -fsSL -H "Authorization: Bearer ${_tok}" "$1"
+    else
+      curl -fsSL "$1"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$1"
+    if [ -n "${_tok}" ]; then
+      wget -qO- --header="Authorization: Bearer ${_tok}" "$1"
+    else
+      wget -qO- "$1"
+    fi
   else
     echo "Neither curl nor wget available; install one and retry." >&2
     exit 1


### PR DESCRIPTION
Lifts the 60/hr unauthenticated GitHub API rate limit for release resolution in every skill's install.sh (optional env; no behavior change when unset). Found when the local verify_all install-URL gate started 403ing during tonight's fleet publish run. Template source updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)