### PR TITLE
fix(registry): live_verified must never regress - gate + shape repair + llms badge fix

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -704,7 +704,7 @@ Governance: The skill reads your Synthesize accounts, services, mappings, integr
 ### HaloPSA (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/halopsa/
-Badge: Awaiting live verification
+Badge: Live-verified
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 
 MSPs run HaloPSA as the service desk - tickets, SLAs, contracts, and the queue that never stops. Ask your AI "what's about to breach SLA," "who's overloaded," or "what's the whole story for this client," and get an answer the portal can't compose in one shot: cross-entity rollups across tickets, clients, contracts, time, and assets, joined offline in one query instead of clicking through five tabs. A local SQLite mirror means QBR-time questions don't hit rate limits.
@@ -1620,7 +1620,7 @@ Governance: The skill drives the sentinelone-cli and sentinelone-mcp binaries, a
 ### Servosity (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/servosity/
-Badge: Awaiting live verification
+Badge: Live-verified
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
 
 MSPs run Servosity as the backup and DR platform - M365, DR Server, and DR Desktop protection across a whole book of clients. Ask your AI "where is my attention needed today", "which backups went stale this week", or "build Acme's QBR backup section" and get fleet-wide answers the per-client dashboard can't compose: ranked attention sweeps, day-over-day drift, ready-to-send stale-backup follow-ups, and the whole book's QBR reports in one pass.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -740,7 +740,7 @@ Governance: The skill drives the halopsa-cli and halopsa-mcp binaries, authentic
 ### HubSpot (CRM)
 
 Page: https://msp-skills.compoundingteams.com/skills/hubspot/
-Badge: Awaiting live verification
+Badge: Live-verified
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hubspot/install.sh)
 
 MSPs run HubSpot as the sales CRM - pipeline, deals, quote-chasing. Ask your AI "which deals went cold," "what's my pipeline health," or "who do I call today," and get an answer the portal can't compose: cross-object rollups across deals, contacts, owners, and engagements, computed offline in one query instead of a dozen exports and saved views.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -64,7 +64,7 @@ What this site calls an MCP server is what ChatGPT calls an app or connector, Cl
   Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/halopsa/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 - HubSpot (CRM) - Pipeline health, stale deals, and owner workload for every client by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/hubspot/
+  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/hubspot/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hubspot/install.sh)
 - Hudu (Documentation) - Audit Hudu documentation hygiene, find stale passwords and expiring certs, and search every company offline.
   Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/hudu/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -61,7 +61,7 @@ What this site calls an MCP server is what ChatGPT calls an app or connector, Cl
   Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/gradient/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/gradient/install.sh)
 - HaloPSA (PSA) - Triage tickets, pre-empt SLA breaches, run cross-client analytics by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/halopsa/
+  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/halopsa/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 - HubSpot (CRM) - Pipeline health, stale deals, and owner workload for every client by asking.
   Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/hubspot/
@@ -138,7 +138,7 @@ What this site calls an MCP server is what ChatGPT calls an app or connector, Cl
   Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sentinelone/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/sentinelone/install.sh)
 - Servosity (Backup/DR) - Fleet attention, stale backups, QBR reports, and restore watch for every client by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/servosity/
+  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/servosity/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
 - Sherweb (Billing) - Reconcile what you owe Sherweb against what customers owe you and surface true net margin per customer.
   Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sherweb/

--- a/tools/maintainer/build-llms.py
+++ b/tools/maintainer/build-llms.py
@@ -225,8 +225,10 @@ def summarize_safety(gov: str) -> str:
 
 
 def badge_state(meta: dict) -> str:
-    lv = meta.get("live_verified", {})
-    if isinstance(lv, dict) and lv.get("status") == "verified":
+    lv = meta.get("live_verified") or {}
+    # The canonical verified value is "live-verified" (verify_live.py writes it;
+    # build-catalog.py reads it) - not "verified".
+    if isinstance(lv, dict) and lv.get("status") == "live-verified":
         return "Live-verified"
     return "Awaiting live verification"
 

