### PR TITLE
chore: back-fill hand-fix ledgers (connectwise-manage, xero, servosity)

### DIFF
--- a/skills/connectwise-manage/handfixes.json
+++ b/skills/connectwise-manage/handfixes.json
@@ -1,0 +1,16 @@
+{
+  "slug": "connectwise-manage",
+  "doc": "docs/reprint-survival.md",
+  "handfixes": [
+    {
+      "id": "composite-auth-doctor-check",
+      "summary": "doctor checks the composite ConnectWise auth (companyId+publicKey:privateKey Basic + clientId header)",
+      "why": "ConnectWise Manage needs composite Basic credentials PLUS a clientId header; the press's single-scheme auth model can't express this, so the doctor auth check is hand-wired to require all four. A reprint reverts doctor to the single-scheme check.",
+      "status": "active",
+      "asserts": [
+        {"file": "cli/internal/cli/doctor.go", "contains": "Hand-wired: the generator's single-scheme model can't express", "min_count": 1},
+        {"file": "cli/internal/cli/doctor.go", "contains": "CW_COMPANY_ID", "min_count": 1}
+      ]
+    }
+  ]
+}

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "servosity",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "servosity is a SPECIAL case: it is engine-swapped from the servosity-msp mint via a staging strip + de-msp rename ritual that is RE-APPLIED on every reprint, so most of its divergence from a stock print is re-derived, not lost. These entries pin the load-bearing engine-swap invariants so a NAIVE reprint (one that bypassed the ritual) is caught. NOTE: a full reprint-diff would surface more; this records the auth/identity invariants that matter most. Separately, issue #78 (bare SERVOSITY_MSP_TOKEN lacks the required 'Token ' auth-scheme prefix) is an OPEN bug, not a hand-fix to preserve.",
+  "handfixes": [
+    {
+      "id": "msp-token-auth-plumbing",
+      "summary": "MSP-token auth (SERVOSITY_MSP_TOKEN env var -> ServosityMspToken -> AuthHeader) is hand-wired by the engine swap",
+      "why": "The servosity-msp engine adds an MSP partner-token auth path the stock print does not have. The env-var wiring and config field are re-applied by the de-msp ritual; a naive reprint that bypassed the ritual would drop them and break authentication.",
+      "status": "active",
+      "asserts": [
+        {"file": "cli/internal/config/config.go", "contains": "SERVOSITY_MSP_TOKEN", "min_count": 1},
+        {"file": "cli/internal/config/config.go", "contains": "ServosityMspToken", "min_count": 1}
+      ]
+    }
+  ]
+}

--- a/skills/xero/handfixes.json
+++ b/skills/xero/handfixes.json
@@ -1,0 +1,25 @@
+{
+  "slug": "xero",
+  "doc": "docs/reprint-survival.md",
+  "handfixes": [
+    {
+      "id": "tenant-id-header-env",
+      "summary": "XERO_TENANT_ID is sourced into the per-request Headers map (Xero-Tenant-Id header on every call)",
+      "why": "Xero requires the Xero-Tenant-Id header on EVERY call alongside the bearer token. The env-var wiring (XERO_TENANT_ID -> Headers) is hand-wired in config.go and pinned by config_auth_test.go; a reprint drops it and every call 401/403s.",
+      "status": "active",
+      "asserts": [
+        {"file": "cli/internal/config/config.go", "contains": "XERO_TENANT_ID", "min_count": 1}
+      ]
+    },
+    {
+      "id": "hand-wired-resource-id-fields",
+      "summary": "5 of 7 resource primary-key fields are hand-wired (accounts/items templated; the rest hand-set)",
+      "why": "Xero's per-resource ID field names (BankTransactionID, ContactID, InvoiceID, JournalID, PaymentID) are hand-wired for ExtractResourceID; the generator only templated accounts/items. Pinned by TestExtractResourceID_Xero. A reprint reverts the five to a generic guess and breaks sync key extraction.",
+      "status": "active",
+      "asserts": [
+        {"file": "cli/internal/store/store.go", "contains": "hand-wired and pinned by TestExtractResourceID_Xero", "min_count": 1},
+        {"file": "cli/internal/store/store.go", "contains": "BankTransactionID", "min_count": 1}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Records the pre-existing hand-fixes `--discover` surfaced so a reprint can't silently clobber them; `--discover` is now clean. Covers connectwise-manage (composite-auth doctor), xero (XERO_TENANT_ID header + 5 hand-wired resource IDs), and servosity (engine-swap MSP-token plumbing).

**Surfaced while back-filling:** servosity's `AuthHeader()` returns the bare token with **no `Token ` prefix**, confirming **issue #78** is a real open auth bug (bare `SERVOSITY_MSP_TOKEN` 401/403s). Flagged for a separate fix - this PR records the plumbing, not the buggy behavior.

Remaining: silent (unmarked) hand-fixes fleet-wide still need a reprint-diff to surface; the `--changed` gate (from #82) catches all new ones going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)