--- a/tools/maintainer/check_registry_state.py
+++ b/tools/maintainer/check_registry_state.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Gate: skills.json stateful fields must not regress vs origin/main.
+
+The failure mode this blocks: an update/fleet branch cut from a stale local
+main carries an old skills.json; its whole-file rewrite then downgrades
+live_verified from 'live-verified' back to 'awaiting', destroying the
+verification receipt. Only verify_live.py revoke - which REMOVES the key -
+may take a skill out of live-verified.
+
+Checks per slug, current file vs origin/main:
+  1. DOWNGRADE - base is live-verified, current still has the key but with any
+     other status. FAIL. (Key removed entirely = explicit revoke = allowed.)
+  2. SHAPE - live_verified must be a dict or absent. null / strings FAIL
+     (a null entry silently reads as awaiting in every consumer).
+
+Exit 0 = clean, 1 = violations (printed), 2 = environment error.
+When origin/main is unreachable the gate SKIPs (exit 0 with a notice) -
+offline runs are still covered by onboard.py register()'s in-process guard.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+REGISTRY = REPO / "tools" / "maintainer" / "skills.json"
+REGISTRY_REF = "origin/main:tools/maintainer/skills.json"
+
+
+def load_current() -> dict:
+    try:
+        return json.loads(REGISTRY.read_text())["skills"]
+    except (OSError, json.JSONDecodeError, KeyError) as e:
+        print(f"check_registry_state: cannot read {REGISTRY}: {e}")
+        sys.exit(2)
+
+
+def load_base() -> dict | None:
+    p = subprocess.run(
+        ["git", "-C", str(REPO), "show", REGISTRY_REF],
+        capture_output=True, text=True,
+    )
+    if p.returncode != 0:
+        return None
+    try:
+        return json.loads(p.stdout)["skills"]
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def lv_status(entry: dict):
+    lv = entry.get("live_verified")
+    return lv.get("status") if isinstance(lv, dict) else None
+
+
+def main() -> int:
+    current = load_current()
+    violations: list[str] = []
+
+    for slug, entry in current.items():
+        # Key-presence check, not .get(): JSON null is an invalid SHAPE (it
+        # silently reads as awaiting in every consumer), absence is the valid
+        # post-revoke state.
+        if "live_verified" in entry and not isinstance(entry["live_verified"], dict):
+            violations.append(
+                f"{slug}: live_verified has invalid shape "
+                f"{entry['live_verified']!r} - must be a dict or absent "
+                "(absence = awaiting)"
+            )
+
+    base = load_base()
+    if base is None:
+        print("check_registry_state: origin/main unreachable - downgrade check "
+              "SKIPPED (onboard.py register() guard still applies)")
+    else:
+        for slug, base_entry in base.items():
+            if lv_status(base_entry) != "live-verified":
+                continue
+            cur_entry = current.get(slug)
+            if cur_entry is None:
+                continue  # slug removal is its own review concern, not this gate's
+            if "live_verified" not in cur_entry:
+                continue  # key removed = explicit verify_live.py revoke
+            if lv_status(cur_entry) != "live-verified":
+                violations.append(
+                    f"{slug}: live_verified DOWNGRADED from 'live-verified' "
+                    f"(origin/main) to {lv_status(cur_entry)!r} - a stale-snapshot "
+                    "merge is destroying a verification receipt. Restore the "
+                    "origin/main value; only verify_live.py revoke may clear it."
+                )
+
+    if violations:
+        print("check_registry_state: FAIL")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print(f"check_registry_state: OK ({len(current)} entries; no stateful regressions)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/maintainer/skills.json
+++ b/tools/maintainer/skills.json
@@ -504,7 +504,12 @@
       "tagline": "Tell it your stack - it recommends and installs the right connectors.",
       "template_version": 2,
       "has_video": false,
-      "live_verified": null
+      "live_verified": {
+        "status": "awaiting",
+        "date": null,
+        "source": null,
+        "evidence": null
+      }
     },
     "mspbots": {
       "system": "MSPbots BI: datasets, KPI snapshots, ticket analytics, exports",

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -47,6 +47,7 @@ echo "== CLI claims vs built binary =="
 if run python3 tools/maintainer/check_cli_claims.py --warn; then pass "CLI claims (warn)"; else warn "CLI claims reported findings"; fi
 
 echo "== Repo gates =="
+if run python3 tools/maintainer/check_registry_state.py;  then pass "registry state";      else fail "registry state";      fi
 if run python3 tools/maintainer/check_skill_contract.py;  then pass "skill contract";      else fail "skill contract";      fi
 if run python3 tools/maintainer/check_md_links.py;        then pass "markdown links";      else fail "markdown links";      fi
 if run python3 tools/maintainer/check_release_contract.py; then pass "release contract";   else fail "release contract";    fi


### PR DESCRIPTION
Structural guard for the badge-destruction class fixed by hand in e0ba17c: stale-base re-onboards could silently flip live_verified back to false. Adds a regression gate (registry state may only advance), shape repair, and the llms/AEO badge_state fix so servosity/halopsa/hubspot read Live-verified in the feed. Authored by the fleet publish session; rebased + verified (verify_all PASS) and PR'd by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)