### PR TITLE
Site redesign PR-1: generator + data layer (named badges, AEO formulas, question book)

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -7,6 +7,8 @@
       "tagline": "Triage Abnormal email threats, confirm remediations, and pull client-ready security reports from your terminal.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/abnormal/"
     },
     {
@@ -15,6 +17,8 @@
       "tagline": "Spot failed backups, offline agents, and unbilled usage across every Acronis tenant by asking.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/acronis/"
     },
     {
@@ -23,6 +27,8 @@
       "tagline": "Patch every client's endpoints and triage CVEs fleet-wide from your terminal.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/action1/"
     },
     {
@@ -31,6 +37,8 @@
       "tagline": "Answer fleet-wide Afi backup coverage, staleness, and licensing questions from one local store.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/afi/"
     },
     {
@@ -39,6 +47,8 @@
       "tagline": "Reconcile AppDirect marketplace billing and chase failed payments across every reseller company before month-close.",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/appdirect/"
     },
     {
@@ -47,6 +57,8 @@
       "tagline": "Answer fleet-health, SLA, and book-of-business questions across your Atera estate from the terminal.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/atera/"
     },
     {
@@ -55,6 +67,8 @@
       "tagline": "Triage tickets, surface unbilled time, and project retainer burn by asking.",
       "category": "PSA",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/autotask/"
     },
     {
@@ -63,6 +77,8 @@
       "tagline": "Catch failed and stale Axcient backups, RPO breaches, and unbilled usage across every client by asking.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/axcient/"
     },
     {
@@ -71,6 +87,8 @@
       "tagline": "Ask what's down, who's paged, where coverage is missing, and your MTTA/MTTR across your Better Stack account",
       "category": "Monitoring",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/betterstack/"
     },
     {
@@ -79,6 +97,8 @@
       "tagline": "Triage every Blumira finding across all your MSP client accounts from one ranked queue",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/blumira/"
     },
     {
@@ -87,6 +107,8 @@
       "tagline": "Every client tenant's M365 posture, license waste, and stale accounts in one cross-tenant rollup.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/cipp/"
     },
     {
@@ -95,6 +117,8 @@
       "tagline": "Triage boards, catch unbilled time, and prep QBRs by asking.",
       "category": "PSA",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/connectwise-manage/"
     },
     {
@@ -103,6 +127,8 @@
       "tagline": "Sweep every Cove customer for failed and stale backups, storage growth, and month-end billing from your terminal.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/cove/"
     },
     {
@@ -111,6 +137,8 @@
       "tagline": "Triage Falcon alerts, find stale sensors, and rank critical vulnerabilities across every tenant by asking.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/crowdstrike/"
     },
     {
@@ -119,6 +147,8 @@
       "tagline": "Fleet-wide Datto BCDR answers - failed screenshots, stale backups, at-risk clients - from a local mirror in one ask.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/datto-bcdr/"
     },
     {
@@ -127,6 +157,8 @@
       "tagline": "Fleet-wide Datto RMM answers - stale agents, alert storms, patch and AV gaps - from a local mirror in one ask.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/datto-rmm/"
     },
     {
@@ -135,6 +167,8 @@
       "tagline": "Roll up Domotz fleet health, offline devices, and asset inventory across every monitored site from the terminal.",
       "category": "Network Monitoring",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/domotz/"
     },
     {
@@ -143,6 +177,8 @@
       "tagline": "Push usage counts, catch billing drift, and trace alerts to PSA tickets in Gradient MSP Synthesize from your terminal.",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/gradient/"
     },
     {
@@ -151,6 +187,8 @@
       "tagline": "Triage tickets, pre-empt SLA breaches, run cross-client analytics by asking.",
       "category": "PSA",
       "verification": "live-verified",
+      "verified_by": "Servosity (maintainer)",
+      "issue_url": null,
       "url": "/skills/halopsa/"
     },
     {
@@ -159,6 +197,8 @@
       "tagline": "Pipeline health, stale deals, and owner workload for every client by asking.",
       "category": "CRM",
       "verification": "live-verified",
+      "verified_by": "Servosity (maintainer)",
+      "issue_url": null,
       "url": "/skills/hubspot/"
     },
     {
@@ -167,6 +207,8 @@
       "tagline": "Audit Hudu documentation hygiene, find stale passwords and expiring certs, and search every company offline.",
       "category": "Documentation",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/hudu/"
     },
     {
@@ -175,6 +217,8 @@
       "tagline": "Triage Huntress incidents and coverage gaps across every client org from one queue.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/huntress/"
     },
     {
@@ -183,6 +227,8 @@
       "tagline": "Find any device, audit stale passwords, and rank thin client docs by asking.",
       "category": "Documentation",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/itglue/"
     },
     {
@@ -191,6 +237,8 @@
       "tagline": "Run the Kaseya BMS service desk, contracts, and billing from your terminal - with offline analytics the web grid can't compute.",
       "category": "PSA",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/kaseya-bms/"
     },
     {
@@ -199,6 +247,8 @@
       "tagline": "Hunt repeat clickers, track risk drift, and close training-coverage gaps across every KnowBe4 client from your terminal.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/knowbe4/"
     },
     {
@@ -207,6 +257,8 @@
       "tagline": "Rank your riskiest endpoints, patch posture, and stale devices across your Level RMM fleet from one command.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/levelio/"
     },
     {
@@ -215,6 +267,8 @@
       "tagline": "See every config change, stale collector, and offline agent across your whole Liongard estate from one command.",
       "category": "Documentation",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/liongard/"
     },
     {
@@ -223,6 +277,8 @@
       "tagline": "Find wasted M365 licenses, audit global admins, and triage Defender alerts by asking.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/microsoft-graph/"
     },
     {
@@ -231,6 +287,8 @@
       "tagline": "Pull datasets, snapshot KPIs, and track ticket backlog trends by asking.",
       "category": "Analytics",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/mspbots/"
     },
     {
@@ -239,6 +297,8 @@
       "tagline": "Find any device, triage issues, and search across every client by asking.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/n-central/"
     },
     {
@@ -247,6 +307,8 @@
       "tagline": "Audit autoscale, sweep idle session hosts, and reconcile per-customer billing across every Nerdio Manager account from your terminal.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/nerdio/"
     },
     {
@@ -255,6 +317,8 @@
       "tagline": "Fleet-wide NinjaOne answers - patch compliance, backup gaps, AV blast-radius - from a local mirror in one query.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/ninjaone/"
     },
     {
@@ -263,6 +327,8 @@
       "tagline": "Triage PagerDuty incidents, on-call schedules, and escalation policies from the terminal.",
       "category": "Incident Response",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/pagerduty/"
     },
     {
@@ -271,6 +337,8 @@
       "tagline": "Find stalled proposals, aging quotes, and unsigned PandaDoc documents from the terminal.",
       "category": "Documentation",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/pandadoc/"
     },
     {
@@ -279,6 +347,8 @@
       "tagline": "Reconcile Pax8 billing, track MRR, and catch usage overages before they hit the customer invoice",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/pax8/"
     },
     {
@@ -287,6 +357,8 @@
       "tagline": "Surface stale deals, weighted forecasts, and overdue follow-ups across your pipeline by asking.",
       "category": "CRM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/pipedrive/"
     },
     {
@@ -295,6 +367,8 @@
       "tagline": "Investigate Proofpoint TAP threats, VAPs, and top clickers from your terminal without burning the daily API quota.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/proofpoint/"
     },
     {
@@ -303,6 +377,8 @@
       "tagline": "Answer AR/AP aging, DSO, cash-forecast, and month-end close questions across QuickBooks Online by asking.",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/quickbooks/"
     },
     {
@@ -311,6 +387,8 @@
       "tagline": "Triage your managed SOC, rank devices at risk, and audit suppression rules from the terminal - no console logins.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/rocketcyber/"
     },
     {
@@ -319,6 +397,8 @@
       "tagline": "Every Rootly incident, alert, and on-call object as a typed command, plus offline MTTR and coverage-gap answers.",
       "category": "Incident Response",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/rootly/"
     },
     {
@@ -327,6 +407,8 @@
       "tagline": "Find every asset on your attack surface, diff it over time, and trace any CVE to the machines it hits.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/runzero/"
     },
     {
@@ -335,6 +417,8 @@
       "tagline": "Surface stale quotes, thin-margin lines, and pipeline velocity across your Salesbuildr quoting by asking.",
       "category": "CRM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/salesbuildr/"
     },
     {
@@ -343,6 +427,8 @@
       "tagline": "Triage threats, find protection gaps, and catch overnight fleet drift across every SentinelOne tenant by asking.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/sentinelone/"
     },
     {
@@ -351,6 +437,8 @@
       "tagline": "Fleet attention, stale backups, QBR reports, and restore watch for every client by asking.",
       "category": "Backup/DR",
       "verification": "live-verified",
+      "verified_by": "Servosity (maintainer)",
+      "issue_url": null,
       "url": "/skills/servosity/"
     },
     {
@@ -359,6 +447,8 @@
       "tagline": "Reconcile what you owe Sherweb against what customers owe you and surface true net margin per customer.",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/sherweb/"
     },
     {
@@ -367,6 +457,8 @@
       "tagline": "Catch silently-failing Microsoft 365 backups across every SkyKick tenant before a customer needs a restore.",
       "category": "Backup/DR",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/skykick/"
     },
     {
@@ -375,6 +467,8 @@
       "tagline": "Catch SLA breaches, unbilled time, and at-risk assets across PSA and RMM by asking.",
       "category": "PSA",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/superops/"
     },
     {
@@ -383,6 +477,8 @@
       "tagline": "Run every Syncro PSA and RMM workflow from your terminal: tickets, billing, and patch gaps in one ask.",
       "category": "PSA",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/syncro/"
     },
     {
@@ -391,6 +487,8 @@
       "tagline": "Triage every agent, sweep patch posture, and run a script across a filtered cohort by asking.",
       "category": "RMM",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/tactical-rmm/"
     },
     {
@@ -399,6 +497,8 @@
       "tagline": "Clear approval backlogs, beat the 31-day audit cliff, and find dark agents across every tenant by asking.",
       "category": "Security",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/threatlocker/"
     },
     {
@@ -407,6 +507,8 @@
       "tagline": "Answer AR/AP aging, reconciliation, and GL tie-out for a Xero org from the terminal - offline, in one call.",
       "category": "Billing",
       "verification": "awaiting",
+      "verified_by": null,
+      "issue_url": null,
       "url": "/skills/xero/"
     }
   ],

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -37,7 +37,7 @@ The vision is simple: one install pattern, every MSP tool. HaloPSA and Servosity
 ### Abnormal Security (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/abnormal/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/abnormal/install.sh)
 
 Abnormal Security plus your AI answers the SOC questions the portal makes you click for: what new email threats are still unremediated right now, what numbers go in this quarter's client security report, and an employee's full account-takeover risk picture - each in one command. It syncs your tenant to a local store, ranks the threat queue, and confirms remediations actually completed.
@@ -75,7 +75,7 @@ Governance: The skill authenticates with a single ABNORMAL_API_TOKEN scoped to y
 ### Acronis Cyber Protect Cloud (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/acronis/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/acronis/install.sh)
 
 MSPs run Acronis Cyber Protect Cloud across dozens of customer tenants, but its partner dashboards report one tenant at a time. Ask your AI "whose backups failed last night," "which agents went offline," or "where am I billing for protection that isn't running," and get the cross-tenant answer in one table - computed offline from a local mirror, not six console drill-downs or a month-end CSV export.
@@ -115,7 +115,7 @@ Governance: The skill drives the acronis-cli and acronis-mcp binaries, authentic
 ### Action1 (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/action1/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/action1/install.sh)
 
 Ask "which endpoints across all my clients are missing the most patches?" and get one ranked list - no clicking org by org. Action1's API and console are siloed per client organization; this skill syncs every org into a local mirror so patch posture, CVE blast-radius, stale agents, and a per-client scorecard become single fleet-wide commands your AI agent runs from the terminal.
@@ -151,7 +151,7 @@ Governance: The skill reads freely - fleet rollups, lists, reports, search, expo
 ### Afi (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/afi/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/afi/install.sh)
 
 Ask your AI 'which mailboxes aren't backed up in Afi?' and get the answer across every tenant at once. This skill walks your whole Afi fleet into a local store, then answers coverage gaps, stale backups, license drift, and per-tenant posture offline - no per-tenant portal clicking, no tripping Afi's rate limits - and runs a verified archive-then-release when someone leaves.
@@ -186,7 +186,7 @@ Governance: The skill reads your Afi fleet (installations, orgs, tenants, resour
 ### AppDirect (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/appdirect/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/appdirect/install.sh)
 
 Ask 'which AppDirect payments failed this week?' or 'reconcile billing before month-close' and get an answer across every reseller company in one call. The skill syncs your whole AppDirect marketplace - subscriptions, invoices, payments, companies, pipeline - into a local mirror, so cross-company billing questions that take hundreds of console clicks return instantly, offline, from your terminal or your AI agent.
@@ -220,7 +220,7 @@ Governance: The skill reads marketplace data - companies, users, subscriptions, 
 ### Atera (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/atera/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/atera/install.sh)
 
 Ask plain-English questions about your whole Atera estate and get answers the portal can't assemble in one view: which agents went dark, which tickets are about to breach SLA, which customers are under-contracted, and what contracts expire next quarter. `atera-cli` syncs Atera into a local SQLite mirror, then answers cross-client rollups instantly and offline - from the terminal or any AI agent.
@@ -258,7 +258,7 @@ Governance: The skill reads everything - agents, tickets, customers, contracts, 
 ### Autotask PSA (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/autotask/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/autotask/install.sh)
 
 MSPs run Autotask PSA as the system of record - tickets, time, contracts, billing. Ask your AI "what's gone stale on the service desk," "which approved time hasn't been invoiced," or "how burned is that block-hours contract," and get answers the portal can't compose: cross-entity rollups across tickets, time, contracts, and resources, computed offline from a local mirror in one query instead of a LiveReport and an Excel export.
@@ -299,7 +299,7 @@ Governance: The skill drives the autotask-cli and autotask-mcp binaries, authent
 ### Axcient x360Recover (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/axcient/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/axcient/install.sh)
 
 MSPs run Axcient x360Recover across dozens of clients, but the portal answers one entity at a time and the public API famously won't tell you which client a device belongs to. Ask your AI "whose backups failed last night," "who's breaching RPO," or "what do I bill each client this month," and get the fleet-wide answer in one table - computed offline from a local mirror that joins the device, job, restore-point, and client data the raw API leaves unconnected.
@@ -339,7 +339,7 @@ Governance: The skill drives the axcient-cli and axcient-mcp binaries, authentic
 ### Better Stack (Monitoring)
 
 Page: https://msp-skills.compoundingteams.com/skills/betterstack/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/betterstack/install.sh)
 
 Ask your AI "what's down and is anyone actually paged?" and get a straight answer across your whole Better Stack account: every client's monitors, heartbeats, open incidents, and on-call rotation in one view. It surfaces the silent monitors that page nobody, the noisy ones waking techs at 3am, your real MTTA/MTTR, and status pages showing green while a monitor is down.
@@ -377,7 +377,7 @@ Governance: The skill reads your Better Stack monitors, heartbeats, incidents, o
 ### Blumira (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/blumira/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/blumira/install.sh)
 
 Running Blumira across a book of client accounts? Ask your AI "what are the worst open findings everywhere," "which detections fell out of coverage this week," or "which domain controllers went dark," and get one cross-account answer the Blumira portal can't compose. Every sub-account is mirrored into a local store, so one ranked triage queue, one MTTR rollup, and one coverage-drift report replace dozens of one-account-at-a-time portal logins.
@@ -414,7 +414,7 @@ Governance: The skill reads findings, detections, agents, and evidence through y
 ### CIPP (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/cipp/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/cipp/install.sh)
 
 CIPP manages Microsoft 365 across all your client tenants, but its portal and API work one tenant at a time. Ask your AI "which tenants are off our security baseline" or "where are we paying for unused licenses" and get the cross-tenant answer the UI never renders: one fan-out pulls every tenant into a local store, then posture, license-waste, stale-account, and standards-drift rollups run instantly - offline, across the whole fleet.
@@ -452,7 +452,7 @@ Governance: The skill drives the cipp-cli and cipp-mcp binaries, authenticating 
 ### ConnectWise PSA (Manage) (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/connectwise-manage/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/connectwise-manage/install.sh)
 
 MSPs run ConnectWise PSA (Manage) as the system of record - tickets, time, agreements, billing. Ask your AI "what's rotting on the board," "which closed tickets have no time logged," or "how burned is that block-hours agreement," and get answers the portal can't compose: cross-entity joins across tickets, time, agreements, and configurations, computed offline from a local mirror in one query instead of five portal screens and an Excel export.
@@ -490,7 +490,7 @@ Governance: The skill drives the connectwise-manage-cli and connectwise-manage-m
 ### Cove Data Protection (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/cove/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/cove/install.sh)
 
 Ask which Cove backups failed last night and get every failed, aborted, or never-started device across all your customers in one sweep, the status codes decoded to plain names. Cove's console scopes to one partner at a time and forgets yesterday; this skill speaks the whole JSON-RPC API and keeps a local snapshot history, so storage-growth and what-changed-since-Friday trends exist at all.
@@ -523,7 +523,7 @@ Governance: The skill is read-first: every command that touches Cove reads (fail
 ### CrowdStrike Falcon (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/crowdstrike/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/crowdstrike/install.sh)
 
 Running CrowdStrike Falcon across a book of client tenants? Ask your AI "what should I triage first across every CID," "which sensors went silent," or "where are the critical vulnerabilities," and get one cross-tenant answer the Falcon console can't compose. Every child CID is mirrored into one local store keyed by CID, so a single scorecard, vuln ranking, and stale-sensor sweep replace flipping Flight Control tenant by tenant.
@@ -563,7 +563,7 @@ Governance: The skill drives the crowdstrike-cli and crowdstrike-mcp binaries, a
 ### Datto BCDR (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/datto-bcdr/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/datto-bcdr/install.sh)
 
 Ask in plain English which Datto backups failed their last screenshot verification, which clients are most at risk, and which appliance fills up first - and get the answer across your whole fleet in seconds. The Datto BCDR API answers one appliance at a time; this skill mirrors every device, agent, and alert locally, so the fleet-wide question the Partner Portal can't answer becomes one instant command.
@@ -602,7 +602,7 @@ Governance: The datto-bcdr skill is read-only for everyday use: it reads your Da
 ### Datto RMM (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/datto-rmm/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/datto-rmm/install.sh)
 
 Ask in plain English which endpoints across every client have gone dark, lost antivirus, fallen behind on patches, or are about to drop out of warranty - and get the list in seconds. Datto RMM plus your AI agent reads a local mirror of your whole multi-site fleet, so the cross-customer questions the portal makes you click through site by site become one instant, reproducible answer.
@@ -636,7 +636,7 @@ Governance: The skill reads your Datto RMM fleet and writes only when you ask it
 ### Domotz (Network Monitoring)
 
 Page: https://msp-skills.compoundingteams.com/skills/domotz/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/domotz/install.sh)
 
 Ask your AI "which client sites have devices down right now?" and get one answer instead of clicking through the Domotz portal Collector by Collector. domotz-cli syncs every Collector into a local mirror, so cross-site rollups - fleet health, every offline device, overnight new-device sweeps, one unified asset inventory - come back as single offline queries your agent can run in seconds.
@@ -670,7 +670,7 @@ Governance: The skill reads your Domotz fleet - Collectors, devices, variables, 
 ### Gradient MSP (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/gradient/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/gradient/install.sh)
 
 Ask your AI to push tonight's usage counts, tell you which accounts' billing changed since the last push, and confirm an alert actually became a PSA ticket - and it runs the real Gradient MSP Synthesize commands and shows you the receipts. The full vendor API from your terminal, plus a local push ledger and offline mirror that Gradient's PowerShell SDK cannot give you.
@@ -704,7 +704,7 @@ Governance: The skill reads your Synthesize accounts, services, mappings, integr
 ### HaloPSA (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/halopsa/
-Badge: Live-verified
+Verification: Live-verified by Servosity (maintainer) (2026-06-05)
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
 
 MSPs run HaloPSA as the service desk - tickets, SLAs, contracts, and the queue that never stops. Ask your AI "what's about to breach SLA," "who's overloaded," or "what's the whole story for this client," and get an answer the portal can't compose in one shot: cross-entity rollups across tickets, clients, contracts, time, and assets, joined offline in one query instead of clicking through five tabs. A local SQLite mirror means QBR-time questions don't hit rate limits.
@@ -740,7 +740,7 @@ Governance: The skill drives the halopsa-cli and halopsa-mcp binaries, authentic
 ### HubSpot (CRM)
 
 Page: https://msp-skills.compoundingteams.com/skills/hubspot/
-Badge: Live-verified
+Verification: Live-verified by Servosity (maintainer) (2026-06-05)
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hubspot/install.sh)
 
 MSPs run HubSpot as the sales CRM - pipeline, deals, quote-chasing. Ask your AI "which deals went cold," "what's my pipeline health," or "who do I call today," and get an answer the portal can't compose: cross-object rollups across deals, contacts, owners, and engagements, computed offline in one query instead of a dozen exports and saved views.
@@ -776,7 +776,7 @@ Governance: The skill drives the hubspot-cli and hubspot-mcp binaries, authentic
 ### Hudu (Documentation)
 
 Page: https://msp-skills.compoundingteams.com/skills/hudu/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hudu/install.sh)
 
 Ask in plain English which clients have the worst documentation, which vault passwords are overdue for rotation, and what SSL certs, domains, or warranties expire next - across every company at once. Hudu plus your AI agent reads a local mirror of your whole instance, so the hygiene questions the portal makes you click through company by company become one instant, reproducible answer.
@@ -810,7 +810,7 @@ Governance: The skill reads everything over a local mirror - audits, search, res
 ### Huntress (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/huntress/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/huntress/install.sh)
 
 Ask "which Huntress incidents are oldest across all my clients?" and get one age-sorted queue spanning every organization - the cross-tenant view the per-org portal never shows. Triage incidents fleet-wide, find coverage gaps and dark agents, reconcile invoiced seats against deployed agents, and trace an indicator's blast radius across your whole account, in plain English, from one local mirror.
@@ -846,7 +846,7 @@ Governance: The skill authenticates with your Huntress API key and secret and is
 ### IT Glue (Documentation)
 
 Page: https://msp-skills.compoundingteams.com/skills/itglue/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/itglue/install.sh)
 
 MSPs keep their whole client world in IT Glue - organizations, contacts, passwords, configurations, documents - but the API answers one record at a time under a 3000-request rate ceiling. Ask your AI "which clients are under-documented," "which credentials haven't rotated in a year," or "which client owns this serial number," and get fleet-wide answers from a local mirror in one query - no portal clicking, no rate-limit math.
@@ -884,7 +884,7 @@ Governance: The skill drives the itglue-cli and itglue-mcp binaries, authenticat
 ### Kaseya BMS (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/kaseya-bms/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/kaseya-bms/install.sh)
 
 Run the Kaseya BMS service desk, contracts, and billing from your terminal - or let your AI agent do it. Ask in plain English which queues are underwater, which tickets are going stale, who's overloaded, how much of each contract you've burned, and what billable time is sitting unbilled - and get the answer instantly from a local mirror, without exporting a single report.
@@ -920,7 +920,7 @@ Governance: The skill reads everything - tickets, CRM, contracts, finance, proje
 ### KnowBe4 (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/knowbe4/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/knowbe4/install.sh)
 
 KnowBe4's console reports one tenant, one phishing test, one chart at a time. This skill syncs your KMSAT data into a local SQLite mirror and answers the questions the portal can't: which users clicked the bait in multiple phishing tests, whose risk score is deteriorating this quarter, and who clicked a phish but finished zero training - across every client, in seconds, from your terminal.
@@ -954,7 +954,7 @@ Governance: The skill reads your KnowBe4 reporting data - accounts, users, group
 ### Level (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/levelio/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/levelio/install.sh)
 
 Ask "which Level endpoints are most at risk right now?" and get one ranked list across active alerts, missing patches, low security scores, and dark devices - not four portal tabs. levelio-cli syncs your whole Level fleet into a local mirror, then answers portfolio-wide questions the portal shows one device at a time: patch exposure, stale agents, alert clusters, and per-client QBR scorecards. Offline, instant, and read-only-safe.
@@ -990,7 +990,7 @@ Governance: The skill reads everything - reports, rollups, search, and a sync to
 ### Liongard (Documentation)
 
 Page: https://msp-skills.compoundingteams.com/skills/liongard/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/liongard/install.sh)
 
 Ask "what changed across all my clients this week," "which Liongard collectors went stale," or "which agents are offline," and get the answer in one command instead of clicking through the portal environment by environment. The skill syncs your whole Liongard estate into a local mirror, then drift-checks, searches, and rolls it up across every environment - so the visibility you already pay for finally reaches you.
@@ -1026,7 +1026,7 @@ Governance: Read commands (drift, health, coverage, the stale/offline/failure ro
 ### Microsoft Graph (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/microsoft-graph/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/microsoft-graph/install.sh)
 
 Microsoft retires the Graph CLI (mgc) on August 28, 2026 and points admins at the heavier PowerShell SDK. This is the lightweight successor: one cross-platform binary, no .NET or PowerShell runtime. Ask your AI "which M365 licenses are we wasting," "who holds privileged admin right now," or "what's new in Defender since yesterday," and get cross-tenant answers computed offline from a local SQLite mirror - one query instead of CSV exports and portal tab-hopping.
@@ -1062,12 +1062,12 @@ Governance: The skill drives the microsoft-graph-cli and microsoft-graph-mcp bin
 ### Concierge (Meta)
 
 Page: https://msp-skills.compoundingteams.com/skills/msp-skills-concierge/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 
 ### MSPbots (Analytics)
 
 Page: https://msp-skills.compoundingteams.com/skills/mspbots/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/mspbots/install.sh)
 
 MSPbots aggregates your PSA, RMM, and finance data into KPI dashboards - then keeps it there. Ask your AI "is our ticket backlog up or down this week" and get the answer the dashboard can't give: point-in-time snapshots, week-over-week deltas, row-level diffs, and full CSV exports - through readable aliases and filters instead of 19-digit resource IDs and a comma-encoded query DSL.
@@ -1107,7 +1107,7 @@ Governance: The skill drives the mspbots-cli and mspbots-mcp binaries, authentic
 ### N-able N-central (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/n-central/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/n-central/install.sh)
 
 N-central knows every device you manage - and answering "where is that machine" still means walking the console's org tree. Ask your AI "what's red right now", "where is EXCHANGE01", or "which devices have no maintenance window before Saturday's patch wave" and get rollups the console can't compose: cross-tenant search from an offline mirror, severity-ranked triage, coverage audits, and a guardian that catches the JWT before it silently dies.
@@ -1147,7 +1147,7 @@ Governance: The skill drives the n-central-cli and n-central-mcp binaries, authe
 ### Nerdio Manager (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/nerdio/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/nerdio/install.sh)
 
 Ask "which host pools have autoscale off across all my customers?" and get one table - not 30 portal logins. Every MSP runs its own Nerdio Manager (NMM) install, so each answer normally means clicking through one tenant at a time. This skill pulls your whole NMM fleet into a local mirror and answers cross-account autoscale, power-state, billing, and Intune questions in a single command.
@@ -1185,7 +1185,7 @@ Governance: The skill reads your whole NMM fleet - accounts, host pools, session
 ### NinjaOne (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/ninjaone/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/ninjaone/install.sh)
 
 NinjaOne is built for real-time, per-device RMM, but its reporting answers one organization at a time. Ask your AI "which clients are below 95% patched," "which endpoints across the fleet have no backup," or "how far did this threat spread" and get fleet-wide rollups computed offline from a local SQLite mirror of your estate - one query instead of a per-org report re-totaled in a spreadsheet or a third-party BI overlay.
@@ -1225,7 +1225,7 @@ Governance: The skill drives the ninjaone-cli and ninjaone-mcp binaries, authent
 ### PagerDuty (Incident Response)
 
 Page: https://msp-skills.compoundingteams.com/skills/pagerduty/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pagerduty/install.sh)
 
 Ask "who's on call for the payments service right now, and when do they hand off?" or "what's our MTTR by service this month?" and get the answer in one command. PagerDuty syncs to a local SQLite mirror, so post-incident analytics, on-call coverage audits, and escalation-gap checks run instantly and offline: no Analytics add-on, no portal clicking, no per-question API call.
@@ -1261,7 +1261,7 @@ Governance: The skill reads everything through your PagerDuty REST API key and w
 ### PandaDoc (Documentation)
 
 Page: https://msp-skills.compoundingteams.com/skills/pandadoc/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pandadoc/install.sh)
 
 Ask your AI "which proposals are stalled?" or "what's our open quote value?" and get the answer in seconds. PandaDoc's portal shows one document at a time and has no rollup for these. This skill syncs your documents, templates, and contacts into a local mirror, so cross-document questions - stalled deals, aging quotes, recipient engagement, dollars in-flight - become one instant query instead of a manual export-and-pivot.
@@ -1299,7 +1299,7 @@ Governance: Reads (pipeline, stalled, aging, value, search, list commands) are a
 ### Pax8 (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/pax8/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pax8/install.sh)
 
 MSPs resell Microsoft, security, and backup through Pax8, then lose days each month reconciling its invoices against subscriptions and their PSA. Ask your AI "where is billing leaking this month," "what's my MRR and margin," or "which usage is about to overage," and get answers the Pax8 portal can't compose: invoices joined to subscriptions joined to usage, computed offline from a local mirror in one query instead of a CSV export and a spreadsheet.
@@ -1335,7 +1335,7 @@ Governance: The skill drives the pax8-cli and pax8-mcp binaries, authenticating 
 ### Pipedrive (CRM)
 
 Page: https://msp-skills.compoundingteams.com/skills/pipedrive/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pipedrive/install.sh)
 
 Ask your AI "which deals are dying and who do I call today," and get a ranked answer in seconds. The Pipedrive skill keeps a local copy of your pipeline so it can join deals, people, activities, and notes the portal shows on separate screens - surfacing stale deals by dollar at risk, a weighted forecast, stage bottlenecks, and rep leaderboards without exporting a single CSV.
@@ -1371,7 +1371,7 @@ Governance: The skill can read your whole pipeline and can create, update, and d
 ### Proofpoint TAP (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/proofpoint/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/proofpoint/install.sh)
 
 Proofpoint TAP's dashboard answers one threat, one clicker, one campaign at a time, and every SIEM pull spends against a hard daily quota. This skill backfills clicks, messages, campaigns, Very Attacked People, and clickers into a local SQLite store, then answers the questions the console can't: who is both heavily attacked and clicking, every event that touched one user, and a full incident brief from a single threatId - offline, in seconds.
@@ -1407,7 +1407,7 @@ Governance: The skill reads your Proofpoint TAP threat data - SIEM click and mes
 ### QuickBooks Online (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/quickbooks/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/quickbooks/install.sh)
 
 Ask your books a question and get the answer, not a CSV export. The skill syncs your QuickBooks Online company into a local SQLite mirror, then answers who owes you (ar-aging), what you owe (ap-aging), where the cash is (balances), which invoices to chase first (invoices stale), and whether the books are clean to close (reconcile) - instantly, offline, across the whole book. No portal clicking, no per-question API call.
@@ -1443,7 +1443,7 @@ Governance: The skill reads everything - aging, balances, DSO, cash forecast, re
 ### RocketCyber (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/rocketcyber/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/rocketcyber/install.sh)
 
 Ask your AI "what broke across all my RocketCyber clients overnight?" and get one ranked board - open incidents, malicious event counts, and offline agents - instead of clicking through a per-client console. The same skill ranks devices at risk, computes incident MTTR for QBRs, trends Microsoft 365 secure scores, and flags stale suppression rules that quietly hide real detections. All from the terminal.
@@ -1474,7 +1474,7 @@ Governance: The skill reads your RocketCyber SOC data - incidents, agents, detec
 ### Rootly (Incident Response)
 
 Page: https://msp-skills.compoundingteams.com/skills/rootly/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/rootly/install.sh)
 
 Ask "who's on call for this service right now?" or "what's our MTTR by service this quarter?" and get the answer in one command. Rootly syncs to a local SQLite mirror, so incident-similarity, resolution mining, on-call coverage audits, and MTTA/MTTR analytics run instantly and offline - no portal clicking, no per-question API call.
@@ -1508,7 +1508,7 @@ Governance: The skill reads incidents, alerts, schedules, and on-call data, and 
 ### runZero (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/runzero/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/runzero/install.sh)
 
 runZero's API answers one entity at a time; it cannot join assets to services to vulnerabilities in a single call. This skill syncs your whole attack surface into a local SQLite copy, then ranks exposure, diffs what changed since the last sync, and traces any CVE to the exact assets it hits - offline, at zero API quota. Ask in plain language; your agent runs the command and reads back the answer.
@@ -1546,7 +1546,7 @@ Governance: The skill reads your runZero attack surface - assets, services, soft
 ### Salesbuildr (CRM)
 
 Page: https://msp-skills.compoundingteams.com/skills/salesbuildr/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/salesbuildr/install.sh)
 
 Ask your AI which quotes are aging, which lines are bleeding margin, and where your pipeline is stalling - and get the answer from your own Salesbuildr data in seconds. salesbuildr-cli syncs your quotes, opportunities, products, and pricing books into a local mirror, so the cross-quote questions the portal can't answer in one click become a single command.
@@ -1580,7 +1580,7 @@ Governance: The skill reads your Salesbuildr quotes, opportunities, products, co
 ### SentinelOne (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/sentinelone/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/sentinelone/install.sh)
 
 Running SentinelOne across a book of customer sites? Ask your AI "what should I triage first across every client," "which endpoints went dark or dropped to detect-only," or "where did this malicious file spread," and get one cross-site answer the console can't compose. Every site is mirrored into a local store, so one triage worklist, one fleet-health rollup, and one posture scorecard replace the morning ritual of flipping the console scope selector tenant by tenant.
@@ -1620,7 +1620,7 @@ Governance: The skill drives the sentinelone-cli and sentinelone-mcp binaries, a
 ### Servosity (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/servosity/
-Badge: Live-verified
+Verification: Live-verified by Servosity (maintainer) (2026-06-05)
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
 
 MSPs run Servosity as the backup and DR platform - M365, DR Server, and DR Desktop protection across a whole book of clients. Ask your AI "where is my attention needed today", "which backups went stale this week", or "build Acme's QBR backup section" and get fleet-wide answers the per-client dashboard can't compose: ranked attention sweeps, day-over-day drift, ready-to-send stale-backup follow-ups, and the whole book's QBR reports in one pass.
@@ -1658,7 +1658,7 @@ Governance: First-party: published by Servosity for MSP partners. The skill driv
 ### Sherweb (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/sherweb/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/sherweb/install.sh)
 
 MSPs resell Microsoft 365, Azure, and security through Sherweb, then spend the monthly close reconciling what they owe Sherweb against what they bill customers. Ask your AI "what's my net margin per customer," "which subscriptions am I paying for but not billing," or "what will this seat change cost," and get answers the Sherweb portal cannot compose: payable charges joined to receivable charges and subscriptions, computed offline from a local mirror in one query instead of a CSV export and a spreadsheet.
@@ -1695,7 +1695,7 @@ Governance: The skill drives the sherweb-cli and sherweb-mcp binaries, authentic
 ### SkyKick (Backup/DR)
 
 Page: https://msp-skills.compoundingteams.com/skills/skykick/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/skykick/install.sh)
 
 Run one fleet-sync, then ask your AI which SkyKick customers have a backup gap right now. It reads every subscription's Exchange/SharePoint posture, snapshot recency, coverage, and retention from a local copy and answers across all your tenants at once - the cross-customer view the per-tenant SkyKick portal never rolls up.
@@ -1727,7 +1727,7 @@ Governance: The skill is read-first: every posture, staleness, coverage, retenti
 ### SuperOps (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/superops/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/superops/install.sh)
 
 SuperOps unifies PSA and RMM on one database, but the console still answers one entity at a time. Ask your AI "who's about to breach SLA, and on whose queue," "what's the full picture on Acme before the QBR," or "which endpoints are unpatched and actively alerting," and get cross-entity answers computed offline from a local SQLite mirror of your tenant - one query instead of five console screens or a scheduled report.
@@ -1763,7 +1763,7 @@ Governance: The skill drives the superops-cli and superops-mcp binaries, authent
 ### Syncro (PSA)
 
 Page: https://msp-skills.compoundingteams.com/skills/syncro/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/syncro/install.sh)
 
 Ask your AI "which customers have logged time we never invoiced?" and get the unbilled hours ranked by customer in seconds - no report exports, no portal clicking. Syncro plus your agent answers billing-leakage, AR-aging, SLA-breach, and patch-gap questions across every customer at once, from one local mirror of your Syncro PSA and RMM data. Free, open source, runs on your laptop.
@@ -1800,7 +1800,7 @@ Governance: The skill is read-first: reporting, rollups, and cross-entity views 
 ### Tactical RMM (RMM)
 
 Page: https://msp-skills.compoundingteams.com/skills/tactical-rmm/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/tactical-rmm/install.sh)
 
 Ask plain-English questions about your whole self-hosted Tactical RMM fleet and get answers the web UI can't assemble in one view: which agents went dark, where patches and reboots are pending across every client, what changed overnight, and which endpoints are unmonitored. `tactical-rmm-cli` mirrors your fleet into local SQLite, then answers cross-client rollups instantly and offline - and can fan a command across a filtered cohort, preview-first.
@@ -1841,7 +1841,7 @@ Governance: The skill reads everything across your fleet - agents, clients, site
 ### ThreatLocker (Security)
 
 Page: https://msp-skills.compoundingteams.com/skills/threatlocker/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/threatlocker/install.sh)
 
 Running ThreatLocker across a whole book of customer tenants? Ask your AI "what approvals are pending everywhere," "which agents went dark this week," or "which clients are about to lose audit evidence," and get one cross-tenant answer the Portal can't compose. Every tenant is mirrored into a local store, so one approval queue, one audit archive, and one health rollup replace dozens of one-tenant-at-a-time Portal logins.
@@ -1879,7 +1879,7 @@ Governance: The skill drives the threatlocker-cli and threatlocker-mcp binaries,
 ### Xero (Billing)
 
 Page: https://msp-skills.compoundingteams.com/skills/xero/
-Badge: Awaiting live verification
+Verification: Awaiting live verification
 Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/xero/install.sh)
 
 Ask in plain English who owes you and how overdue, which authorised invoices still have no payment applied, and whether the general ledger ties to outstanding invoices at close - for a Xero organisation, in one call. Xero plus your AI agent reads a local mirror of the org, so the aging, reconciliation, and tie-out questions the web reports make you export and pivot become one instant, offline answer.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,160 +6,160 @@ What this site calls an MCP server is what ChatGPT calls an app or connector, Cl
 
 ## Connectors
 
-- Abnormal Security (Security) - Triage Abnormal email threats, confirm remediations, and pull client-ready security reports from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/abnormal/
+- Abnormal Security (Security) - ask "What new, unremediated email threats need attention right now?" - Triage Abnormal email threats, confirm remediations, and pull client-ready security reports from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/abnormal/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/abnormal/install.sh)
-- Acronis Cyber Protect Cloud (Backup/DR) - Spot failed backups, offline agents, and unbilled usage across every Acronis tenant by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/acronis/
+- Acronis Cyber Protect Cloud (Backup/DR) - ask "Whose backups succeeded, failed, or went stale across every customer last night?" - Spot failed backups, offline agents, and unbilled usage across every Acronis tenant by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/acronis/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/acronis/install.sh)
-- Action1 (RMM) - Patch every client's endpoints and triage CVEs fleet-wide from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/action1/
+- Action1 (RMM) - ask "Which endpoints across all clients are missing the most patches?" - Patch every client's endpoints and triage CVEs fleet-wide from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/action1/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/action1/install.sh)
-- Afi (Backup/DR) - Answer fleet-wide Afi backup coverage, staleness, and licensing questions from one local store.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/afi/
+- Afi (Backup/DR) - ask "Which resources have no backup protection at all?" - Answer fleet-wide Afi backup coverage, staleness, and licensing questions from one local store.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/afi/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/afi/install.sh)
-- AppDirect (Billing) - Reconcile AppDirect marketplace billing and chase failed payments across every reseller company before month-close.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/appdirect/
+- AppDirect (Billing) - ask "Which payments failed or stalled in the last week, across every company?" - Reconcile AppDirect marketplace billing and chase failed payments across every reseller company before month-close.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/appdirect/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/appdirect/install.sh)
-- Atera (RMM) - Answer fleet-health, SLA, and book-of-business questions across your Atera estate from the terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/atera/
+- Atera (RMM) - ask "Which agents have gone offline or stopped checking in?" - Answer fleet-health, SLA, and book-of-business questions across your Atera estate from the terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/atera/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/atera/install.sh)
-- Autotask PSA (PSA) - Triage tickets, surface unbilled time, and project retainer burn by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/autotask/
+- Autotask PSA (PSA) - ask "Which approved time entries haven't been invoiced yet?" - Triage tickets, surface unbilled time, and project retainer burn by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/autotask/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/autotask/install.sh)
-- Axcient x360Recover (Backup/DR) - Catch failed and stale Axcient backups, RPO breaches, and unbilled usage across every client by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/axcient/
+- Axcient x360Recover (Backup/DR) - ask "Whose backups failed or went stale across every client last night?" - Catch failed and stale Axcient backups, RPO breaches, and unbilled usage across every client by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/axcient/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/axcient/install.sh)
-- Better Stack (Monitoring) - Ask what's down, who's paged, where coverage is missing, and your MTTA/MTTR across your Better Stack account
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/betterstack/
+- Better Stack (Monitoring) - ask "What's down right now and is anyone actually paged?" - Ask what's down, who's paged, where coverage is missing, and your MTTA/MTTR across your Better Stack account
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/betterstack/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/betterstack/install.sh)
-- Blumira (Security) - Triage every Blumira finding across all your MSP client accounts from one ranked queue
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/blumira/
+- Blumira (Security) - ask "What are the worst open findings across all my client accounts right now?" - Triage every Blumira finding across all your MSP client accounts from one ranked queue
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/blumira/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/blumira/install.sh)
-- CIPP (Security) - Every client tenant's M365 posture, license waste, and stale accounts in one cross-tenant rollup.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/cipp/
+- CIPP (Security) - ask "Which tenants still have users without MFA registered?" - Every client tenant's M365 posture, license waste, and stale accounts in one cross-tenant rollup.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/cipp/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/cipp/install.sh)
-- ConnectWise PSA (Manage) (PSA) - Triage boards, catch unbilled time, and prep QBRs by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/connectwise-manage/
+- ConnectWise PSA (Manage) (PSA) - ask "Which tickets did we touch this week that have zero time logged against them?" - Triage boards, catch unbilled time, and prep QBRs by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/connectwise-manage/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/connectwise-manage/install.sh)
-- Cove Data Protection (Backup/DR) - Sweep every Cove customer for failed and stale backups, storage growth, and month-end billing from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/cove/
+- Cove Data Protection (Backup/DR) - ask "Which devices failed their last backup since yesterday?" - Sweep every Cove customer for failed and stale backups, storage growth, and month-end billing from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/cove/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/cove/install.sh)
-- CrowdStrike Falcon (Security) - Triage Falcon alerts, find stale sensors, and rank critical vulnerabilities across every tenant by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/crowdstrike/
+- CrowdStrike Falcon (Security) - ask "What should I triage first across all my client tenants right now?" - Triage Falcon alerts, find stale sensors, and rank critical vulnerabilities across every tenant by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/crowdstrike/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/crowdstrike/install.sh)
-- Datto BCDR (Backup/DR) - Fleet-wide Datto BCDR answers - failed screenshots, stale backups, at-risk clients - from a local mirror in one ask.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/datto-bcdr/
+- Datto BCDR (Backup/DR) - ask "Which protected machines failed their last backup screenshot verification?" - Fleet-wide Datto BCDR answers - failed screenshots, stale backups, at-risk clients - from a local mirror in one ask.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/datto-bcdr/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/datto-bcdr/install.sh)
-- Datto RMM (RMM) - Fleet-wide Datto RMM answers - stale agents, alert storms, patch and AV gaps - from a local mirror in one ask.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/datto-rmm/
+- Datto RMM (RMM) - ask "Which devices haven't checked in for 30 days, across every client?" - Fleet-wide Datto RMM answers - stale agents, alert storms, patch and AV gaps - from a local mirror in one ask.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/datto-rmm/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/datto-rmm/install.sh)
-- Domotz (Network Monitoring) - Roll up Domotz fleet health, offline devices, and asset inventory across every monitored site from the terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/domotz/
+- Domotz (Network Monitoring) - ask "Is anything on fire across all my sites?" - Roll up Domotz fleet health, offline devices, and asset inventory across every monitored site from the terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/domotz/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/domotz/install.sh)
-- Gradient MSP (Billing) - Push usage counts, catch billing drift, and trace alerts to PSA tickets in Gradient MSP Synthesize from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/gradient/
+- Gradient MSP (Billing) - ask "Push a whole file of usage counts and rebuild billing exactly once?" - Push usage counts, catch billing drift, and trace alerts to PSA tickets in Gradient MSP Synthesize from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/gradient/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/gradient/install.sh)
-- HaloPSA (PSA) - Triage tickets, pre-empt SLA breaches, run cross-client analytics by asking.
-  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/halopsa/
+- HaloPSA (PSA) - ask "What's about to breach SLA in the next 24 hours?" - Triage tickets, pre-empt SLA breaches, run cross-client analytics by asking.
+  Verification: Live-verified by Servosity (maintainer) (2026-06-05). Page: https://msp-skills.compoundingteams.com/skills/halopsa/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/halopsa/install.sh)
-- HubSpot (CRM) - Pipeline health, stale deals, and owner workload for every client by asking.
-  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/hubspot/
+- HubSpot (CRM) - ask "Which open deals have gone cold with no engagement in the last three weeks?" - Pipeline health, stale deals, and owner workload for every client by asking.
+  Verification: Live-verified by Servosity (maintainer) (2026-06-05). Page: https://msp-skills.compoundingteams.com/skills/hubspot/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hubspot/install.sh)
-- Hudu (Documentation) - Audit Hudu documentation hygiene, find stale passwords and expiring certs, and search every company offline.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/hudu/
+- Hudu (Documentation) - ask "Which clients have the worst documentation completeness?" - Audit Hudu documentation hygiene, find stale passwords and expiring certs, and search every company offline.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/hudu/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/hudu/install.sh)
-- Huntress (Security) - Triage Huntress incidents and coverage gaps across every client org from one queue.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/huntress/
+- Huntress (Security) - ask "Which incidents are oldest across every client org?" - Triage Huntress incidents and coverage gaps across every client org from one queue.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/huntress/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/huntress/install.sh)
-- IT Glue (Documentation) - Find any device, audit stale passwords, and rank thin client docs by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/itglue/
+- IT Glue (Documentation) - ask "Which client owns this device, serial number, or contact?" - Find any device, audit stale passwords, and rank thin client docs by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/itglue/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/itglue/install.sh)
-- Kaseya BMS (PSA) - Run the Kaseya BMS service desk, contracts, and billing from your terminal - with offline analytics the web grid can't compute.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/kaseya-bms/
+- Kaseya BMS (PSA) - ask "Which queues are underwater and what's going stale before standup?" - Run the Kaseya BMS service desk, contracts, and billing from your terminal - with offline analytics the web grid can't compute.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/kaseya-bms/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/kaseya-bms/install.sh)
-- KnowBe4 (Security) - Hunt repeat clickers, track risk drift, and close training-coverage gaps across every KnowBe4 client from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/knowbe4/
+- KnowBe4 (Security) - ask "Who clicked the bait in more than one phishing test?" - Hunt repeat clickers, track risk drift, and close training-coverage gaps across every KnowBe4 client from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/knowbe4/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/knowbe4/install.sh)
-- Level (RMM) - Rank your riskiest endpoints, patch posture, and stale devices across your Level RMM fleet from one command.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/levelio/
+- Level (RMM) - ask "Which devices are most at risk across alerts, patches, score, and staleness?" - Rank your riskiest endpoints, patch posture, and stale devices across your Level RMM fleet from one command.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/levelio/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/levelio/install.sh)
-- Liongard (Documentation) - See every config change, stale collector, and offline agent across your whole Liongard estate from one command.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/liongard/
+- Liongard (Documentation) - ask "What changed across all my clients in the last 24 hours?" - See every config change, stale collector, and offline agent across your whole Liongard estate from one command.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/liongard/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/liongard/install.sh)
-- Microsoft Graph (Security) - Find wasted M365 licenses, audit global admins, and triage Defender alerts by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/microsoft-graph/
+- Microsoft Graph (Security) - ask "Which SKUs are we paying for but not fully using, ranked by wasted seats?" - Find wasted M365 licenses, audit global admins, and triage Defender alerts by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/microsoft-graph/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/microsoft-graph/install.sh)
 - Concierge (Meta) - Tell it your stack - it recommends and installs the right connectors.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/msp-skills-concierge/
-- MSPbots (Analytics) - Pull datasets, snapshot KPIs, and track ticket backlog trends by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/mspbots/
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/msp-skills-concierge/
+- MSPbots (Analytics) - ask "Is our open-ticket backlog up or down versus last week?" - Pull datasets, snapshot KPIs, and track ticket backlog trends by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/mspbots/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/mspbots/install.sh)
-- N-able N-central (RMM) - Find any device, triage issues, and search across every client by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/n-central/
+- N-able N-central (RMM) - ask "What's red right now, grouped by customer and ranked by severity?" - Find any device, triage issues, and search across every client by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/n-central/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/n-central/install.sh)
-- Nerdio Manager (RMM) - Audit autoscale, sweep idle session hosts, and reconcile per-customer billing across every Nerdio Manager account from your terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/nerdio/
+- Nerdio Manager (RMM) - ask "Which host pools have autoscale off or drifting across every customer?" - Audit autoscale, sweep idle session hosts, and reconcile per-customer billing across every Nerdio Manager account from your terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/nerdio/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/nerdio/install.sh)
-- NinjaOne (RMM) - Fleet-wide NinjaOne answers - patch compliance, backup gaps, AV blast-radius - from a local mirror in one query.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/ninjaone/
+- NinjaOne (RMM) - ask "Which organizations are below 95% patch compliance?" - Fleet-wide NinjaOne answers - patch compliance, backup gaps, AV blast-radius - from a local mirror in one query.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/ninjaone/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/ninjaone/install.sh)
-- PagerDuty (Incident Response) - Triage PagerDuty incidents, on-call schedules, and escalation policies from the terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pagerduty/
+- PagerDuty (Incident Response) - ask "What's on fire right now, ranked by SLA risk?" - Triage PagerDuty incidents, on-call schedules, and escalation policies from the terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pagerduty/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pagerduty/install.sh)
-- PandaDoc (Documentation) - Find stalled proposals, aging quotes, and unsigned PandaDoc documents from the terminal.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pandadoc/
+- PandaDoc (Documentation) - ask "Which documents were sent but never completed?" - Find stalled proposals, aging quotes, and unsigned PandaDoc documents from the terminal.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pandadoc/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pandadoc/install.sh)
-- Pax8 (Billing) - Reconcile Pax8 billing, track MRR, and catch usage overages before they hit the customer invoice
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pax8/
+- Pax8 (Billing) - ask "Where is my billing leaking - invoiced for a cancelled product, or active but never billed?" - Reconcile Pax8 billing, track MRR, and catch usage overages before they hit the customer invoice
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pax8/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pax8/install.sh)
-- Pipedrive (CRM) - Surface stale deals, weighted forecasts, and overdue follow-ups across your pipeline by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pipedrive/
+- Pipedrive (CRM) - ask "Which open deals has nobody touched in two weeks, worst dollar value first?" - Surface stale deals, weighted forecasts, and overdue follow-ups across your pipeline by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/pipedrive/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/pipedrive/install.sh)
-- Proofpoint TAP (Security) - Investigate Proofpoint TAP threats, VAPs, and top clickers from your terminal without burning the daily API quota.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/proofpoint/
+- Proofpoint TAP (Security) - ask "What malicious clicks and messages got through overnight?" - Investigate Proofpoint TAP threats, VAPs, and top clickers from your terminal without burning the daily API quota.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/proofpoint/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/proofpoint/install.sh)
-- QuickBooks Online (Billing) - Answer AR/AP aging, DSO, cash-forecast, and month-end close questions across QuickBooks Online by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/quickbooks/
+- QuickBooks Online (Billing) - ask "Who owes us money, bucketed 0-30 / 31-60 / 61-90 / 90+?" - Answer AR/AP aging, DSO, cash-forecast, and month-end close questions across QuickBooks Online by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/quickbooks/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/quickbooks/install.sh)
-- RocketCyber (Security) - Triage your managed SOC, rank devices at risk, and audit suppression rules from the terminal - no console logins.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/rocketcyber/
+- RocketCyber (Security) - ask "What broke across all my clients overnight?" - Triage your managed SOC, rank devices at risk, and audit suppression rules from the terminal - no console logins.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/rocketcyber/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/rocketcyber/install.sh)
-- Rootly (Incident Response) - Every Rootly incident, alert, and on-call object as a typed command, plus offline MTTR and coverage-gap answers.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/rootly/
+- Rootly (Incident Response) - ask "Who's on call right now across every service and schedule?" - Every Rootly incident, alert, and on-call object as a typed command, plus offline MTTR and coverage-gap answers.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/rootly/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/rootly/install.sh)
-- runZero (Security) - Find every asset on your attack surface, diff it over time, and trace any CVE to the machines it hits.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/runzero/
+- runZero (Security) - ask "Which of our assets are most exposed right now?" - Find every asset on your attack surface, diff it over time, and trace any CVE to the machines it hits.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/runzero/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/runzero/install.sh)
-- Salesbuildr (CRM) - Surface stale quotes, thin-margin lines, and pipeline velocity across your Salesbuildr quoting by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/salesbuildr/
+- Salesbuildr (CRM) - ask "Which sent or approved quotes are aging, and how much is at risk?" - Surface stale quotes, thin-margin lines, and pipeline velocity across your Salesbuildr quoting by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/salesbuildr/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/salesbuildr/install.sh)
-- SentinelOne (Security) - Triage threats, find protection gaps, and catch overnight fleet drift across every SentinelOne tenant by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sentinelone/
+- SentinelOne (Security) - ask "What should I triage first across all my client sites right now?" - Triage threats, find protection gaps, and catch overnight fleet drift across every SentinelOne tenant by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sentinelone/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/sentinelone/install.sh)
-- Servosity (Backup/DR) - Fleet attention, stale backups, QBR reports, and restore watch for every client by asking.
-  Badge: Live-verified. Page: https://msp-skills.compoundingteams.com/skills/servosity/
+- Servosity (Backup/DR) - ask "Where is my attention needed today, ranked worst-first?" - Fleet attention, stale backups, QBR reports, and restore watch for every client by asking.
+  Verification: Live-verified by Servosity (maintainer) (2026-06-05). Page: https://msp-skills.compoundingteams.com/skills/servosity/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/servosity/install.sh)
-- Sherweb (Billing) - Reconcile what you owe Sherweb against what customers owe you and surface true net margin per customer.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sherweb/
+- Sherweb (Billing) - ask "What is my net margin per customer this month - receivable minus payable?" - Reconcile what you owe Sherweb against what customers owe you and surface true net margin per customer.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/sherweb/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/sherweb/install.sh)
-- SkyKick (Backup/DR) - Catch silently-failing Microsoft 365 backups across every SkyKick tenant before a customer needs a restore.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/skykick/
+- SkyKick (Backup/DR) - ask "Which customers have a protection gap right now?" - Catch silently-failing Microsoft 365 backups across every SkyKick tenant before a customer needs a restore.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/skykick/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/skykick/install.sh)
-- SuperOps (PSA) - Catch SLA breaches, unbilled time, and at-risk assets across PSA and RMM by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/superops/
+- SuperOps (PSA) - ask "Who's about to breach SLA, grouped by technician?" - Catch SLA breaches, unbilled time, and at-risk assets across PSA and RMM by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/superops/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/superops/install.sh)
-- Syncro (PSA) - Run every Syncro PSA and RMM workflow from your terminal: tickets, billing, and patch gaps in one ask.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/syncro/
+- Syncro (PSA) - ask "Which customers have logged time we never invoiced?" - Run every Syncro PSA and RMM workflow from your terminal: tickets, billing, and patch gaps in one ask.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/syncro/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/syncro/install.sh)
-- Tactical RMM (RMM) - Triage every agent, sweep patch posture, and run a script across a filtered cohort by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/tactical-rmm/
+- Tactical RMM (RMM) - ask "What's the overall health of my fleet right now?" - Triage every agent, sweep patch posture, and run a script across a filtered cohort by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/tactical-rmm/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/tactical-rmm/install.sh)
-- ThreatLocker (Security) - Clear approval backlogs, beat the 31-day audit cliff, and find dark agents across every tenant by asking.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/threatlocker/
+- ThreatLocker (Security) - ask "What application approvals are pending across all my clients right now?" - Clear approval backlogs, beat the 31-day audit cliff, and find dark agents across every tenant by asking.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/threatlocker/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/threatlocker/install.sh)
-- Xero (Billing) - Answer AR/AP aging, reconciliation, and GL tie-out for a Xero org from the terminal - offline, in one call.
-  Badge: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/xero/
+- Xero (Billing) - ask "Who owes us, and how overdue is each invoice?" - Answer AR/AP aging, reconciliation, and GL tie-out for a Xero org from the terminal - offline, in one call.
+  Verification: Awaiting live verification. Page: https://msp-skills.compoundingteams.com/skills/xero/
   Install: bash <(curl -fsSL https://raw.githubusercontent.com/servosity/msp-skills/main/skills/xero/install.sh)
 
 ## Key pages

--- a/docs/question-book.md
+++ b/docs/question-book.md
@@ -1,0 +1,899 @@
+---
+layout: default
+title: "The MSP AI Question Book - 200+ plain-English questions your AI can answer"
+description: "606 plain-English questions your AI can answer from the PSA, RMM, backup, security, and billing tools you already run - aggregated from all 51 free MSP Skills connectors. No code required, runs locally."
+permalink: /question-book/
+---
+
+# The MSP AI Question Book
+
+606 plain-English questions MSP owners ask their AI every day - aggregated from the 51 free, open source connectors on this site and grouped by tool category. Every question maps to a real, gate-verified command your AI agent runs against your PSA, RMM, backup, security, or billing stack - locally, without your data leaving your network. Find your tools, steal the questions.
+
+Each connector installs in about 60 seconds and works with Claude, ChatGPT, Copilot, and any MCP-capable agent. New to the term? [What an MCP server is →](/what-is-an-mcp-server/)
+
+## Analytics
+
+### MSPbots
+
+Free MSPbots MCP server: [install and ask →](/skills/mspbots/)
+
+- Is our ticket backlog up or down versus last week?
+- Pull the open tickets updated since June 1
+- Export the whole tickets dataset to CSV for the QBR deck
+- Is our open-ticket backlog up or down versus last week?
+- What changed in open tickets since the last snapshot - rows added, removed, or edited?
+- What columns does this dataset have, and what types?
+- Export the entire dataset to CSV for the QBR deck
+- Capture today's KPI snapshot (schedule it and history accrues)
+- Stop pasting 19-digit IDs - name the dataset once
+- Are my API key and resource bindings working?
+
+## Backup/DR
+
+### Acronis Cyber Protect Cloud
+
+Free Acronis Cyber Protect Cloud MCP server: [install and ask →](/skills/acronis/)
+
+- Whose backups failed last night?
+- Which backup agents have gone offline across all my customers?
+- Where am I billing for protection that isn't running?
+- Whose backups succeeded, failed, or went stale across every customer last night?
+- Show me each failed or missed backup in the last 24 hours, newest first
+- Which customers have gone too long without a good backup (SLA breach)?
+- Which backup agents have silently gone offline across all tenants?
+- Did every customer's agents update after the rollout?
+- Where am I billing for protection that isn't actually running?
+- Which usage has no matching SKU, and which paid SKUs have zero usage?
+- What grew or shrank in usage between two months?
+- Give me the full picture on one customer before the call
+- Which enabled customers are missing users, agents, or offering items?
+
+### Afi
+
+Free Afi MCP server: [install and ask →](/skills/afi/)
+
+- Which resources across the whole fleet have no backup protection?
+- Show me protected resources whose newest backup is older than 48 hours.
+- Where am I over- or under-provisioned on Afi licenses?
+- Which resources have no backup protection at all?
+- Which protected resources have a stale backup (silent failures)?
+- Is the whole fleet green this morning, or who failed?
+- What is one tenant's full backup posture for a QBR or ticket?
+- Am I over- or under-licensed on Afi seats?
+- Who is jane.doe@example.com in Afi, across Multi-Geo tenants?
+- Safely back up then release a departing employee's mailbox?
+
+### Axcient x360Recover
+
+Free Axcient x360Recover MCP server: [install and ask →](/skills/axcient/)
+
+- Whose backups failed or went stale last night?
+- Give me backup-compliance evidence for this client - restore-point age, AutoVerify, and an RPO pass/fail
+- What does each client consume this month for invoice reconciliation?
+- Whose backups failed or went stale across every client last night?
+- Give me one row per client: devices total, failing, stale, RPO-breach, and AutoVerify-fail counts
+- Which devices are past their recovery-point objective, grouped by client?
+- Only show the devices actually breaching RPO at the cloud tier
+- Produce backup-compliance evidence for one client (restore-point age + AutoVerify + RPO verdict)
+- Only the compliance rows that fail RPO or AutoVerify
+- What does each client consume for invoice reconciliation this month?
+- Which devices does each appliance protect, and what state are those backups in?
+- Find everything matching a client or device name across synced data
+- Refresh the local mirror, then run the morning sweep
+
+### Cove Data Protection
+
+Free Cove Data Protection MCP server: [install and ask →](/skills/cove/)
+
+- Which devices failed their last backup across all my customers since yesterday?
+- Give me the month-end billing usage for every device as a CSV.
+- Which devices and customers grew their backup storage the most this week?
+- Which devices failed their last backup since yesterday?
+- Which devices have had no successful backup in 3 days?
+- What is the fleet-wide health rollup, broken down per customer?
+- Which devices and customers grew their storage fastest this week?
+- What is the month-end billing usage per device, with codes decoded?
+- Which device SKUs or seat counts changed since last month?
+- Which backup statuses flipped since my last snapshot?
+
+### Datto BCDR
+
+Free Datto BCDR MCP server: [install and ask →](/skills/datto-bcdr/)
+
+- Which protected machines failed their last backup screenshot verification, across every client?
+- Which agents haven't taken a local snapshot or synced offsite recently, fleet-wide?
+- Which of my clients are most at risk right now in Datto?
+- Which protected machines failed their last backup screenshot verification?
+- Which agents are behind on local snapshots or offsite sync?
+- What percentage of my fleet is actually recoverable right now?
+- Which clients are most at risk across backups, alerts, and storage?
+- Show me every open alert across the whole fleet, grouped by client.
+- Which appliance runs out of local or offsite storage first?
+- Which protected machines are paused, archived, or on an appliance that went dark?
+- Which machines are running an outdated backup agent?
+- Give me a one-page backup health report for a single client before the QBR.
+
+### Servosity
+
+Free Servosity MCP server: [install and ask →](/skills/servosity/)
+
+- Where is my attention needed today, worst first?
+- Build the backup section of Acme's QBR as a PDF
+- Which installed agents still aren't pulling backups?
+- Where is my attention needed today, ranked worst-first?
+- What got worse since yesterday, and what recovered?
+- Which clients have backups stale for 7+ days?
+- Draft the follow-up email for every client with a stale backup
+- Quarter-end: every client's QBR backup report in one pass
+- Watch every client's restore queue during a DR event
+- Does my Servosity bill match what I invoice my clients?
+
+### SkyKick
+
+Free SkyKick MCP server: [install and ask →](/skills/skykick/)
+
+- Which of my SkyKick customers has a backup gap right now?
+- Show me every mailbox that hasn't been snapshotted in the last two days.
+- What's discovered but not protected across all my tenants?
+- Which customers have a protection gap right now?
+- Whose mailboxes haven't been snapshotted in 48 hours?
+- What's discovered but not actually being backed up?
+- Which tenants fall below our retention floor?
+- Where is autodiscover off, so new mailboxes silently never enroll?
+- What protection changed since my last review?
+- What open alerts exist across the whole fleet, worst first?
+- How does backup posture roll up by partner?
+
+## Billing
+
+### AppDirect
+
+Free AppDirect MCP server: [install and ask →](/skills/appdirect/)
+
+- Which AppDirect payments failed in the last 7 days, across every company?
+- Reconcile AppDirect billing for the last 30 days - what's active but unbilled, overdue, or failed?
+- Show me everything on AppDirect company <companyId>.
+- Which payments failed or stalled in the last week, across every company?
+- What's active-but-unbilled, overdue, or failed before month-close?
+- What changed in subscriptions this week - new, ended, or suspended?
+- Show one customer's full picture - users, subscriptions, invoices, opportunities.
+- What does my assisted-sales pipeline look like by status?
+- Which open opportunities have gone stale?
+- Find any company, subscription, invoice, or opportunity by keyword.
+- Pull the whole marketplace into a local mirror for offline analysis.
+
+### Gradient MSP
+
+Free Gradient MSP MCP server: [install and ask →](/skills/gradient/)
+
+- Push tonight's usage counts from this file in one shot
+- Show me which accounts' usage changed since my last push
+- Send this alert and tell me when the PSA ticket actually exists
+- Push a whole file of usage counts and rebuild billing exactly once?
+- Which accounts' usage changed between my last two pushes?
+- Send an alert and confirm the PSA ticket was actually created?
+- Which of my dispatched alerts never became tickets?
+- Which accounts are unmapped or missing a vendor SKU?
+- Is my integration ready to flip to active?
+- Add a single ad-hoc unit count for one account and service?
+- Are my credentials valid and what's my integration status?
+
+### Pax8
+
+Free Pax8 MCP server: [install and ask →](/skills/pax8/)
+
+- Where is my Pax8 billing leaking this month?
+- What is my recurring revenue and margin right now, by product?
+- Which customers are about to blow past their usual usage?
+- Where is my billing leaking - invoiced for a cancelled product, or active but never billed?
+- Can I catch that leakage before the next invoice finalizes?
+- What is my MRR and margin right now, broken down by product?
+- Which usage summaries are running hot before they hit the invoice?
+- What changed in my book of business this week - new, cancelled, resized subscriptions?
+- Which customers cost the most across every invoice?
+- Everything about one customer - subscriptions, contacts, invoices, usage - in one view?
+- Which products can I resell that match a vendor or keyword?
+
+### QuickBooks Online
+
+Free QuickBooks Online MCP server: [install and ask →](/skills/quickbooks/)
+
+- Who owes us money, and how overdue are they?
+- Which overdue invoices should I chase first?
+- What does our cash position look like over the next month?
+- Who owes us money, bucketed 0-30 / 31-60 / 61-90 / 90+?
+- What do we owe vendors, and when is it due?
+- Where does our cash stand across accounts, AR, and AP?
+- What net cash movement is scheduled over the next 4 weeks?
+- What is our DSO, and who are the slowest payers?
+- Are the books clean enough to close this month?
+- Which payments came in but were never applied to an invoice?
+- Which customers are duplicated in our list?
+- Who slipped an aging bucket since our last check?
+
+### Sherweb
+
+Free Sherweb MCP server: [install and ask →](/skills/sherweb/)
+
+- What is my net margin per customer this month?
+- Which subscriptions am I paying for but not billing back?
+- What will bumping this customer to 25 seats cost before I commit it?
+- What is my net margin per customer this month - receivable minus payable?
+- Whose margin is sliding month over month before an account goes negative?
+- Which active subscriptions am I paying Sherweb for but not billing the customer?
+- Where am I absorbing metered usage I never billed back?
+- Which subscriptions have more seats paid than seats actually used?
+- What changed on my payable charges since the last sync - new, vanished, or repriced?
+- What subscriptions were added, cancelled, or resized across my whole book this month?
+- How many total seats of each product do I carry across every customer?
+- What will a seat change cost before I actually submit the amendment?
+
+### Xero
+
+Free Xero MCP server: [install and ask →](/skills/xero/)
+
+- Who owes us money, and how overdue is each one?
+- Which authorised invoices are still owed with no payment applied?
+- Do the books tie out before I sign off the close?
+- Who owes us, and how overdue is each invoice?
+- What do we owe suppliers, bucketed by age?
+- Which contacts carry the most receivable risk?
+- Which authorised invoices are still owed with no applied payment?
+- Which bank transactions are unreconciled, and what might they match?
+- Do the GL control accounts tie to outstanding invoices at close?
+- What posted to a single account, as a running balance?
+- What changed in the organisation since last week?
+- Give me one state-of-the-org summary in a single call.
+- Find every synced record matching a keyword.
+
+## CRM
+
+### HubSpot
+
+Free HubSpot MCP server: [install and ask →](/skills/hubspot/)
+
+- Which of my open deals have gone cold with no activity in three weeks?
+- What's my pipeline health right now - count, dollars, and what's at risk per stage?
+- How are open deals spread across my reps by stage and dollar value?
+- Which open deals have gone cold with no engagement in the last three weeks?
+- Which of my contacts haven't been touched in a month?
+- What's my pipeline health right now - per-stage count, dollars, and what's at risk?
+- How is the open-deal load spread across my reps?
+- Who should I call today, ranked by stale-days, deal size, and stage?
+- Which are my top deals by composite score (signal, amount, stage, recency)?
+- What's the full activity trail for a specific deal - every call, email, meeting, note, and task?
+- Which meetings were ever Scheduled in a given month, even after they flipped to Completed or No Show?
+
+### Pipedrive
+
+Free Pipedrive MCP server: [install and ask →](/skills/pipedrive/)
+
+- Which open deals has nobody touched in two weeks, worst dollar value first?
+- What's my weighted forecast for this quarter by pipeline?
+- Give me the full picture on Jane Smith before my call.
+- What's my weighted forecast for this quarter, and what's expected to close?
+- Which deals are stuck in a stage longer than that stage usually takes?
+- Which open deals have no next activity scheduled?
+- Rank my reps by won value over the last 90 days.
+- What changed since yesterday, and who do I need to call today?
+- Which deals did we lose in the last six months, with reasons, for a re-engagement push?
+- Find likely-duplicate organizations so I can clean up the CRM.
+- Search every synced deal, person, and organization for a name.
+- Pull my whole pipeline into a local copy for offline, zero-API-call analysis.
+
+### Salesbuildr
+
+Free Salesbuildr MCP server: [install and ask →](/skills/salesbuildr/)
+
+- Which quotes have been sitting sent or approved for two weeks, and how much revenue is at risk?
+- Show me every quote line priced under 20% markup.
+- Which companies, contacts, and products are missing the external ID my PSA sync needs?
+- Which sent or approved quotes are aging, and how much is at risk?
+- Which quote line items are priced below my markup floor?
+- How does my quote pipeline convert stage by stage, in count and dollars?
+- Where have per-company pricing-book prices drifted from the master catalog?
+- What's my win rate by owner, stage, or category?
+- What's my probability-weighted recurring-revenue forecast on the open pipeline?
+- Which catalog products have I never quoted to a given company?
+- Which records are missing the external ID my PSA sync depends on?
+
+## Documentation
+
+### Hudu
+
+Free Hudu MCP server: [install and ask →](/skills/hudu/)
+
+- Which clients have the worst documentation completeness right now?
+- Show me vault passwords that haven't been rotated in 180 days, grouped by company
+- What expires in the next 30 days across all my clients?
+- Which clients have the worst documentation completeness?
+- What's expiring in the next 30 days across every client?
+- Which vault passwords are overdue for rotation?
+- Which knowledge-base articles are stale and probably out of date?
+- Which assets have drifted from their layout's current schema?
+- Give me one worst-first hygiene scorecard across every company.
+- Find everything matching a keyword across all synced docs.
+- Resolve this Hudu link to its asset, company, and relations.
+- Which PSA/RMM records don't map to a live Hudu asset?
+- Scaffold a new client's docs from our house template.
+
+### IT Glue
+
+Free IT Glue MCP server: [install and ask →](/skills/itglue/)
+
+- Which client does this Fortinet firewall belong to?
+- Which credentials haven't been rotated in over a year, by client?
+- Which clients are under-documented right now?
+- Which client owns this device, serial number, or contact?
+- Which clients are under-documented, thinnest first?
+- Which credentials haven't been rotated in a year, grouped by client?
+- What changed across every client since a given date?
+- Which contacts are duplicated across or within clients?
+- Everything we know about one client, in a single offline read?
+- Which records are orphaned after a client was offboarded?
+- List every organization in the account.
+
+### Liongard
+
+Free Liongard MCP server: [install and ask →](/skills/liongard/)
+
+- What changed across all my clients in the last 7 days?
+- Which Liongard collectors have gone stale?
+- Give me the MFA-enabled count for every system as a CSV.
+- What changed across all my clients in the last 24 hours?
+- Which collectors (launchpoints) have gone stale?
+- Which agents are offline right now, and whose environment do they serve?
+- Give me one health scorecard for the whole estate.
+- Show me one client's complete picture in a single command.
+- Which inspections failed or errored across the estate?
+- Pull one metric across every system, CSV-ready for a report.
+- Which systems breach a threshold, like patch age over 30 days?
+- Where are my monitoring gaps (systems with no launchpoint, environments with no systems)?
+- Which environments are still missing a given inspector?
+- What is the full change history for one system?
+- Search everything I've synced for a term.
+
+### PandaDoc
+
+Free PandaDoc MCP server: [install and ask →](/skills/pandadoc/)
+
+- Which proposals are stalled?
+- How much money is tied up in open quotes right now?
+- Which clients have gone cold?
+- Which documents were sent but never completed?
+- How much money is tied up in open quotes?
+- What does my whole document funnel look like right now?
+- How long has each document sat in its current status?
+- Which clients haven't signed anything in a month?
+- Who should I follow up with today?
+- Which recipients actually open and sign vs. let documents sit?
+- Which templates actually close?
+- Which sent documents have no auto-reminder set?
+- What changed in the last day?
+
+## Incident Response
+
+### PagerDuty
+
+Free PagerDuty MCP server: [install and ask →](/skills/pagerduty/)
+
+- What's our mean time to acknowledge and resolve by service over the last 30 days?
+- Which services have a broken escalation chain or a single point of failure?
+- Who's on call for the Payments service right now, and when's the handoff?
+- What's on fire right now, ranked by SLA risk?
+- Who's on call for a service right now, and when's the handoff?
+- What's our MTTA and MTTR by service this month?
+- Which services have a broken escalation chain or single point of failure?
+- Where does a schedule have nobody on call over the next two weeks?
+- Which responders carry the most pages and off-hours load?
+- Which services are the noisiest?
+- What changed right before this incident broke?
+- What's the full timeline of this incident?
+- Which open incidents are quietly rotting with no recent activity?
+
+### Rootly
+
+Free Rootly MCP server: [install and ask →](/skills/rootly/)
+
+- What's our mean time to acknowledge and resolve by service over the last quarter?
+- Where does an on-call schedule have an unstaffed gap in the next two weeks?
+- Who's on call right now across every service, escalation tier included?
+- Who's on call right now across every service and schedule?
+- What past incidents are most similar to this one?
+- What actually fixed this service the last time it broke?
+- What's our MTTA and MTTR by service this quarter?
+- Where does an on-call schedule have an unstaffed gap?
+- Is it safe to deploy this service right now?
+- Give me one screen for this active incident.
+- Which incidents are breaching or about to breach SLA?
+- Which open action items are overdue, grouped by owner?
+- Draft a paste-ready post-mortem skeleton for this incident.
+
+## Monitoring
+
+### Better Stack
+
+Free Better Stack MCP server: [install and ask →](/skills/betterstack/)
+
+- Which monitors would page nobody if they went down right now?
+- What was our MTTA and MTTR over the last 30 days, by monitor?
+- What's down right now and is anyone actually paged?
+- Which monitors would page nobody if they failed?
+- What's our MTTA and MTTR over the last 30 days, by monitor?
+- Which monitors are the noisiest over the last week?
+- Is anyone actually on call right now, or is there a gap?
+- Which heartbeats are most at risk of a silent miss?
+- Are any status pages green while a monitor has an open incident?
+- How healthy is each client group right now?
+- Give me one health board for the whole account.
+- Which open incidents are oldest and still unacknowledged?
+
+## Network Monitoring
+
+### Domotz
+
+Free Domotz MCP server: [install and ask →](/skills/domotz/)
+
+- Which client sites have devices down right now?
+- Give me one asset inventory across every site
+- Show me new devices that appeared anywhere in the last 24 hours
+- Is anything on fire across all my sites?
+- Which Collectors (sites) are offline or degraded right now?
+- What devices are offline across every client?
+- What new devices appeared on any network in the last day?
+- Where are IP conflicts across the fleet?
+- Which devices can't be fully monitored (auth or SNMP gaps)?
+- How many devices of each vendor do we manage?
+- Which Collectors have gone quiet (stale sync)?
+- Find a hostname or IP anywhere in the synced fleet
+
+## PSA
+
+### Autotask PSA
+
+Free Autotask PSA MCP server: [install and ask →](/skills/autotask/)
+
+- Which approved time haven't we invoiced yet?
+- What's gone stale on the service desk in the last week?
+- Give me the full picture on company 1234 before my 2 o'clock
+- Which approved time entries haven't been invoiced yet?
+- How stale is the service desk right now, bucketed by age?
+- Which open tickets has nobody touched in a week?
+- Which unassigned tickets should the dispatcher pick up first?
+- Who's overloaded before I assign the next ticket?
+- How burned are our block-hour contracts, and when do they run out?
+- Everything we know about one company - tickets, contacts, contracts, config items, opportunities?
+- What's the month-end billing picture - unbilled time, contract burn, money on the table?
+- What's the label-to-ID map for the ticket status picklist?
+
+### ConnectWise PSA (Manage)
+
+Free ConnectWise PSA (Manage) MCP server: [install and ask →](/skills/connectwise-manage/)
+
+- Which tickets did we close this week with no time logged?
+- What's gone stale on the Help Desk board in the last three days?
+- Give me the full picture on Acme Corp before my 2 o'clock
+- Which tickets did we touch this week that have zero time logged against them?
+- Which clients are about to blow through their block-hours agreement?
+- What does the Help Desk board look like right now - age, owner, priority?
+- Which open tickets has nobody touched in five days?
+- Who has bandwidth for the next ticket?
+- Which tickets are sitting unassigned on the board?
+- Everything we know about one client - contacts, agreements, configurations, open tickets?
+- Write me a valid conditions filter for open Help Desk tickets
+
+### HaloPSA
+
+Free HaloPSA MCP server: [install and ask →](/skills/halopsa/)
+
+- What's about to breach SLA in the next 24 hours, sorted by time-to-breach?
+- Give me the whole story for this client on one screen - tickets, contracts, hours left, assets.
+- Who's overloaded right now - open tickets, hours logged, oldest open ticket per agent?
+- What's about to breach SLA in the next 24 hours?
+- What's the dispatcher view across all agents and teams?
+- Who's overloaded right now?
+- What's the whole story for this client, on one screen?
+- How much contract time is left, and who's tracking over their bank?
+- Which clients have stale tickets aging out that I should close?
+- What changed in Halo since this morning while I was in a meeting?
+- Which KB article should the tech link to for this ticket?
+
+### Kaseya BMS
+
+Free Kaseya BMS MCP server: [install and ask →](/skills/kaseya-bms/)
+
+- Which queues are underwater this morning, and how many tickets are going stale?
+- How many approved billable hours are sitting unbilled per client right now?
+- Who's overloaded and who can take the next ticket?
+- Which queues are underwater and what's going stale before standup?
+- Which open tickets haven't been touched in a week, oldest first?
+- How much of each contract have we burned this quarter?
+- What approved billable time is ready to invoice, by account?
+- What's the open sales pipeline by stage, and which deals have slipped?
+- Find every ticket mentioning a phrase across the whole tenant
+- Sync the tenant into a local mirror for instant offline queries
+
+### SuperOps
+
+Free SuperOps MCP server: [install and ask →](/skills/superops/)
+
+- Who's about to breach SLA, and on whose queue?
+- Give me the full picture on Acme Corp before my 2 o'clock
+- Which endpoints are missing a critical patch and actively alerting?
+- Who's about to breach SLA, grouped by technician?
+- Which clients have alerts still sitting unresolved?
+- Which open tickets has nobody touched in a week?
+- Everything about one client - sites, users, contracts, tickets, assets, open invoices?
+- Where is billable time concentrated before this month's invoicing?
+- Give my triage agent one ticket with its worklogs, client, and SLA in a single read
+- Search every synced ticket, asset, and client for "disk full"
+
+### Syncro
+
+Free Syncro MCP server: [install and ask →](/skills/syncro/)
+
+- Which customers have logged labor we never invoiced?
+- Bucket our unpaid invoices into aging tiers
+- Give me a full snapshot for customer 12345
+- Which customers have logged time we never invoiced?
+- Which closed tickets had billable time that was never invoiced?
+- How is our unpaid AR aging (0-30/30-60/60-90/90+)?
+- What is our revenue per labor hour by customer this quarter?
+- Which open tickets are going stale with no recent activity?
+- Which assets are missing the most critical patches?
+- Which customers generate the most RMM alert noise?
+- Which RMM alerts never became a ticket?
+- Give me one cross-entity card for a single customer.
+
+## RMM
+
+### Action1
+
+Free Action1 MCP server: [install and ask →](/skills/action1/)
+
+- Which endpoints across all my clients are missing the most patches?
+- Rank our CVEs by how many endpoints they hit, known-exploited ones first
+- Which agents have gone dark across the whole fleet in the last two weeks?
+- Which endpoints across all clients are missing the most patches?
+- Which CVEs hit the most machines, weighted by severity and known-exploited status?
+- Which agents have stopped checking in across the fleet?
+- What is the patch-and-vulnerability posture for each client organization?
+- Which endpoints are waiting on a reboot to finish a patch cycle?
+- Rank every endpoint by overall risk (missing updates, open CVEs, reboot, staleness)
+- What software is installed across the whole fleet, deduped by version?
+- What changed since the last sync - what got remediated, what is newly missing?
+- List the managed endpoints in one client organization
+- What updates are available or missing for one organization?
+
+### Atera
+
+Free Atera MCP server: [install and ask →](/skills/atera/)
+
+- Which Atera agents have gone dark in the last 30 days?
+- Which open Atera tickets are about to breach SLA?
+- Which customers have managed agents but no active contract?
+- Which agents have gone offline or stopped checking in?
+- Which open tickets are closest to breaching SLA?
+- Who is overloaded on the service desk right now?
+- What contracts expire in the next 60 days?
+- What's my full book of business by customer and contract mix?
+- Which machines generate the most alerts over a week?
+- What's the patch-compliance picture across the fleet?
+- Which machines are running an end-of-life OS?
+- What changed across agents, tickets, and alerts in the last 24 hours?
+
+### Datto RMM
+
+Free Datto RMM MCP server: [install and ask →](/skills/datto-rmm/)
+
+- Which endpoints across all my clients have stopped checking in?
+- Show me every endpoint where antivirus is missing or not running
+- Which devices have hardware warranties expiring in the next 60 days?
+- Which devices haven't checked in for 30 days, across every client?
+- Where is antivirus missing, disabled, or not running?
+- Which endpoints are most behind on patches right now?
+- Which devices have warranties expiring in the next 60 days?
+- Which devices are generating the most alert noise this week?
+- Give me a one-page health scorecard for a client before the QBR.
+- How many copies of an app are installed fleet-wide, and which versions?
+- Which devices are running an out-of-date RMM agent?
+
+### Level
+
+Free Level MCP server: [install and ask →](/skills/levelio/)
+
+- Which Level devices are most at risk right now?
+- Which Level devices have gone dark in the last 30 days?
+- Give me a per-client posture scorecard for my Level fleet
+- Which devices are most at risk across alerts, patches, score, and staleness?
+- Which devices have gone dark and stopped checking in?
+- What is my fleet-wide patch exposure, by category?
+- How is my fleet broken down by OS, platform, or group?
+- Where are my active critical fires, clustered by group?
+- Give me a per-client posture scorecard for QBRs.
+- Which devices are below my security-score threshold?
+- Which devices are waiting on a reboot to finish patching?
+- Which monitors fire most often across the fleet?
+- What changed since yesterday - new alerts, updates, device activity?
+
+### N-able N-central
+
+Free N-able N-central MCP server: [install and ask →](/skills/n-central/)
+
+- Where is EXCHANGE01?
+- What's red right now, worst first, by customer?
+- Is our N-central API access healthy, and when does it expire?
+- What's red right now, grouped by customer and ranked by severity?
+- Where is EXCHANGE01 - server, service org, customer, site?
+- Find anything named acme across every server we run
+- Which devices are missing the Backup Plan custom property, by customer?
+- Which devices have no maintenance window before the June 15 patch wave?
+- Is the JWT healthy, and when does the API user's password kill it?
+- Hardware and software inventory for one device
+- Every device, exported for the QBR or your documentation tool
+
+### Nerdio Manager
+
+Free Nerdio Manager MCP server: [install and ask →](/skills/nerdio/)
+
+- Which host pools have autoscale disabled or drifting across all my customers?
+- Give me a per-customer billing and unpaid-balance rollup for May
+- Run script 42 on these three accounts and tell me when all of them are done
+- Which host pools have autoscale off or drifting across every customer?
+- What is running right now across all accounts, and where?
+- What did each customer get billed this period, and who is unpaid?
+- Which customers' Azure usage spiked month-over-month?
+- List every customer account I manage
+- Show the host pools for one account
+- Which Intune devices does this account have?
+- Did that backup or provisioning job actually finish?
+- Run one scripted action across many accounts and wait for all of them
+- Search everything I have synced, offline
+
+### NinjaOne
+
+Free NinjaOne MCP server: [install and ask →](/skills/ninjaone/)
+
+- Which clients are below 95% patch compliance right now?
+- Which endpoints across the whole fleet have no backup?
+- Every device carrying this threat, fleet-wide
+- Which organizations are below 95% patch compliance?
+- Which endpoints across the fleet have no backup at all?
+- Which devices is a given threat on, fleet-wide?
+- Which devices have antivirus definitions older than a week?
+- What is each organization's overall health score, and why?
+- Which devices have not checked in for two weeks?
+- Which devices are running an end-of-life operating system?
+- Where is a software title sprawling across too many versions?
+- Did patch compliance get better or worse since last week?
+- Search every synced device, organization, and alert for a string?
+
+### Tactical RMM
+
+Free Tactical RMM MCP server: [install and ask →](/skills/tactical-rmm/)
+
+- Which agents across all my clients have gone dark in the last week?
+- Where do I stand on pending patches and reboots across every client?
+- Run whoami on every online Windows agent - show me the cohort before it executes
+- What's the overall health of my fleet right now?
+- Which agents need attention first?
+- Which agents have gone dark or stopped checking in?
+- Where are patches and reboots pending across every client?
+- What changed across the fleet in the last few hours?
+- Which endpoints have no checks configured (monitoring gaps)?
+- What's each client's posture in a single row?
+- Which checks are failing on the most agents?
+- Which agents have a given software package installed?
+- Summarize alerts by severity over the last day
+- Which agents have a named Windows service stopped?
+
+## Security
+
+### Abnormal Security
+
+Free Abnormal Security MCP server: [install and ask →](/skills/abnormal/)
+
+- What new email threats hit us in the last 24 hours that nobody has remediated yet?
+- Pull last quarter's attacks-stopped and impersonation numbers for the client report
+- Give me the full account-takeover risk picture for jane@acme.com
+- What new, unremediated email threats need attention right now?
+- Pull a client-ready security report for the quarter
+- What is the account-takeover risk picture for this employee?
+- Is this vendor showing email-compromise signs?
+- Remediate a threat and block until it actually completes
+- List the latest Abnormal cases
+- How many attacks did we stop this week?
+- Find threats from a spoofed sender
+
+### Blumira
+
+Free Blumira MCP server: [install and ask →](/skills/blumira/)
+
+- Show me the highest-priority open findings across every client account, ranked into one queue
+- Which detection rules fell out of coverage versus our basis ruleset, across all accounts?
+- Which domain controllers went stale or unprotected across every client?
+- What are the worst open findings across all my client accounts right now?
+- What changed since my last sync, new, resolved, or status-changed findings?
+- What's my mean-time-to-resolve per account over the last month?
+- Which open findings are about to breach my age-based SLA?
+- Which detection rules are missing or disabled versus our basis ruleset?
+- Which domain controllers are stale or unprotected across every account?
+- Which findings were resolved and then re-fired?
+- Which detections keep firing over and over across accounts?
+- Give me one per-account rollup of open findings, age, and agent health?
+- Which findings mention this IOC, hostname, or user in their evidence?
+- Pull every account's Blumira data into a local mirror for offline questions?
+- Give me a flat finding-to-owner-to-status table to reconcile against my PSA?
+- Which analyst is carrying the most open findings, and how old are they?
+
+### CIPP
+
+Free CIPP MCP server: [install and ask →](/skills/cipp/)
+
+- Show me MFA registration across every tenant
+- Which assigned M365 licenses are going unused across all my clients?
+- Offboard this CSV of departures across their tenants without tripping rate limits
+- Which tenants still have users without MFA registered?
+- How does Conditional Access coverage compare across all tenants?
+- Where am I paying for M365 licenses nobody uses?
+- Which licensed accounts haven't signed in for 90 days, across every client?
+- Which tenants drifted off our security baseline since the last check?
+- Pull one read across every client tenant at once and keep it locally
+- Offboard a batch of departures from a CSV with 429 backoff and resume
+- Are my CIPP credentials and connectivity healthy?
+
+### CrowdStrike Falcon
+
+Free CrowdStrike Falcon MCP server: [install and ask →](/skills/crowdstrike/)
+
+- Give me one severity-sorted alert queue across every tenant
+- Rank the critical vulnerabilities across every CrowdStrike tenant
+- Which hosts haven't reported a sensor heartbeat in two weeks, across all tenants?
+- What should I triage first across all my client tenants right now?
+- Rank the critical vulnerabilities across every tenant?
+- Which hosts haven't reported a sensor heartbeat lately?
+- Give me one posture scorecard per tenant for the QBR deck?
+- Which tenants are under-protected versus my prevention-policy baseline?
+- Which single fix clears the most hosts and tenants?
+- Which tenants got worse since the last sync?
+- Map every child CID, CID group, and role grant across my MSSP?
+- Search every synced host, alert, vuln, and policy across all tenants?
+- Pull every child tenant's Falcon data into a local mirror for offline queries?
+
+### Huntress
+
+Free Huntress MCP server: [install and ask →](/skills/huntress/)
+
+- Show me every open Huntress incident across all my clients, oldest first.
+- Am I paying for more Huntress seats than I have agents deployed?
+- Which Huntress agents haven't called home in a week?
+- Which incidents are oldest across every client org?
+- Where are my posture gaps - stale callbacks, disabled Defender or firewall?
+- Has this IP or file hash touched any of my clients?
+- Am I billed for more seats than I have agents deployed?
+- Which agents went dark in the last week?
+- What is my mean time-to-resolve per client?
+- What changed across the fleet since my last shift?
+- Give me a QBR scorecard for one client.
+
+### KnowBe4
+
+Free KnowBe4 MCP server: [install and ask →](/skills/knowbe4/)
+
+- Which users clicked the bait in two or more phishing tests in the last 90 days?
+- Rank the users whose risk score worsened the most this quarter
+- Who clicked a phish but has no passed training to show for it?
+- Who clicked the bait in more than one phishing test?
+- Whose risk score is getting worse this quarter?
+- Who clicked a phish but never passed training?
+- Which active users have zero training or zero phishing coverage?
+- Is training actually working for the Finance group?
+- Who are my highest-risk users, with the why behind the score?
+- Which departments are driving our risk up?
+- Assemble the full client quarterly review in one command
+- Who never reports a simulated phish?
+- Is my synced data fresh enough to trust a clicker hunt?
+
+### Microsoft Graph
+
+Free Microsoft Graph MCP server: [install and ask →](/skills/microsoft-graph/)
+
+- Which M365 licenses are we paying for but not using?
+- Who holds global admin or other privileged roles right now?
+- What security alerts are new and still open since yesterday?
+- Which SKUs are we paying for but not fully using, ranked by wasted seats?
+- Which disabled or guest accounts still hold a paid license?
+- Who exactly is consuming one specific SKU before I reclaim seats?
+- Who holds a privileged directory role right now, and which holders are guest or disabled?
+- What open security alerts are new since yesterday, by severity and source?
+- Which Intune devices are non-compliant, unencrypted, or stale this month?
+- Which groups are ownerless, empty, or guest-heavy across the tenant?
+- Where does this tenant stand overall - users, license waste, admins, alerts, device drift?
+
+### Proofpoint TAP
+
+Free Proofpoint TAP MCP server: [install and ask →](/skills/proofpoint/)
+
+- What malicious clicks and messages got through in the last 12 hours?
+- Who is both Very Attacked and a top clicker right now?
+- Give me the full incident brief for this threatId
+- What malicious clicks and messages got through overnight?
+- Who is both Very Attacked and a top clicker?
+- Give me the full incident brief for a threatId
+- What indicators should I block from this threat?
+- Show me every event that touched one user
+- Who are my Very Attacked People this month?
+- Which permitted clicks and delivered threats still need a response?
+- What threats are inside this campaign?
+- Decode this urldefense-rewritten link to its real target
+- Is my synced threat data fresh enough to trust an offline query?
+
+### RocketCyber
+
+Free RocketCyber MCP server: [install and ask →](/skills/rocketcyber/)
+
+- What broke across all my RocketCyber clients in the last 24 hours?
+- Which devices are most at risk right now?
+- Which suppression rules are stale and could be masking alerts?
+- What broke across all my clients overnight?
+- Which devices went dark this week?
+- How fast is my SOC actually resolving incidents?
+- Which machines are riskiest in Defender right now?
+- Is this client's Microsoft 365 posture improving?
+- Which suppression rules are stale and may hide detections?
+- What detection events fired, by verdict?
+
+### runZero
+
+Free runZero MCP server: [install and ask →](/skills/runzero/)
+
+- Which of our assets are most exposed right now?
+- What appeared or disappeared on our attack surface since last week?
+- Which of our assets are affected by CVE-2024-3094?
+- Only the internet-facing ones?
+- What changed on our attack surface since last week?
+- What newly became exposed or vulnerable since the last sync?
+- Which assets are affected by a given CVE?
+- Where are risky services concentrated in a subnet?
+- Which TLS certificates are expiring soon or using weak crypto?
+- Which assets are stale, end-of-life, or unowned?
+- How many assets run a given software product, by version?
+- Scan a subnet on a site and wait for the result?
+
+### SentinelOne
+
+Free SentinelOne MCP server: [install and ask →](/skills/sentinelone/)
+
+- Give me the ranked triage worklist of every open threat across all my client sites
+- Show me every endpoint this hash touched and which are still active, not mitigated
+- Which endpoints are decaying worst first - offline, out-of-date, infected, or under-protected?
+- What should I triage first across all my client sites right now?
+- Where did this malicious file spread, and which endpoints are still active?
+- Which endpoints are decaying - offline, out-of-date, infected, or under-protected?
+- Which clients have protection gaps (detect-only, Ranger off, firewall off)?
+- What changed across the whole fleet since yesterday?
+- Which threats keep coming back after we mitigated them?
+- Are we hitting our mitigation SLA, and where are the breaches?
+- Rank my clients by risk so I know which tenant to call first?
+- Give me one posture scorecard per client for the QBR deck?
+- Pull every site's SentinelOne data into a local mirror for offline queries?
+
+### ThreatLocker
+
+Free ThreatLocker MCP server: [install and ask →](/skills/threatlocker/)
+
+- Show me every pending approval across all my clients, grouped so duplicate files collapse into one row
+- Approve this file everywhere it's pending, but show me the plan before you do
+- Which clients are about to lose audit evidence, and pull it before they do
+- What application approvals are pending across all my clients right now?
+- Approve this file hash everywhere it's pending, but show me the plan first?
+- Which clients are about to lose audit evidence to the 31-day retention cliff?
+- Export every client's audit log before it ages off?
+- What security-relevant changes (protection off, policy edits, maintenance) happened across all tenants this week?
+- Which ThreatLocker agents are offline or stale across every client?
+- Where does this binary live across my whole book, approved or pending?
+- Pull every tenant's ThreatLocker data into a local mirror for offline queries?
+
+---
+
+Want a question answered live? **[Build Sessions](https://compoundingteams.com/build-sessions)** are free every Thursday - bring one of these questions and your own tenant.

--- a/docs/skills/abnormal.md
+++ b/docs/skills/abnormal.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Abnormal Security MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Abnormal Security MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The full Abnormal Security REST API in your terminal and your agents - with a local threat store, ranked SOC triage, blocking remediation, and one-shot client reporting."
 permalink: /skills/abnormal/
 skill_name: "Abnormal Security MCP"
 image: /assets/social/abnormal/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Abnormal Security?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Abnormal Security, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Abnormal Security MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Abnormal Security MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a Abnormal Security question in plain language; it runs abnormal-cli for you."
 ---
 
-# Abnormal Security + AI in 60 seconds
+# The Abnormal Security MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Abnormal Security
-> API. Not affiliated with, endorsed by, or sponsored by Abnormal Security Corporation.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Abnormal Security Corporation.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Abnormal Security. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Abnormal Security to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Abnormal Security plus your AI answers the SOC questions the portal makes you click for: what new email threats are still unremediated right now, what numbers go in this quarter's client security report, and an employee's full account-takeover risk picture - each in one command. It syncs your tenant to a local store, ranks the threat queue, and confirms remediations actually completed.
 
@@ -133,6 +140,14 @@ The skill authenticates with a single ABNORMAL_API_TOKEN scoped to your tenant. 
 
 ## Frequently asked questions
 
+### Is there an MCP server for Abnormal Security?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Abnormal Security, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Abnormal Security MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Abnormal Security MCP server via a secure bridge. Step-by-step in the install guide.
@@ -166,9 +181,15 @@ It can remediate threats and delete or move malicious messages through the remed
 No. Detection tuning, policy, and configuration stay in the portal. This is a read-first, action-on-approval surface for your terminal and your agents, not a replacement UI.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the Abnormal Security API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/acronis.md
+++ b/docs/skills/acronis.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Acronis Cyber Protect Cloud MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Acronis Cyber Protect Cloud MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first real CLI for the Acronis Cyber Protect Cloud platform - every tenant, agent, and usage metric mirrored locally, with cross-tenant rollups no single API call returns."
 permalink: /skills/acronis/
 skill_name: "Acronis Cyber Protect Cloud MCP"
 image: /assets/social/acronis/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Acronis Cyber Protect Cloud?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Acronis Cyber Protect Cloud, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Acronis Cyber Protect Cloud MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Acronis MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a Acronis Cyber Protect Cloud question in plain language; it runs acronis-cli for you."
 ---
 
-# Acronis Cyber Protect Cloud + AI in 60 seconds
+# The Acronis Cyber Protect Cloud MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Acronis
-> API. Not affiliated with, endorsed by, or sponsored by Acronis International GmbH.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Acronis International GmbH.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Acronis Cyber Protect Cloud. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Acronis Cyber Protect Cloud to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run Acronis Cyber Protect Cloud across dozens of customer tenants, but its partner dashboards report one tenant at a time. Ask your AI "whose backups failed last night," "which agents went offline," or "where am I billing for protection that isn't running," and get the cross-tenant answer in one table - computed offline from a local mirror, not six console drill-downs or a month-end CSV export.
 
@@ -137,6 +144,14 @@ The skill drives the acronis-cli and acronis-mcp binaries, authenticating with a
 
 ## Frequently asked questions
 
+### Is there an MCP server for Acronis Cyber Protect Cloud?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Acronis Cyber Protect Cloud, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Acronis Cyber Protect Cloud MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Acronis MCP server via a secure bridge. Step-by-step in the install guide.
@@ -170,9 +185,15 @@ Whichever hosts your Acronis account. Set ACRONIS_DATACENTER (for example us-clo
 No. The console stays best for configuring protection plans and running restores. This skill adds the cross-tenant reporting layer the partner dashboards don't - one place to ask whose backups failed, which agents are offline, and where billing and protection diverge.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Afi](/skills/afi/) · [Axcient x360Recover](/skills/axcient/) · [Cove Data Protection](/skills/cove/) · [Datto BCDR](/skills/datto-bcdr/) · [Servosity](/skills/servosity/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Acronis Cyber Protect Cloud API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/action1.md
+++ b/docs/skills/action1.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Action1 MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Action1 MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Action1 endpoint, plus fleet-wide patch and vulnerability views across all your organizations."
 permalink: /skills/action1/
 skill_name: "Action1 MCP"
 image: /assets/social/action1/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Action1?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Action1, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Action1 MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Action1 MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Action1 question in plain language; it runs action1-cli for you."
 ---
 
-# Action1 + AI in 60 seconds
+# The Action1 MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Action1
-> API. Not affiliated with, endorsed by, or sponsored by Action1 Corporation.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Action1 Corporation.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Action1. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Action1 to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "which endpoints across all my clients are missing the most patches?" and get one ranked list - no clicking org by org. Action1's API and console are siloed per client organization; this skill syncs every org into a local mirror so patch posture, CVE blast-radius, stale agents, and a per-client scorecard become single fleet-wide commands your AI agent runs from the terminal.
 
@@ -132,6 +139,14 @@ The skill reads freely - fleet rollups, lists, reports, search, export - and tho
 
 ## Frequently asked questions
 
+### Is there an MCP server for Action1?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Action1, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Action1 MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Action1 MCP server via a secure bridge. Step-by-step in the install guide.
@@ -157,9 +172,15 @@ An API client (Client ID + Client Secret) from your Action1 console's API Creden
 No. The console stays your place to configure automations and approve patches interactively. This skill answers the cross-organization questions the console shows one org at a time - fleet patch posture, CVE blast-radius, per-client scorecards - and lets your AI agent run them.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the Action1 API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/afi.md
+++ b/docs/skills/afi.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Afi MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Afi MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first CLI for Afi SaaS backup - full public-API coverage plus the fleet-wide coverage, staleness, and offboarding answers the rate-limited API can't serve live."
 permalink: /skills/afi/
 skill_name: "Afi MCP"
 image: /assets/social/afi/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Afi?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Afi, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Afi MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Afi MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Afi question in plain language; it runs afi-cli for you."
 ---
 
-# Afi + AI in 60 seconds
+# The Afi MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Afi
-> API. Not affiliated with, endorsed by, or sponsored by Afi.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Afi.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Afi. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Afi to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI 'which mailboxes aren't backed up in Afi?' and get the answer across every tenant at once. This skill walks your whole Afi fleet into a local store, then answers coverage gaps, stale backups, license drift, and per-tenant posture offline - no per-tenant portal clicking, no tripping Afi's rate limits - and runs a verified archive-then-release when someone leaves.
 
@@ -132,6 +139,14 @@ The skill reads your Afi fleet (installations, orgs, tenants, resources, protect
 
 ## Frequently asked questions
 
+### Is there an MCP server for Afi?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Afi, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Afi MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Afi MCP server via a secure bridge. Step-by-step in the install guide.
@@ -161,9 +176,15 @@ Yes - you need an Afi account and an Application API key (created in the Afi por
 No. Restores, exports, and policy editing still happen in the Afi portal - the public API does not expose them. This skill is the read, report, and guarded-offboard layer: it answers fleet questions and runs the verified archive-then-release, then hands you back to the portal for the actions only it can do.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Axcient x360Recover](/skills/axcient/) · [Cove Data Protection](/skills/cove/) · [Datto BCDR](/skills/datto-bcdr/) · [Servosity](/skills/servosity/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Afi API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/appdirect.md
+++ b/docs/skills/appdirect.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "AppDirect MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "AppDirect MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every documented AppDirect marketplace operation in one binary, plus offline sync and billing-reconciliation joins."
 permalink: /skills/appdirect/
 skill_name: "AppDirect MCP"
 image: /assets/social/appdirect/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for AppDirect?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for AppDirect, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the AppDirect MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local AppDirect MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a AppDirect question in plain language; it runs appdirect-cli for you."
 ---
 
-# AppDirect + AI in 60 seconds
+# The AppDirect MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the AppDirect
-> API. Not affiliated with, endorsed by, or sponsored by AppDirect, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by AppDirect, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for AppDirect. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects AppDirect to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask 'which AppDirect payments failed this week?' or 'reconcile billing before month-close' and get an answer across every reseller company in one call. The skill syncs your whole AppDirect marketplace - subscriptions, invoices, payments, companies, pipeline - into a local mirror, so cross-company billing questions that take hundreds of console clicks return instantly, offline, from your terminal or your AI agent.
 
@@ -130,6 +137,14 @@ The skill reads marketplace data - companies, users, subscriptions, invoices, pa
 
 ## Frequently asked questions
 
+### Is there an MCP server for AppDirect?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for AppDirect, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the AppDirect MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local AppDirect MCP server via a secure bridge. Step-by-step in the install guide.
@@ -155,9 +170,15 @@ Yes. The skill authenticates with partner API credentials (OAuth2 client_credent
 It is built to avoid them. The marketplace REST API uses leaky-bucket rate limits (for example, 20-request buckets that refill a few per second); because this skill syncs to a local mirror and answers most questions offline, your day-to-day queries make almost no live calls. Sync itself respects the limits and you can cap request rate with --rate-limit.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [Gradient MSP](/skills/gradient/) · [Pax8](/skills/pax8/) · [QuickBooks Online](/skills/quickbooks/) · [Sherweb](/skills/sherweb/) · [Xero](/skills/xero/)
+
 ## Status
 
 Beta. Validated against the AppDirect API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/atera.md
+++ b/docs/skills/atera.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Atera MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Atera MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Atera RMM + PSA endpoint, plus a local SQLite mirror that answers fleet-health, SLA, and book-of-business questions no single API call can."
 permalink: /skills/atera/
 skill_name: "Atera MCP"
 image: /assets/social/atera/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Atera?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Atera, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Atera MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Atera MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Atera question in plain language; it runs atera-cli for you."
 ---
 
-# Atera + AI in 60 seconds
+# The Atera MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Atera
-> API. Not affiliated with, endorsed by, or sponsored by Atera Networks Ltd.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Atera Networks Ltd.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Atera. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Atera to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask plain-English questions about your whole Atera estate and get answers the portal can't assemble in one view: which agents went dark, which tickets are about to breach SLA, which customers are under-contracted, and what contracts expire next quarter. `atera-cli` syncs Atera into a local SQLite mirror, then answers cross-client rollups instantly and offline - from the terminal or any AI agent.
 
@@ -133,6 +140,14 @@ The skill reads everything - agents, tickets, customers, contracts, alerts, devi
 
 ## Frequently asked questions
 
+### Is there an MCP server for Atera?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Atera, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Atera MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Atera MCP server via a secure bridge. Step-by-step in the install guide.
@@ -162,9 +177,15 @@ No. You need an Atera account and an API key created under Admin → API. Any pl
 No - it complements it. The portal stays your system of record and remote-access console; this skill adds the cross-client, terminal-and-AI query layer the portal doesn't offer.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the Atera API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/autotask.md
+++ b/docs/skills/autotask.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Autotask PSA MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Autotask PSA MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Autotask entity at the command line, plus a local SQLite mirror that answers ticket-aging, workload, unbilled-time, and account-360 questions no other Autotask tool can."
 permalink: /skills/autotask/
 skill_name: "Autotask PSA MCP"
 image: /assets/social/autotask/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Autotask PSA?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Autotask PSA, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Autotask PSA MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Autotask MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -34,12 +38,15 @@ howto:
     text: "Ask your AI agent a Autotask PSA question in plain language; it runs autotask-cli for you."
 ---
 
-# Autotask PSA + AI in 60 seconds
+# The Autotask PSA MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Autotask
-> API. Not affiliated with, endorsed by, or sponsored by Datto, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Datto, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Autotask PSA. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Autotask PSA to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run Autotask PSA as the system of record - tickets, time, contracts, billing. Ask your AI "what's gone stale on the service desk," "which approved time hasn't been invoiced," or "how burned is that block-hours contract," and get answers the portal can't compose: cross-entity rollups across tickets, time, contracts, and resources, computed offline from a local mirror in one query instead of a LiveReport and an Excel export.
 
@@ -136,6 +143,14 @@ The skill drives the autotask-cli and autotask-mcp binaries, authenticating with
 
 ## Frequently asked questions
 
+### Is there an MCP server for Autotask PSA?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Autotask PSA, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Autotask PSA MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Autotask MCP server via a secure bridge. Step-by-step in the install guide.
@@ -173,9 +188,15 @@ Run autotask-cli picklist "Tickets" "status" (or any entity and field) and it pr
 Same product. Autotask PSA is now branded Datto Autotask PSA under Kaseya; this skill targets the Autotask REST API, which both names refer to. It does not cover Datto RMM - that is a separate product with a separate API.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [ConnectWise PSA (Manage)](/skills/connectwise-manage/) · [HaloPSA](/skills/halopsa/) · [Kaseya BMS](/skills/kaseya-bms/) · [SuperOps](/skills/superops/) · [Syncro](/skills/syncro/)
+
 ## Status
 
 Beta. Validated against the Autotask PSA API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/axcient.md
+++ b/docs/skills/axcient.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Axcient x360Recover MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Axcient x360Recover MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every x360Recover endpoint plus the fleet-wide backup-health answers the API alone cannot give: offline, joined, and agent-ready."
 permalink: /skills/axcient/
 skill_name: "Axcient x360Recover MCP"
 image: /assets/social/axcient/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Axcient x360Recover?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Axcient x360Recover, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Axcient x360Recover MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Axcient MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a Axcient x360Recover question in plain language; it runs axcient-cli for you."
 ---
 
-# Axcient x360Recover + AI in 60 seconds
+# The Axcient x360Recover MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Axcient
-> API. Not affiliated with, endorsed by, or sponsored by Axcient, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Axcient, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Axcient x360Recover. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Axcient x360Recover to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run Axcient x360Recover across dozens of clients, but the portal answers one entity at a time and the public API famously won't tell you which client a device belongs to. Ask your AI "whose backups failed last night," "who's breaching RPO," or "what do I bill each client this month," and get the fleet-wide answer in one table - computed offline from a local mirror that joins the device, job, restore-point, and client data the raw API leaves unconnected.
 
@@ -137,6 +144,14 @@ The skill drives the axcient-cli and axcient-mcp binaries, authenticating with a
 
 ## Frequently asked questions
 
+### Is there an MCP server for Axcient x360Recover?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Axcient x360Recover, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Axcient x360Recover MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Axcient MCP server via a secure bridge. Step-by-step in the install guide.
@@ -170,9 +185,15 @@ Yes. Axcient hosts a public mock server - set AXCIENT_BASE_URL=https://ax-pub-re
 No. This skill is the x360Recover (BCDR) public API only - vaults, appliances, devices, jobs, restore points, AutoVerify, and usage. x360Sync and x360Cloud are separate products with separate APIs.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Afi](/skills/afi/) · [Cove Data Protection](/skills/cove/) · [Datto BCDR](/skills/datto-bcdr/) · [Servosity](/skills/servosity/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Axcient x360Recover API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/betterstack.md
+++ b/docs/skills/betterstack.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Better Stack MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Better Stack MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Better Stack Uptime feature, plus an offline SQLite mirror and cross-resource fleet analytics \u2014 what's down and who's paged, coverage gaps, MTTA/MTTR, flapping, on-call gaps, and status-page drift \u2014 that the API alone can't answer."
 permalink: /skills/betterstack/
 skill_name: "Better Stack MCP"
 image: /assets/social/betterstack/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Better Stack?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Better Stack, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Better Stack MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Better Stack MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Better Stack question in plain language; it runs betterstack-cli for you."
 ---
 
-# Better Stack + AI in 60 seconds
+# The Better Stack MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Better Stack
-> API. Not affiliated with, endorsed by, or sponsored by Better Stack.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Better Stack.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Better Stack. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Better Stack to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "what's down and is anyone actually paged?" and get a straight answer across your whole Better Stack account: every client's monitors, heartbeats, open incidents, and on-call rotation in one view. It surfaces the silent monitors that page nobody, the noisy ones waking techs at 3am, your real MTTA/MTTR, and status pages showing green while a monitor is down.
 
@@ -133,6 +140,14 @@ The skill reads your Better Stack monitors, heartbeats, incidents, on-call calen
 
 ## Frequently asked questions
 
+### Is there an MCP server for Better Stack?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Better Stack, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Better Stack MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Better Stack MCP server via a secure bridge. Step-by-step in the install guide.
@@ -165,6 +180,8 @@ No, it complements it. The portal is still where you configure monitors and watc
 ## Status
 
 Beta. Validated against the Better Stack API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/blumira.md
+++ b/docs/skills/blumira.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Blumira MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Blumira MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Blumira finding, detection, and agent across your direct org and every MSP sub-account - in one offline-searchable store with cross-account triage and over-time trends no single API call can answer."
 permalink: /skills/blumira/
 skill_name: "Blumira MCP"
 image: /assets/social/blumira/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Blumira?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Blumira, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Blumira MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Blumira MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a Blumira question in plain language; it runs blumira-cli for you."
 ---
 
-# Blumira + AI in 60 seconds
+# The Blumira MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Blumira
-> API. Not affiliated with, endorsed by, or sponsored by Blumira, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Blumira, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Blumira. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Blumira to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Running Blumira across a book of client accounts? Ask your AI "what are the worst open findings everywhere," "which detections fell out of coverage this week," or "which domain controllers went dark," and get one cross-account answer the Blumira portal can't compose. Every sub-account is mirrored into a local store, so one ranked triage queue, one MTTR rollup, and one coverage-drift report replace dozens of one-account-at-a-time portal logins.
 
@@ -131,6 +138,14 @@ The skill reads findings, detections, agents, and evidence through your Blumira 
 
 ## Frequently asked questions
 
+### Is there an MCP server for Blumira?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Blumira, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Blumira MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Blumira MCP server via a secure bridge. Step-by-step in the install guide.
@@ -152,9 +167,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 The cross-account commands (triage, overview, coverage across every client) read Blumira's MSP sub-account API, so they need partner API credentials with sub-account access. A single-org account still gets every direct-org command, findings, evidence search, and agent and detection rollups, plus offline sync. Generate credentials under Settings > Organization > Generate API Credentials, then run `blumira-cli auth login`.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the Blumira API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/cipp.md
+++ b/docs/skills/cipp.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "CIPP MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "CIPP MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "First single-binary CLI for CIPP  -  offline SQLite store, fleet posture analytics, and cross-tenant fan-out no other CIPP tool has."
 permalink: /skills/cipp/
 skill_name: "CIPP MCP"
 image: /assets/social/cipp/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for CIPP?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for CIPP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the CIPP MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local CIPP MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a CIPP question in plain language; it runs cipp-cli for you."
 ---
 
-# CIPP + AI in 60 seconds
+# The CIPP MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the CIPP
-> API. Not affiliated with, endorsed by, or sponsored by CyberDrain.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by CyberDrain.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for CIPP. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects CIPP to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 CIPP manages Microsoft 365 across all your client tenants, but its portal and API work one tenant at a time. Ask your AI "which tenants are off our security baseline" or "where are we paying for unused licenses" and get the cross-tenant answer the UI never renders: one fan-out pulls every tenant into a local store, then posture, license-waste, stale-account, and standards-drift rollups run instantly - offline, across the whole fleet.
 
@@ -134,6 +141,14 @@ The skill drives the cipp-cli and cipp-mcp binaries, authenticating to your self
 
 ## Frequently asked questions
 
+### Is there an MCP server for CIPP?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for CIPP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the CIPP MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local CIPP MCP server via a secure bridge. Step-by-step in the install guide.
@@ -167,9 +182,15 @@ Both. CIPP is a full management API, so the CLI can create users, offboard, set 
 No. CIPP stays your portal for deep single-tenant work. This skill adds the cross-tenant reporting layer and lets your AI agent drive CIPP from natural language.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the CIPP API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/connectwise-manage.md
+++ b/docs/skills/connectwise-manage.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "ConnectWise PSA (Manage) MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "ConnectWise PSA (Manage) MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every ConnectWise PSA workflow from the terminal \u2014 with a typed conditions query builder, offline SQLite sync, and cross-entity views (unbilled work, account 360, board triage) the PSA web UI can't give you."
 permalink: /skills/connectwise-manage/
 skill_name: "ConnectWise PSA (Manage) MCP"
 image: /assets/social/connectwise-manage/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for ConnectWise PSA (Manage)?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for ConnectWise PSA (Manage), built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the ConnectWise PSA (Manage) MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local ConnectWise Manage MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a ConnectWise PSA (Manage) question in plain language; it runs connectwise-manage-cli for you."
 ---
 
-# ConnectWise PSA (Manage) + AI in 60 seconds
+# The ConnectWise PSA (Manage) MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the ConnectWise Manage
-> API. Not affiliated with, endorsed by, or sponsored by ConnectWise, LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by ConnectWise, LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for ConnectWise PSA (Manage). It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects ConnectWise PSA (Manage) to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run ConnectWise PSA (Manage) as the system of record - tickets, time, agreements, billing. Ask your AI "what's rotting on the board," "which closed tickets have no time logged," or "how burned is that block-hours agreement," and get answers the portal can't compose: cross-entity joins across tickets, time, agreements, and configurations, computed offline from a local mirror in one query instead of five portal screens and an Excel export.
 
@@ -133,6 +140,14 @@ The skill drives the connectwise-manage-cli and connectwise-manage-mcp binaries,
 
 ## Frequently asked questions
 
+### Is there an MCP server for ConnectWise PSA (Manage)?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for ConnectWise PSA (Manage), built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the ConnectWise PSA (Manage) MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local ConnectWise Manage MCP server via a secure bridge. Step-by-step in the install guide.
@@ -166,9 +181,15 @@ An API Member with public/private keys from your own Manage instance, plus a cli
 Yes. CW_SITE accepts your own server's hostname as well as the cloud region hosts; the CLI builds the standard v4_6_release/apis/3.0 base URL either way.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [Autotask PSA](/skills/autotask/) · [HaloPSA](/skills/halopsa/) · [Kaseya BMS](/skills/kaseya-bms/) · [SuperOps](/skills/superops/) · [Syncro](/skills/syncro/)
+
 ## Status
 
 Beta. Validated against the ConnectWise PSA (Manage) API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/cove.md
+++ b/docs/skills/cove.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Cove Data Protection MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Cove Data Protection MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first CLI and MCP server for Cove Data Protection: fleet-wide backup health, billing usage, and storage trends from your terminal, with the local history the vendor console doesn't keep."
 permalink: /skills/cove/
 skill_name: "Cove Data Protection MCP"
 image: /assets/social/cove/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Cove Data Protection?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Cove Data Protection, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Cove Data Protection MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Cove Data Protection MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Cove Data Protection question in plain language; it runs cove-cli for you."
 ---
 
-# Cove Data Protection + AI in 60 seconds
+# The Cove Data Protection MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Cove Data Protection
-> API. Not affiliated with, endorsed by, or sponsored by N-able.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by N-able.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Cove Data Protection. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Cove Data Protection to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask which Cove backups failed last night and get every failed, aborted, or never-started device across all your customers in one sweep, the status codes decoded to plain names. Cove's console scopes to one partner at a time and forgets yesterday; this skill speaks the whole JSON-RPC API and keeps a local snapshot history, so storage-growth and what-changed-since-Friday trends exist at all.
 
@@ -130,6 +137,14 @@ The skill is read-first: every command that touches Cove reads (failure sweeps, 
 
 ## Frequently asked questions
 
+### Is there an MCP server for Cove Data Protection?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Cove Data Protection, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Cove Data Protection MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Cove Data Protection MCP server via a secure bridge. Step-by-step in the install guide.
@@ -155,9 +170,15 @@ An API-enabled backup.management user: a Security Officer service account with t
 No. This skill speaks the Cove management API: fleet health, billing, storage trends, and enumeration. Restores and per-session file browsing run through the Backup Manager client and the storage-node Reporting Service, which this CLI does not cover.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Afi](/skills/afi/) · [Axcient x360Recover](/skills/axcient/) · [Datto BCDR](/skills/datto-bcdr/) · [Servosity](/skills/servosity/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Cove Data Protection API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/crowdstrike.md
+++ b/docs/skills/crowdstrike.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "CrowdStrike Falcon MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "CrowdStrike Falcon MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every CrowdStrike Falcon MSP operation, plus a Flight-Control-aware local store that answers fleet-wide questions across all your tenants at once \u2014 something no other Falcon tool (including the official MCP server) does."
 permalink: /skills/crowdstrike/
 skill_name: "CrowdStrike Falcon MCP"
 image: /assets/social/crowdstrike/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for CrowdStrike Falcon?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for CrowdStrike Falcon, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the CrowdStrike Falcon MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local CrowdStrike MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a CrowdStrike Falcon question in plain language; it runs crowdstrike-cli for you."
 ---
 
-# CrowdStrike Falcon + AI in 60 seconds
+# The CrowdStrike Falcon MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the CrowdStrike
-> API. Not affiliated with, endorsed by, or sponsored by CrowdStrike, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by CrowdStrike, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for CrowdStrike Falcon. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects CrowdStrike Falcon to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Running CrowdStrike Falcon across a book of client tenants? Ask your AI "what should I triage first across every CID," "which sensors went silent," or "where are the critical vulnerabilities," and get one cross-tenant answer the Falcon console can't compose. Every child CID is mirrored into one local store keyed by CID, so a single scorecard, vuln ranking, and stale-sensor sweep replace flipping Flight Control tenant by tenant.
 
@@ -135,6 +142,14 @@ The skill drives the crowdstrike-cli and crowdstrike-mcp binaries, authenticatin
 
 ## Frequently asked questions
 
+### Is there an MCP server for CrowdStrike Falcon?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for CrowdStrike Falcon, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the CrowdStrike Falcon MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local CrowdStrike MCP server via a secure bridge. Step-by-step in the install guide.
@@ -168,9 +183,15 @@ Read scopes for the entities you query - Alerts (read), Hosts (read), Spotlight 
 No. The console stays best for hunting, RTR sessions, policy authoring, and the interactive response workflow inside one CID. This skill adds cross-tenant queries and scriptable actions to your AI agent so you stop scoping into each CID to answer book-wide questions.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the CrowdStrike Falcon API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/datto-bcdr.md
+++ b/docs/skills/datto-bcdr.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Datto BCDR MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Datto BCDR MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Sync your whole Datto BCDR fleet into local SQLite and answer the questions the per-appliance Partner Portal can't: which backups failed screenshot verification, which are stale, and which clients are at risk."
 permalink: /skills/datto-bcdr/
 skill_name: "Datto BCDR MCP"
 image: /assets/social/datto-bcdr/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Datto BCDR?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Datto BCDR, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Datto BCDR MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Datto BCDR MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a Datto BCDR question in plain language; it runs datto-bcdr-cli for you."
 ---
 
-# Datto BCDR + AI in 60 seconds
+# The Datto BCDR MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Datto BCDR
-> API. Not affiliated with, endorsed by, or sponsored by Datto, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Datto, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Datto BCDR. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Datto BCDR to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask in plain English which Datto backups failed their last screenshot verification, which clients are most at risk, and which appliance fills up first - and get the answer across your whole fleet in seconds. The Datto BCDR API answers one appliance at a time; this skill mirrors every device, agent, and alert locally, so the fleet-wide question the Partner Portal can't answer becomes one instant command.
 
@@ -136,6 +143,14 @@ The datto-bcdr skill is read-only for everyday use: it reads your Datto BCDR fle
 
 ## Frequently asked questions
 
+### Is there an MCP server for Datto BCDR?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Datto BCDR, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Datto BCDR MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Datto BCDR MCP server via a secure bridge. Step-by-step in the install guide.
@@ -169,9 +184,15 @@ No. It answers the fleet-wide, cross-client questions the per-appliance portal c
 Read-only for everyday use - every analysis, list, and report command only reads. The single exception is `import`, an explicit bulk data-load command you would never run by accident; preview it with --dry-run first.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Afi](/skills/afi/) · [Axcient x360Recover](/skills/axcient/) · [Cove Data Protection](/skills/cove/) · [Servosity](/skills/servosity/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Datto BCDR API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/datto-rmm.md
+++ b/docs/skills/datto-rmm.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Datto RMM MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Datto RMM MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Datto RMM API operation, plus a local SQLite fleet store and fleet-wide analytics no other Datto tool has."
 permalink: /skills/datto-rmm/
 skill_name: "Datto RMM MCP"
 image: /assets/social/datto-rmm/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Datto RMM?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Datto RMM, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Datto RMM MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Datto RMM MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Datto RMM question in plain language; it runs datto-rmm-cli for you."
 ---
 
-# Datto RMM + AI in 60 seconds
+# The Datto RMM MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Datto RMM
-> API. Not affiliated with, endorsed by, or sponsored by Datto, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Datto, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Datto RMM. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Datto RMM to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask in plain English which endpoints across every client have gone dark, lost antivirus, fallen behind on patches, or are about to drop out of warranty - and get the list in seconds. Datto RMM plus your AI agent reads a local mirror of your whole multi-site fleet, so the cross-customer questions the portal makes you click through site by site become one instant, reproducible answer.
 
@@ -129,6 +136,14 @@ The skill reads your Datto RMM fleet and writes only when you ask it to - creati
 
 ## Frequently asked questions
 
+### Is there an MCP server for Datto RMM?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Datto RMM, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Datto RMM MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Datto RMM MCP server via a secure bridge. Step-by-step in the install guide.
@@ -154,9 +169,15 @@ It's gentle by design. The skill syncs your fleet into a local mirror once, then
 You need an API key and secret key from Setup > Users in your Datto RMM portal (the OAuth API user). The skill can only do what that API user is allowed to do, so scope the user to the access your workflow actually needs.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the Datto RMM API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/domotz.md
+++ b/docs/skills/domotz.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Domotz MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Domotz MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Domotz endpoint, plus a local SQLite fleet mirror that answers cross-site questions."
 permalink: /skills/domotz/
 skill_name: "Domotz MCP"
 image: /assets/social/domotz/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Domotz?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Domotz, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Domotz MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Domotz MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a Domotz question in plain language; it runs domotz-cli for you."
 ---
 
-# Domotz + AI in 60 seconds
+# The Domotz MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Domotz
-> API. Not affiliated with, endorsed by, or sponsored by Domotz Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Domotz Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Domotz. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Domotz to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "which client sites have devices down right now?" and get one answer instead of clicking through the Domotz portal Collector by Collector. domotz-cli syncs every Collector into a local mirror, so cross-site rollups - fleet health, every offline device, overnight new-device sweeps, one unified asset inventory - come back as single offline queries your agent can run in seconds.
 
@@ -129,6 +136,14 @@ The skill reads your Domotz fleet - Collectors, devices, variables, alerts, and 
 
 ## Frequently asked questions
 
+### Is there an MCP server for Domotz?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Domotz, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Domotz MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Domotz MCP server via a secure bridge. Step-by-step in the install guide.
@@ -153,6 +168,8 @@ No add-on is required - you generate an API Key from the Domotz Portal under Set
 ## Status
 
 Beta. Validated against the Domotz API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/gradient.md
+++ b/docs/skills/gradient.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Gradient MSP MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Gradient MSP MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The Gradient MSP Synthesize vendor API from your terminal: bulk usage pushes with a single billing rebuild, a local push-drift ledger, and alert-to-ticket tracing the portal and SDK don't offer."
 permalink: /skills/gradient/
 skill_name: "Gradient MSP MCP"
 image: /assets/social/gradient/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Gradient MSP?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Gradient MSP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Gradient MSP MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Gradient MSP MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Gradient MSP question in plain language; it runs gradient-cli for you."
 ---
 
-# Gradient MSP + AI in 60 seconds
+# The Gradient MSP MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Gradient MSP
-> API. Not affiliated with, endorsed by, or sponsored by Gradient MSP, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Gradient MSP, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Gradient MSP. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Gradient MSP to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI to push tonight's usage counts, tell you which accounts' billing changed since the last push, and confirm an alert actually became a PSA ticket - and it runs the real Gradient MSP Synthesize commands and shows you the receipts. The full vendor API from your terminal, plus a local push ledger and offline mirror that Gradient's PowerShell SDK cannot give you.
 
@@ -129,6 +136,14 @@ The skill reads your Synthesize accounts, services, mappings, integration status
 
 ## Frequently asked questions
 
+### Is there an MCP server for Gradient MSP?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Gradient MSP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Gradient MSP MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Gradient MSP MCP server via a secure bridge. Step-by-step in the install guide.
@@ -154,9 +169,15 @@ A Synthesize vendor token. Set GRADIENT_TOKEN to the base64 of <vendorApiKey>:<p
 No. Mapping approval and reconciliation review still happen in the Synthesize portal (or are handled by Gradient's MBR service). This CLI is the vendor and integration side: it pushes accounts, services, and usage counts in, audits what was pushed, and traces alerts to PSA tickets. It complements the portal, it does not log into it.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [AppDirect](/skills/appdirect/) · [Pax8](/skills/pax8/) · [QuickBooks Online](/skills/quickbooks/) · [Sherweb](/skills/sherweb/) · [Xero](/skills/xero/)
+
 ## Status
 
 Beta. Validated against the Gradient MSP API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/halopsa.md
+++ b/docs/skills/halopsa.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "HaloPSA MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "HaloPSA MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every HaloPSA, HaloITSM and HaloCRM feature, plus a local SQLite store and cross-entity views the API can't return."
 permalink: /skills/halopsa/
 skill_name: "HaloPSA MCP"
 image: /assets/social/halopsa/wide-1200x630.png
 verification: live-verified
 faqs:
+  - q: "Is there an MCP server for HaloPSA?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for HaloPSA, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the HaloPSA MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on Plus, Pro, Team, Business, Enterprise, and Education plans (the Free tier does not yet expose Developer Mode). ChatGPT connects to remote MCP servers over HTTPS, not local stdio binaries, so you expose the local HaloPSA MCP server via the mcp-remote bridge or your own HTTPS endpoint. Step-by-step in mcp-install.md."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a HaloPSA question in plain language; it runs halopsa-cli for you."
 ---
 
-# HaloPSA + AI in 60 seconds
+# The HaloPSA MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the HaloPSA
-> API. Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Halo Service Solutions Ltd..
 
-**Live-verified** - confirmed by a real MSP against a live HaloPSA tenant (2026-06-05).
+**✓ Live-verified by Servosity (maintainer)** against a production tenant · 2026-06-05.
+
+Yes - there is an MCP server for HaloPSA. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects HaloPSA to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run HaloPSA as the service desk - tickets, SLAs, contracts, and the queue that never stops. Ask your AI "what's about to breach SLA," "who's overloaded," or "what's the whole story for this client," and get an answer the portal can't compose in one shot: cross-entity rollups across tickets, clients, contracts, time, and assets, joined offline in one query instead of clicking through five tabs. A local SQLite mirror means QBR-time questions don't hit rate limits.
 
@@ -132,6 +139,14 @@ The skill drives the halopsa-cli and halopsa-mcp binaries, authenticating to you
 
 ## Frequently asked questions
 
+### Is there an MCP server for HaloPSA?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for HaloPSA, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the HaloPSA MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on Plus, Pro, Team, Business, Enterprise, and Education plans (the Free tier does not yet expose Developer Mode). ChatGPT connects to remote MCP servers over HTTPS, not local stdio binaries, so you expose the local HaloPSA MCP server via the mcp-remote bridge or your own HTTPS endpoint. Step-by-step in mcp-install.md.
@@ -161,9 +176,15 @@ Yes. The PowerShell installer is the Windows path, and the CLI and MCP binaries 
 Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use (Claude, ChatGPT, Codex, and so on), billed by your AI provider, not by us.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [Autotask PSA](/skills/autotask/) · [ConnectWise PSA (Manage)](/skills/connectwise-manage/) · [Kaseya BMS](/skills/kaseya-bms/) · [SuperOps](/skills/superops/) · [Syncro](/skills/syncro/)
+
 ## Status
 
 Beta. Validated against the HaloPSA API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/hubspot.md
+++ b/docs/skills/hubspot.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "HubSpot MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "HubSpot MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every HubSpot Sales Hub feature, plus offline cross-object queries, property-change-history reporting, and an agent-native data layer no other HubSpot tool has."
 permalink: /skills/hubspot/
 skill_name: "HubSpot MCP"
 image: /assets/social/hubspot/wide-1200x630.png
 verification: live-verified
 faqs:
+  - q: "Is there an MCP server for HubSpot?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for HubSpot, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the HubSpot MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local HubSpot MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a HubSpot question in plain language; it runs hubspot-cli for you."
 ---
 
-# HubSpot + AI in 60 seconds
+# The HubSpot MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the HubSpot
-> API. Not affiliated with, endorsed by, or sponsored by HubSpot, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by HubSpot, Inc..
 
-**Live-verified** - confirmed by a real MSP against a live HubSpot tenant (2026-06-05).
+**✓ Live-verified by Servosity (maintainer)** against a production tenant · 2026-06-05.
+
+Yes - there is an MCP server for HubSpot. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects HubSpot to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run HubSpot as the sales CRM - pipeline, deals, quote-chasing. Ask your AI "which deals went cold," "what's my pipeline health," or "who do I call today," and get an answer the portal can't compose: cross-object rollups across deals, contacts, owners, and engagements, computed offline in one query instead of a dozen exports and saved views.
 
@@ -131,6 +138,14 @@ The skill drives the hubspot-cli and hubspot-mcp binaries, authenticating only w
 
 ## Frequently asked questions
 
+### Is there an MCP server for HubSpot?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for HubSpot, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the HubSpot MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local HubSpot MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ No partnership is required. You create a HubSpot Private App access token from y
 It works against any portal that issues a Private App access token with the read scopes you grant. Which objects, properties, and history depth are available is governed by your HubSpot plan and the scopes on the token, not by this skill.
 
 
+## More CRM connectors
+
+Run more than one CRM tool, or comparing options? These connectors work the same way: [Pipedrive](/skills/pipedrive/) · [Salesbuildr](/skills/salesbuildr/)
+
 ## Status
 
 Beta. Validated against the HubSpot API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/hudu.md
+++ b/docs/skills/hudu.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Hudu MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Hudu MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Hudu cmdlet, plus an offline SQLite mirror, cross-entity audits, and agent-native output no PowerShell module or read-only MCP ships."
 permalink: /skills/hudu/
 skill_name: "Hudu MCP"
 image: /assets/social/hudu/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Hudu?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Hudu, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Hudu MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Hudu MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a Hudu question in plain language; it runs hudu-cli for you."
 ---
 
-# Hudu + AI in 60 seconds
+# The Hudu MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Hudu
-> API. Not affiliated with, endorsed by, or sponsored by Hudu Technologies, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Hudu Technologies, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Hudu. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Hudu to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask in plain English which clients have the worst documentation, which vault passwords are overdue for rotation, and what SSL certs, domains, or warranties expire next - across every company at once. Hudu plus your AI agent reads a local mirror of your whole instance, so the hygiene questions the portal makes you click through company by company become one instant, reproducible answer.
 
@@ -129,6 +136,14 @@ The skill reads everything over a local mirror - audits, search, resolve, and re
 
 ## Frequently asked questions
 
+### Is there an MCP server for Hudu?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Hudu, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Hudu MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Hudu MCP server via a secure bridge. Step-by-step in the install guide.
@@ -150,9 +165,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 Mostly. Audits and search run over whatever you've synced, so they work with any key. The one limit: Hudu's global asset-list endpoint requires a global (not company-scoped) key - with a scoped key, use 'assets list-by-company <company_id>' instead. The 'onboard --apply' write path also needs a global key.
 
 
+## More Documentation connectors
+
+Run more than one Documentation tool, or comparing options? These connectors work the same way: [IT Glue](/skills/itglue/) · [Liongard](/skills/liongard/) · [PandaDoc](/skills/pandadoc/)
+
 ## Status
 
 Beta. Validated against the Hudu API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/huntress.md
+++ b/docs/skills/huntress.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Huntress MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Huntress MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Huntress endpoint, plus a local SQLite mirror that delivers fleet-wide incident, coverage, and billing rollups the API and official MCP can't."
 permalink: /skills/huntress/
 skill_name: "Huntress MCP"
 image: /assets/social/huntress/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Huntress?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Huntress, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Huntress MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Huntress MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Huntress question in plain language; it runs huntress-cli for you."
 ---
 
-# Huntress + AI in 60 seconds
+# The Huntress MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Huntress
-> API. Not affiliated with, endorsed by, or sponsored by Huntress Labs, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Huntress Labs, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Huntress. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Huntress to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "which Huntress incidents are oldest across all my clients?" and get one age-sorted queue spanning every organization - the cross-tenant view the per-org portal never shows. Triage incidents fleet-wide, find coverage gaps and dark agents, reconcile invoiced seats against deployed agents, and trace an indicator's blast radius across your whole account, in plain English, from one local mirror.
 
@@ -131,6 +138,14 @@ The skill authenticates with your Huntress API key and secret and is read-first:
 
 ## Frequently asked questions
 
+### Is there an MCP server for Huntress?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Huntress, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Huntress MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Huntress MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ Sync pulls your account into a local mirror once, then every rollup and search r
 No - it complements it. The portal stays your console for configuration and deep investigation; this skill answers the cross-tenant and historical questions the portal can only show one organization at a time.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the Huntress API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/itglue.md
+++ b/docs/skills/itglue.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "IT Glue MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "IT Glue MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every IT Glue resource, plus an offline SQLite mirror, fleet-wide cross-resource search, and documentation-hygiene analytics no other IT Glue tool offers."
 permalink: /skills/itglue/
 skill_name: "IT Glue MCP"
 image: /assets/social/itglue/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for IT Glue?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for IT Glue, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the IT Glue MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local IT Glue MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a IT Glue question in plain language; it runs itglue-cli for you."
 ---
 
-# IT Glue + AI in 60 seconds
+# The IT Glue MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the IT Glue
-> API. Not affiliated with, endorsed by, or sponsored by Kaseya US LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Kaseya US LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for IT Glue. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects IT Glue to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs keep their whole client world in IT Glue - organizations, contacts, passwords, configurations, documents - but the API answers one record at a time under a 3000-request rate ceiling. Ask your AI "which clients are under-documented," "which credentials haven't rotated in a year," or "which client owns this serial number," and get fleet-wide answers from a local mirror in one query - no portal clicking, no rate-limit math.
 
@@ -133,6 +140,14 @@ The skill drives the itglue-cli and itglue-mcp binaries, authenticating with an 
 
 ## Frequently asked questions
 
+### Is there an MCP server for IT Glue?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for IT Glue, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the IT Glue MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local IT Glue MCP server via a secure bridge. Step-by-step in the install guide.
@@ -166,9 +181,15 @@ Yes. IT Glue hosts data in regional API endpoints; set ITGLUE_BASE_URL to your r
 No. The CLI reads, and creates or updates contacts, passwords, configurations, and documents - it exposes no delete for any IT Glue resource. The coverage and stale-password audits read metadata only; password secret values are never read or printed.
 
 
+## More Documentation connectors
+
+Run more than one Documentation tool, or comparing options? These connectors work the same way: [Hudu](/skills/hudu/) · [Liongard](/skills/liongard/) · [PandaDoc](/skills/pandadoc/)
+
 ## Status
 
 Beta. Validated against the IT Glue API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/kaseya-bms.md
+++ b/docs/skills/kaseya-bms.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Kaseya BMS MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Kaseya BMS MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first dedicated CLI and MCP server for Kaseya BMS - the full PSA surface plus offline sync, full-text search, and the queue, contract-burn, and unbilled-time analytics the web grid can't compute."
 permalink: /skills/kaseya-bms/
 skill_name: "Kaseya BMS MCP"
 image: /assets/social/kaseya-bms/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Kaseya BMS?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Kaseya BMS, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Kaseya BMS MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Kaseya BMS MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Kaseya BMS question in plain language; it runs kaseya-bms-cli for you."
 ---
 
-# Kaseya BMS + AI in 60 seconds
+# The Kaseya BMS MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Kaseya BMS
-> API. Not affiliated with, endorsed by, or sponsored by Kaseya US LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Kaseya US LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Kaseya BMS. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Kaseya BMS to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Run the Kaseya BMS service desk, contracts, and billing from your terminal - or let your AI agent do it. Ask in plain English which queues are underwater, which tickets are going stale, who's overloaded, how much of each contract you've burned, and what billable time is sitting unbilled - and get the answer instantly from a local mirror, without exporting a single report.
 
@@ -132,6 +139,14 @@ The skill reads everything - tickets, CRM, contracts, finance, projects - and ca
 
 ## Frequently asked questions
 
+### Is there an MCP server for Kaseya BMS?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Kaseya BMS, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Kaseya BMS MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Kaseya BMS MCP server via a secure bridge. Step-by-step in the install guide.
@@ -161,9 +176,15 @@ Yes - you need a Kaseya BMS tenant and an API user. The skill authenticates as t
 No. It's a faster path for the questions you ask every day - queue health, unbilled time, pipeline - and for letting an AI agent drive the service desk. The BMS portal stays your system of record.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [Autotask PSA](/skills/autotask/) · [ConnectWise PSA (Manage)](/skills/connectwise-manage/) · [HaloPSA](/skills/halopsa/) · [SuperOps](/skills/superops/) · [Syncro](/skills/syncro/)
+
 ## Status
 
 Beta. Validated against the Kaseya BMS API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/knowbe4.md
+++ b/docs/skills/knowbe4.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "KnowBe4 MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "KnowBe4 MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every KnowBe4 KMSAT reporting feature plus a local SQLite store that answers the cross-client questions the console can't \u2014 repeat-clicker hunts and training-coverage anti-joins."
 permalink: /skills/knowbe4/
 skill_name: "KnowBe4 MCP"
 image: /assets/social/knowbe4/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for KnowBe4?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for KnowBe4, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the KnowBe4 MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local KnowBe4 MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a KnowBe4 question in plain language; it runs knowbe4-cli for you."
 ---
 
-# KnowBe4 + AI in 60 seconds
+# The KnowBe4 MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the KnowBe4
-> API. Not affiliated with, endorsed by, or sponsored by KnowBe4, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by KnowBe4, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for KnowBe4. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects KnowBe4 to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 KnowBe4's console reports one tenant, one phishing test, one chart at a time. This skill syncs your KMSAT data into a local SQLite mirror and answers the questions the portal can't: which users clicked the bait in multiple phishing tests, whose risk score is deteriorating this quarter, and who clicked a phish but finished zero training - across every client, in seconds, from your terminal.
 
@@ -128,6 +135,14 @@ The skill reads your KnowBe4 reporting data - accounts, users, groups, phishing 
 
 ## Frequently asked questions
 
+### Is there an MCP server for KnowBe4?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for KnowBe4, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the KnowBe4 MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local KnowBe4 MCP server via a secure bridge. Step-by-step in the install guide.
@@ -149,9 +164,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 Neither. It uses your standard KMSAT Reporting API key (Account Settings - API - enable Reporting API) and your region (us, eu, ca, uk, or de). It reads what your account already exposes and adds the cross-client rollups the console doesn't. The one write path that needs extra setup is pushing custom risk events, which uses a separate, opt-in User Event API key.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the KnowBe4 API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/levelio.md
+++ b/docs/skills/levelio.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Level MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Level MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Level RMM endpoint, plus a local SQLite fleet store and offline cross-entity rollups no Level tool has: at-risk ranking, patch posture, alert triage, and stale-device detection in one command."
 permalink: /skills/levelio/
 skill_name: "Level MCP"
 image: /assets/social/levelio/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Level?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Level, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Level MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Level MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Level question in plain language; it runs levelio-cli for you."
 ---
 
-# Level + AI in 60 seconds
+# The Level MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Level
-> API. Not affiliated with, endorsed by, or sponsored by Level.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Level.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Level. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Level to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "which Level endpoints are most at risk right now?" and get one ranked list across active alerts, missing patches, low security scores, and dark devices - not four portal tabs. levelio-cli syncs your whole Level fleet into a local mirror, then answers portfolio-wide questions the portal shows one device at a time: patch exposure, stale agents, alert clusters, and per-client QBR scorecards. Offline, instant, and read-only-safe.
 
@@ -131,6 +138,14 @@ The skill reads everything - reports, rollups, search, and a sync to a local mir
 
 ## Frequently asked questions
 
+### Is there an MCP server for Level?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Level, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Level MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Level MCP server via a secure bridge. Step-by-step in the install guide.
@@ -156,9 +171,15 @@ Only 'sync' calls the Level API, and it paginates politely. Every report, rollup
 You need a Level account and an API key (Settings > API keys). A read-only key is enough for every report and rollup here, and you can scope it tighter than your portal login. The skill itself is free and open source.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the Level API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/liongard.md
+++ b/docs/skills/liongard.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Liongard MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Liongard MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Liongard endpoint, plus an offline copy of your whole MSP estate you can join, search, and drift-check from one command."
 permalink: /skills/liongard/
 skill_name: "Liongard MCP"
 image: /assets/social/liongard/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Liongard?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Liongard, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Liongard MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Liongard MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a Liongard question in plain language; it runs liongard-cli for you."
 ---
 
-# Liongard + AI in 60 seconds
+# The Liongard MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Liongard
-> API. Not affiliated with, endorsed by, or sponsored by Liongard, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Liongard, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Liongard. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Liongard to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "what changed across all my clients this week," "which Liongard collectors went stale," or "which agents are offline," and get the answer in one command instead of clicking through the portal environment by environment. The skill syncs your whole Liongard estate into a local mirror, then drift-checks, searches, and rolls it up across every environment - so the visibility you already pay for finally reaches you.
 
@@ -131,6 +138,14 @@ Read commands (drift, health, coverage, the stale/offline/failure rollups, searc
 
 ## Frequently asked questions
 
+### Is there an MCP server for Liongard?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Liongard, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Liongard MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Liongard MCP server via a secure bridge. Step-by-step in the install guide.
@@ -152,9 +167,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 Yes - you use your own Liongard instance and access keys, so the skill only reaches data your credentials already permit. Because it syncs once into a local mirror and answers most questions from there, it makes far fewer API calls than a per-question live wrapper, which keeps you well clear of rate limits during reporting and QBR prep.
 
 
+## More Documentation connectors
+
+Run more than one Documentation tool, or comparing options? These connectors work the same way: [Hudu](/skills/hudu/) · [IT Glue](/skills/itglue/) · [PandaDoc](/skills/pandadoc/)
+
 ## Status
 
 Beta. Validated against the Liongard API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/microsoft-graph.md
+++ b/docs/skills/microsoft-graph.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Microsoft Graph MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Microsoft Graph MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The maintained single-binary successor to the retiring mgc \u2014 every MSP-relevant Microsoft Graph surface, plus an offline store that finds wasted licenses, privileged-access risks, and stale devices no single API call can."
 permalink: /skills/microsoft-graph/
 skill_name: "Microsoft Graph MCP"
 image: /assets/social/microsoft-graph/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Microsoft Graph?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Microsoft Graph, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Microsoft Graph MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Microsoft Graph MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Microsoft Graph question in plain language; it runs microsoft-graph-cli for you."
 ---
 
-# Microsoft Graph + AI in 60 seconds
+# The Microsoft Graph MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Microsoft Graph
-> API. Not affiliated with, endorsed by, or sponsored by Microsoft Corporation.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Microsoft Corporation.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Microsoft Graph. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Microsoft Graph to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Microsoft retires the Graph CLI (mgc) on August 28, 2026 and points admins at the heavier PowerShell SDK. This is the lightweight successor: one cross-platform binary, no .NET or PowerShell runtime. Ask your AI "which M365 licenses are we wasting," "who holds privileged admin right now," or "what's new in Defender since yesterday," and get cross-tenant answers computed offline from a local SQLite mirror - one query instead of CSV exports and portal tab-hopping.
 
@@ -131,6 +138,14 @@ The skill drives the microsoft-graph-cli and microsoft-graph-mcp binaries, authe
 
 ## Frequently asked questions
 
+### Is there an MCP server for Microsoft Graph?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Microsoft Graph, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Microsoft Graph MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Microsoft Graph MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ Either. Run `auth login --tenant <id> --client-id <id> --client-secret <secret>`
 Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the Microsoft Graph API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/mspbots.md
+++ b/docs/skills/mspbots.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "MSPbots MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "MSPbots MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first MSPbots tool anywhere \u2014 readable filters, alias-named resources, full exports, and the KPI history MSPbots itself doesn't keep."
 permalink: /skills/mspbots/
 skill_name: "MSPbots MCP"
 image: /assets/social/mspbots/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for MSPbots?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for MSPbots, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the MSPbots MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local MSPbots MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -34,12 +38,15 @@ howto:
     text: "Ask your AI agent a MSPbots question in plain language; it runs mspbots-cli for you."
 ---
 
-# MSPbots + AI in 60 seconds
+# The MSPbots MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the MSPbots
-> API. Not affiliated with, endorsed by, or sponsored by MSPbots, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by MSPbots, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for MSPbots. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects MSPbots to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPbots aggregates your PSA, RMM, and finance data into KPI dashboards - then keeps it there. Ask your AI "is our ticket backlog up or down this week" and get the answer the dashboard can't give: point-in-time snapshots, week-over-week deltas, row-level diffs, and full CSV exports - through readable aliases and filters instead of 19-digit resource IDs and a comma-encoded query DSL.
 
@@ -135,6 +142,14 @@ The skill drives the mspbots-cli and mspbots-mcp binaries, authenticating with a
 
 ## Frequently asked questions
 
+### Is there an MCP server for MSPbots?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for MSPbots, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the MSPbots MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local MSPbots MCP server via a secure bridge. Step-by-step in the install guide.
@@ -175,6 +190,8 @@ Yes - pull, export, snapshot, describe, and registry add all accept --type widge
 ## Status
 
 Beta. Validated against the MSPbots API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/n-central.md
+++ b/docs/skills/n-central.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "N-able N-central MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "N-able N-central MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every N-central REST endpoint, plus an offline SQLite mirror of your whole org tree, cross-tenant search, issue-triage rollups, and a JWT-expiry guardian no other N-central tool has."
 permalink: /skills/n-central/
 skill_name: "N-able N-central MCP"
 image: /assets/social/n-central/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for N-able N-central?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for N-able N-central, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the N-able N-central MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local N-central MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -34,12 +38,15 @@ howto:
     text: "Ask your AI agent a N-able N-central question in plain language; it runs n-central-cli for you."
 ---
 
-# N-able N-central + AI in 60 seconds
+# The N-able N-central MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the N-able N-central
-> API. Not affiliated with, endorsed by, or sponsored by N-able, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by N-able, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for N-able N-central. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects N-able N-central to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 N-central knows every device you manage - and answering "where is that machine" still means walking the console's org tree. Ask your AI "what's red right now", "where is EXCHANGE01", or "which devices have no maintenance window before Saturday's patch wave" and get rollups the console can't compose: cross-tenant search from an offline mirror, severity-ranked triage, coverage audits, and a guardian that catches the JWT before it silently dies.
 
@@ -135,6 +142,14 @@ The skill drives the n-central-cli and n-central-mcp binaries, authenticating wi
 
 ## Frequently asked questions
 
+### Is there an MCP server for N-able N-central?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for N-able N-central, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the N-able N-central MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local N-central MCP server via a secure bridge. Step-by-step in the install guide.
@@ -172,9 +187,15 @@ N-able documents per-endpoint concurrency caps - 429 responses beyond roughly 3 
 No. This skill targets the N-central REST API specifically. N-sight is a separate N-able product with a separate API.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the N-able N-central API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/nerdio.md
+++ b/docs/skills/nerdio.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Nerdio Manager MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Nerdio Manager MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first non-PowerShell client for the Nerdio Manager for MSP API - cross-account AVD fleet audits, async-job plumbing, and offline search no other Nerdio tool has."
 permalink: /skills/nerdio/
 skill_name: "Nerdio Manager MCP"
 image: /assets/social/nerdio/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Nerdio Manager?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Nerdio Manager, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Nerdio Manager MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Nerdio Manager MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Nerdio Manager question in plain language; it runs nerdio-cli for you."
 ---
 
-# Nerdio Manager + AI in 60 seconds
+# The Nerdio Manager MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Nerdio Manager
-> API. Not affiliated with, endorsed by, or sponsored by Nerdio, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Nerdio, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Nerdio Manager. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Nerdio Manager to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "which host pools have autoscale off across all my customers?" and get one table - not 30 portal logins. Every MSP runs its own Nerdio Manager (NMM) install, so each answer normally means clicking through one tenant at a time. This skill pulls your whole NMM fleet into a local mirror and answers cross-account autoscale, power-state, billing, and Intune questions in a single command.
 
@@ -135,6 +142,14 @@ The skill reads your whole NMM fleet - accounts, host pools, session hosts, Intu
 
 ## Frequently asked questions
 
+### Is there an MCP server for Nerdio Manager?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Nerdio Manager, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Nerdio Manager MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Nerdio Manager MCP server via a secure bridge. Step-by-step in the install guide.
@@ -164,9 +179,15 @@ No. It is a read-first, cross-account companion. Day-to-day operating still happ
 Every NMM mutation (provisioning, scripted actions, backup, host power) is async and returns a job ID. Run nerdio-cli job wait <job_id> to poll it to a terminal state and exit non-zero if it failed - so your agent never reports "done" on a job that actually errored.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [NinjaOne](/skills/ninjaone/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the Nerdio Manager API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/ninjaone.md
+++ b/docs/skills/ninjaone.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "NinjaOne MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "NinjaOne MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every NinjaOne report, plus a local store that answers fleet-wide questions no single API call can: patch compliance, backup gaps, AV blast-radius, health, drift."
 permalink: /skills/ninjaone/
 skill_name: "NinjaOne MCP"
 image: /assets/social/ninjaone/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for NinjaOne?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for NinjaOne, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the NinjaOne MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local NinjaOne MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a NinjaOne question in plain language; it runs ninjaone-cli for you."
 ---
 
-# NinjaOne + AI in 60 seconds
+# The NinjaOne MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the NinjaOne
-> API. Not affiliated with, endorsed by, or sponsored by NinjaOne, LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by NinjaOne, LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for NinjaOne. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects NinjaOne to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 NinjaOne is built for real-time, per-device RMM, but its reporting answers one organization at a time. Ask your AI "which clients are below 95% patched," "which endpoints across the fleet have no backup," or "how far did this threat spread" and get fleet-wide rollups computed offline from a local SQLite mirror of your estate - one query instead of a per-org report re-totaled in a spreadsheet or a third-party BI overlay.
 
@@ -135,6 +142,14 @@ The skill drives the ninjaone-cli and ninjaone-mcp binaries, authenticating with
 
 ## Frequently asked questions
 
+### Is there an MCP server for NinjaOne?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for NinjaOne, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the NinjaOne MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local NinjaOne MCP server via a secure bridge. Step-by-step in the install guide.
@@ -168,9 +183,15 @@ The headline fleet views are read-only. The CLI also wraps NinjaOne's write surf
 Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [Tactical RMM](/skills/tactical-rmm/)
+
 ## Status
 
 Beta. Validated against the NinjaOne API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/pagerduty.md
+++ b/docs/skills/pagerduty.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "PagerDuty MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "PagerDuty MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first real CLI for PagerDuty incident response and on-call management - incidents, services, schedules, escalation policies, and analytics mirrored locally, with live triage, on-call resolution, coverage audits, and MTTA/MTTR reporting no single API call returns."
 permalink: /skills/pagerduty/
 skill_name: "PagerDuty MCP"
 image: /assets/social/pagerduty/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for PagerDuty?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for PagerDuty, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the PagerDuty MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local PagerDuty MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a PagerDuty question in plain language; it runs pagerduty-cli for you."
 ---
 
-# PagerDuty + AI in 60 seconds
+# The PagerDuty MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the PagerDuty
-> API. Not affiliated with, endorsed by, or sponsored by PagerDuty, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by PagerDuty, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for PagerDuty. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects PagerDuty to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "who's on call for the payments service right now, and when do they hand off?" or "what's our MTTR by service this month?" and get the answer in one command. PagerDuty syncs to a local SQLite mirror, so post-incident analytics, on-call coverage audits, and escalation-gap checks run instantly and offline: no Analytics add-on, no portal clicking, no per-question API call.
 
@@ -131,6 +138,14 @@ The skill reads everything through your PagerDuty REST API key and writes only w
 
 ## Frequently asked questions
 
+### Is there an MCP server for PagerDuty?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for PagerDuty, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the PagerDuty MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local PagerDuty MCP server via a secure bridge. Step-by-step in the install guide.
@@ -156,9 +171,15 @@ Rarely. Read questions run against the local SQLite mirror, not the API - you sy
 No. The skill computes MTTA, MTTR, responder workload, and noisy-service rankings locally from the incidents and log entries any REST API key can read, so you get the post-incident numbers without the paid Analytics tier.
 
 
+## More Incident Response connectors
+
+Run more than one Incident Response tool, or comparing options? These connectors work the same way: [Rootly](/skills/rootly/)
+
 ## Status
 
 Beta. Validated against the PagerDuty API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/pandadoc.md
+++ b/docs/skills/pandadoc.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "PandaDoc MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "PandaDoc MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every PandaDoc endpoint, plus an offline document pipeline no other PandaDoc tool has  -  stalled deals, aging, recipient engagement, and open quote value from a local store."
 permalink: /skills/pandadoc/
 skill_name: "PandaDoc MCP"
 image: /assets/social/pandadoc/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for PandaDoc?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for PandaDoc, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the PandaDoc MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local PandaDoc MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a PandaDoc question in plain language; it runs pandadoc-cli for you."
 ---
 
-# PandaDoc + AI in 60 seconds
+# The PandaDoc MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the PandaDoc
-> API. Not affiliated with, endorsed by, or sponsored by PandaDoc, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by PandaDoc, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for PandaDoc. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects PandaDoc to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "which proposals are stalled?" or "what's our open quote value?" and get the answer in seconds. PandaDoc's portal shows one document at a time and has no rollup for these. This skill syncs your documents, templates, and contacts into a local mirror, so cross-document questions - stalled deals, aging quotes, recipient engagement, dollars in-flight - become one instant query instead of a manual export-and-pivot.
 
@@ -133,6 +140,14 @@ Reads (pipeline, stalled, aging, value, search, list commands) are always safe a
 
 ## Frequently asked questions
 
+### Is there an MCP server for PandaDoc?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for PandaDoc, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the PandaDoc MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local PandaDoc MCP server via a secure bridge. Step-by-step in the install guide.
@@ -162,9 +177,15 @@ You need your own PandaDoc account with API access (included on PandaDoc's paid 
 No. You still create, send, and sign documents in PandaDoc. This adds the cross-document reporting and follow-up rollups the portal doesn't surface, so you can ask your AI instead of exporting spreadsheets.
 
 
+## More Documentation connectors
+
+Run more than one Documentation tool, or comparing options? These connectors work the same way: [Hudu](/skills/hudu/) · [IT Glue](/skills/itglue/) · [Liongard](/skills/liongard/)
+
 ## Status
 
 Beta. Validated against the PandaDoc API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/pax8.md
+++ b/docs/skills/pax8.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Pax8 MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Pax8 MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Pax8 Partner API endpoint, plus an offline store that reconciles billing, tracks MRR, and catches usage overages no Pax8 tool surfaces."
 permalink: /skills/pax8/
 skill_name: "Pax8 MCP"
 image: /assets/social/pax8/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Pax8?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Pax8, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Pax8 MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Pax8 MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Pax8 question in plain language; it runs pax8-cli for you."
 ---
 
-# Pax8 + AI in 60 seconds
+# The Pax8 MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Pax8
-> API. Not affiliated with, endorsed by, or sponsored by Pax8, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Pax8, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Pax8. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Pax8 to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs resell Microsoft, security, and backup through Pax8, then lose days each month reconciling its invoices against subscriptions and their PSA. Ask your AI "where is billing leaking this month," "what's my MRR and margin," or "which usage is about to overage," and get answers the Pax8 portal can't compose: invoices joined to subscriptions joined to usage, computed offline from a local mirror in one query instead of a CSV export and a spreadsheet.
 
@@ -131,6 +138,14 @@ The skill drives the pax8-cli and pax8-mcp binaries, authenticating with a Pax8 
 
 ## Frequently asked questions
 
+### Is there an MCP server for Pax8?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Pax8, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Pax8 MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Pax8 MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ After the first sync, the analytics commands (reconcile, mrr, overage, spend, si
 No. Provisioning, ordering, and support workflows stay in the portal. This skill answers the cross-entity billing and revenue questions the portal cannot compose in one place, from your terminal or agent.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [AppDirect](/skills/appdirect/) · [Gradient MSP](/skills/gradient/) · [QuickBooks Online](/skills/quickbooks/) · [Sherweb](/skills/sherweb/) · [Xero](/skills/xero/)
+
 ## Status
 
 Beta. Validated against the Pax8 API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/pipedrive.md
+++ b/docs/skills/pipedrive.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Pipedrive MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Pipedrive MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Full Pipedrive CRUD plus a local SQLite pipeline copy: stale deals, forecasts, aging, dupes, rep leaderboards."
 permalink: /skills/pipedrive/
 skill_name: "Pipedrive MCP"
 image: /assets/social/pipedrive/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Pipedrive?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Pipedrive, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Pipedrive MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Pipedrive MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Pipedrive question in plain language; it runs pipedrive-cli for you."
 ---
 
-# Pipedrive + AI in 60 seconds
+# The Pipedrive MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Pipedrive
-> API. Not affiliated with, endorsed by, or sponsored by Pipedrive OÜ.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Pipedrive OÜ.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Pipedrive. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Pipedrive to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "which deals are dying and who do I call today," and get a ranked answer in seconds. The Pipedrive skill keeps a local copy of your pipeline so it can join deals, people, activities, and notes the portal shows on separate screens - surfacing stale deals by dollar at risk, a weighted forecast, stage bottlenecks, and rep leaderboards without exporting a single CSV.
 
@@ -131,6 +138,14 @@ The skill can read your whole pipeline and can create, update, and delete CRM re
 
 ## Frequently asked questions
 
+### Is there an MCP server for Pipedrive?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Pipedrive, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Pipedrive MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Pipedrive MCP server via a secure bridge. Step-by-step in the install guide.
@@ -156,9 +171,15 @@ No. Any Pipedrive plan that issues an API token works - find it under Settings >
 Day-to-day questions answer from the local mirror after a `sync`, so they make zero API calls. `sync` itself paginates politely - tune `--rate-limit` and `--concurrency`, and use `--since 24h` to refresh only what changed - and live calls only happen when local data is missing or stale.
 
 
+## More CRM connectors
+
+Run more than one CRM tool, or comparing options? These connectors work the same way: [HubSpot](/skills/hubspot/) · [Salesbuildr](/skills/salesbuildr/)
+
 ## Status
 
 Beta. Validated against the Pipedrive API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/proofpoint.md
+++ b/docs/skills/proofpoint.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Proofpoint TAP MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Proofpoint TAP MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Proofpoint TAP Threat Insight endpoint plus a local threat store that answers cross-endpoint questions - who is both attacked and clicking, what touched a given user - without re-spending the limited daily API quota."
 permalink: /skills/proofpoint/
 skill_name: "Proofpoint TAP MCP"
 image: /assets/social/proofpoint/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Proofpoint TAP?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Proofpoint TAP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Proofpoint TAP MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Proofpoint MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Proofpoint TAP question in plain language; it runs proofpoint-cli for you."
 ---
 
-# Proofpoint TAP + AI in 60 seconds
+# The Proofpoint TAP MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Proofpoint
-> API. Not affiliated with, endorsed by, or sponsored by Proofpoint, Inc.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Proofpoint, Inc.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Proofpoint TAP. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Proofpoint TAP to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Proofpoint TAP's dashboard answers one threat, one clicker, one campaign at a time, and every SIEM pull spends against a hard daily quota. This skill backfills clicks, messages, campaigns, Very Attacked People, and clickers into a local SQLite store, then answers the questions the console can't: who is both heavily attacked and clicking, every event that touched one user, and a full incident brief from a single threatId - offline, in seconds.
 
@@ -130,6 +137,14 @@ The skill reads your Proofpoint TAP threat data - SIEM click and message events,
 
 ## Frequently asked questions
 
+### Is there an MCP server for Proofpoint TAP?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Proofpoint TAP, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Proofpoint TAP MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Proofpoint MCP server via a secure bridge. Step-by-step in the install guide.
@@ -155,9 +170,15 @@ No - avoiding that is the point. TAP caps you at 1,800 SIEM requests and 50 camp
 No. It uses your standard TAP (Targeted Attack Protection) Service Principal and Secret, created under Settings then Connected Applications in the TAP dashboard. It reads the Threat Insight endpoints your account already exposes; it does not require Proofpoint Essentials administration or a separate partner program.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the Proofpoint TAP API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/quickbooks.md
+++ b/docs/skills/quickbooks.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "QuickBooks Online MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "QuickBooks Online MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every QuickBooks Online Accounting entity, plus an offline SQLite mirror, cross-entity search, and AR/AP aging no SDK or read-only MCP ships."
 permalink: /skills/quickbooks/
 skill_name: "QuickBooks Online MCP"
 image: /assets/social/quickbooks/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for QuickBooks Online?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for QuickBooks Online, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the QuickBooks Online MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local QuickBooks Online MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a QuickBooks Online question in plain language; it runs quickbooks-cli for you."
 ---
 
-# QuickBooks Online + AI in 60 seconds
+# The QuickBooks Online MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the QuickBooks Online
-> API. Not affiliated with, endorsed by, or sponsored by Intuit Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Intuit Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for QuickBooks Online. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects QuickBooks Online to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your books a question and get the answer, not a CSV export. The skill syncs your QuickBooks Online company into a local SQLite mirror, then answers who owes you (ar-aging), what you owe (ap-aging), where the cash is (balances), which invoices to chase first (invoices stale), and whether the books are clean to close (reconcile) - instantly, offline, across the whole book. No portal clicking, no per-question API call.
 
@@ -130,6 +137,14 @@ The skill reads everything - aging, balances, DSO, cash forecast, reconciliation
 
 ## Frequently asked questions
 
+### Is there an MCP server for QuickBooks Online?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for QuickBooks Online, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the QuickBooks Online MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local QuickBooks Online MCP server via a secure bridge. Step-by-step in the install guide.
@@ -155,9 +170,15 @@ Rarely. The only API-heavy step is the one-time sync that mirrors your company i
 No. You need a QuickBooks Online company and an OAuth access token scoped to com.intuit.quickbooks.accounting, plus your company realm ID. You mint the token from the Intuit Developer portal or the OAuth 2.0 Playground, and `quickbooks-cli auth refresh` turns a refresh token into a fresh access token - no partner status required.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [AppDirect](/skills/appdirect/) · [Gradient MSP](/skills/gradient/) · [Pax8](/skills/pax8/) · [Sherweb](/skills/sherweb/) · [Xero](/skills/xero/)
+
 ## Status
 
 Beta. Validated against the QuickBooks Online API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/rocketcyber.md
+++ b/docs/skills/rocketcyber.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "RocketCyber MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "RocketCyber MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first CLI and MCP server for RocketCyber Managed SOC: triage, incident MTTR, device risk ranking, and posture analytics the console doesn't compute."
 permalink: /skills/rocketcyber/
 skill_name: "RocketCyber MCP"
 image: /assets/social/rocketcyber/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for RocketCyber?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for RocketCyber, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the RocketCyber MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local RocketCyber MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a RocketCyber question in plain language; it runs rocketcyber-cli for you."
 ---
 
-# RocketCyber + AI in 60 seconds
+# The RocketCyber MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the RocketCyber
-> API. Not affiliated with, endorsed by, or sponsored by Kaseya.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Kaseya.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for RocketCyber. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects RocketCyber to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "what broke across all my RocketCyber clients overnight?" and get one ranked board - open incidents, malicious event counts, and offline agents - instead of clicking through a per-client console. The same skill ranks devices at risk, computes incident MTTR for QBRs, trends Microsoft 365 secure scores, and flags stale suppression rules that quietly hide real detections. All from the terminal.
 
@@ -125,6 +132,14 @@ The skill reads your RocketCyber SOC data - incidents, agents, detection events,
 
 ## Frequently asked questions
 
+### Is there an MCP server for RocketCyber?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for RocketCyber, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the RocketCyber MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local RocketCyber MCP server via a secure bridge. Step-by-step in the install guide.
@@ -146,9 +161,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 A RocketCyber provider account and an API token you generate in the RocketCyber app. The skill talks to the RocketCyber Customer API v3 (US region by default; set ROCKETCYBER_BASE_URL for the EU endpoint) and reads your own SOC data - incidents, agents, detection events, Defender, Microsoft 365 posture, and suppression rules - scoped to the accounts your token can see.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the RocketCyber API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/rootly.md
+++ b/docs/skills/rootly.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Rootly MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Rootly MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Rootly incident, alert, and on-call object as a typed command - plus a local SQLite mirror that answers related-incident, MTTR, coverage-gap, and on-call questions offline and instantly."
 permalink: /skills/rootly/
 skill_name: "Rootly MCP"
 image: /assets/social/rootly/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Rootly?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Rootly, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Rootly MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Rootly MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a Rootly question in plain language; it runs rootly-cli for you."
 ---
 
-# Rootly + AI in 60 seconds
+# The Rootly MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Rootly
-> API. Not affiliated with, endorsed by, or sponsored by Rootly, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Rootly, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Rootly. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Rootly to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask "who's on call for this service right now?" or "what's our MTTR by service this quarter?" and get the answer in one command. Rootly syncs to a local SQLite mirror, so incident-similarity, resolution mining, on-call coverage audits, and MTTA/MTTR analytics run instantly and offline - no portal clicking, no per-question API call.
 
@@ -130,6 +137,14 @@ The skill reads incidents, alerts, schedules, and on-call data, and can create o
 
 ## Frequently asked questions
 
+### Is there an MCP server for Rootly?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Rootly, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Rootly MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Rootly MCP server via a secure bridge. Step-by-step in the install guide.
@@ -151,9 +166,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 Rarely. Read questions run against the local SQLite mirror, not the API - you sync once, then analytics, search, and the on-call views are offline. Only sync and live writes call Rootly.
 
 
+## More Incident Response connectors
+
+Run more than one Incident Response tool, or comparing options? These connectors work the same way: [PagerDuty](/skills/pagerduty/)
+
 ## Status
 
 Beta. Validated against the Rootly API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/runzero.md
+++ b/docs/skills/runzero.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "runZero MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "runZero MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every runZero query, plus a local SQLite copy of your whole attack surface that diffs over time, joins assets to vulnerabilities offline, and costs zero API quota to re-slice."
 permalink: /skills/runzero/
 skill_name: "runZero MCP"
 image: /assets/social/runzero/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for runZero?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for runZero, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the runZero MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local runZero MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a runZero question in plain language; it runs runzero-cli for you."
 ---
 
-# runZero + AI in 60 seconds
+# The runZero MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the runZero
-> API. Not affiliated with, endorsed by, or sponsored by runZero, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by runZero, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for runZero. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects runZero to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 runZero's API answers one entity at a time; it cannot join assets to services to vulnerabilities in a single call. This skill syncs your whole attack surface into a local SQLite copy, then ranks exposure, diffs what changed since the last sync, and traces any CVE to the exact assets it hits - offline, at zero API quota. Ask in plain language; your agent runs the command and reads back the answer.
 
@@ -133,6 +140,14 @@ The skill reads your runZero attack surface - assets, services, software, vulner
 
 ## Frequently asked questions
 
+### Is there an MCP server for runZero?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for runZero, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the runZero MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local runZero MCP server via a secure bridge. Step-by-step in the install guide.
@@ -162,9 +177,15 @@ Yes. It defaults to the hosted console at console.runzero.com; point it at your 
 A read/Export token (Export ET, Organization OT, or Account CT key) covers sync and every analysis command. Launching a scan with scan-watch or org create-scan needs a token with scan permission. Scope the credential to only what your workflow uses.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [SentinelOne](/skills/sentinelone/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the runZero API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/salesbuildr.md
+++ b/docs/skills/salesbuildr.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Salesbuildr MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Salesbuildr MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Salesbuildr resource as a scriptable command, plus offline margin and pipeline analytics."
 permalink: /skills/salesbuildr/
 skill_name: "Salesbuildr MCP"
 image: /assets/social/salesbuildr/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Salesbuildr?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Salesbuildr, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Salesbuildr MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Salesbuildr MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -28,12 +32,15 @@ howto:
     text: "Ask your AI agent a Salesbuildr question in plain language; it runs salesbuildr-cli for you."
 ---
 
-# Salesbuildr + AI in 60 seconds
+# The Salesbuildr MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Salesbuildr
-> API. Not affiliated with, endorsed by, or sponsored by Salesbuildr.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Salesbuildr.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Salesbuildr. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Salesbuildr to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI which quotes are aging, which lines are bleeding margin, and where your pipeline is stalling - and get the answer from your own Salesbuildr data in seconds. salesbuildr-cli syncs your quotes, opportunities, products, and pricing books into a local mirror, so the cross-quote questions the portal can't answer in one click become a single command.
 
@@ -130,6 +137,14 @@ The skill reads your Salesbuildr quotes, opportunities, products, companies, and
 
 ## Frequently asked questions
 
+### Is there an MCP server for Salesbuildr?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Salesbuildr, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Salesbuildr MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Salesbuildr MCP server via a secure bridge. Step-by-step in the install guide.
@@ -155,9 +170,15 @@ No. The analytics read a local SQLite mirror, not the live API - you sync once, 
 You need a Salesbuildr account, a Public API key from your portal, and your tenant subdomain. It does not replace your Autotask/ConnectWise sync - it reads your Salesbuildr data and flags the records missing the external ID that sync depends on, so you can fix the gaps. It never writes to your PSA.
 
 
+## More CRM connectors
+
+Run more than one CRM tool, or comparing options? These connectors work the same way: [HubSpot](/skills/hubspot/) · [Pipedrive](/skills/pipedrive/)
+
 ## Status
 
 Beta. Validated against the Salesbuildr API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/sentinelone.md
+++ b/docs/skills/sentinelone.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "SentinelOne MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "SentinelOne MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every SentinelOne v2.1 management endpoint, plus an offline SQLite store and cross-entity analytics \u2014 fleet health, threat triage, blast radius, drift \u2014 that no console view offers."
 permalink: /skills/sentinelone/
 skill_name: "SentinelOne MCP"
 image: /assets/social/sentinelone/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for SentinelOne?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for SentinelOne, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the SentinelOne MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SentinelOne MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a SentinelOne question in plain language; it runs sentinelone-cli for you."
 ---
 
-# SentinelOne + AI in 60 seconds
+# The SentinelOne MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the SentinelOne
-> API. Not affiliated with, endorsed by, or sponsored by SentinelOne, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by SentinelOne, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for SentinelOne. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects SentinelOne to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Running SentinelOne across a book of customer sites? Ask your AI "what should I triage first across every client," "which endpoints went dark or dropped to detect-only," or "where did this malicious file spread," and get one cross-site answer the console can't compose. Every site is mirrored into a local store, so one triage worklist, one fleet-health rollup, and one posture scorecard replace the morning ritual of flipping the console scope selector tenant by tenant.
 
@@ -135,6 +142,14 @@ The skill drives the sentinelone-cli and sentinelone-mcp binaries, authenticatin
 
 ## Frequently asked questions
 
+### Is there an MCP server for SentinelOne?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for SentinelOne, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the SentinelOne MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SentinelOne MCP server via a secure bridge. Step-by-step in the install guide.
@@ -168,9 +183,15 @@ Each install points at one console URL plus its token, which already spans every
 No. The console stays best for hunting, policy authoring, and the interactive response workflow. This skill adds cross-site queries and scriptable actions to your AI agent so you stop scoping into each site to answer book-wide questions.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [ThreatLocker](/skills/threatlocker/)
+
 ## Status
 
 Beta. Validated against the SentinelOne API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/servosity.md
+++ b/docs/skills/servosity.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Servosity MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Servosity MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "The first MSP-fleet CLI for backup. Every Servosity API endpoint as a typed command, plus a local mirror that lets you ask questions the dashboard can't \u2014 across your whole book of clients."
 permalink: /skills/servosity/
 skill_name: "Servosity MCP"
 image: /assets/social/servosity/wide-1200x630.png
 verification: live-verified
 faqs:
+  - q: "Is there an MCP server for Servosity?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Servosity, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Servosity MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Servosity MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,14 @@ howto:
     text: "Ask your AI agent a Servosity question in plain language; it runs servosity-cli for you."
 ---
 
-# Servosity + AI in 60 seconds
+# The Servosity MCP Server - free, local, built for MSPs
 
 > Published by Servosity Inc. for MSP partners. Servosity is a trademark of
 > Servosity Inc.. Apache-2.0 licensed.
 
-**Live-verified** - confirmed by a real MSP against a live Servosity tenant (2026-06-05).
+**✓ Live-verified by Servosity (maintainer)** against a production tenant · 2026-06-05.
+
+Yes - there is an MCP server for Servosity. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Servosity to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs run Servosity as the backup and DR platform - M365, DR Server, and DR Desktop protection across a whole book of clients. Ask your AI "where is my attention needed today", "which backups went stale this week", or "build Acme's QBR backup section" and get fleet-wide answers the per-client dashboard can't compose: ranked attention sweeps, day-over-day drift, ready-to-send stale-backup follow-ups, and the whole book's QBR reports in one pass.
 
@@ -133,6 +139,14 @@ First-party: published by Servosity for MSP partners. The skill drives the servo
 
 ## Frequently asked questions
 
+### Is there an MCP server for Servosity?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Servosity, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Servosity MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Servosity MCP server via a secure bridge. Step-by-step in the install guide.
@@ -166,9 +180,15 @@ After a sync, the fleet views (attention, drift, stale-backups, backup-facts, qb
 Yes - the CLI authenticates with an MSP partner token. If you're not a partner yet, start at servosity.com; the skill itself is Apache-2.0 and free either way.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Afi](/skills/afi/) · [Axcient x360Recover](/skills/axcient/) · [Cove Data Protection](/skills/cove/) · [Datto BCDR](/skills/datto-bcdr/) · [SkyKick](/skills/skykick/)
+
 ## Status
 
 Beta. Validated against the Servosity API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/sherweb.md
+++ b/docs/skills/sherweb.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Sherweb MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Sherweb MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Sherweb Partner API capability, plus a local SQLite store, offline analytics, and margin/drift/orphan joins no other Sherweb tool has."
 permalink: /skills/sherweb/
 skill_name: "Sherweb MCP"
 image: /assets/social/sherweb/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Sherweb?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Sherweb, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Sherweb MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Sherweb MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Sherweb question in plain language; it runs sherweb-cli for you."
 ---
 
-# Sherweb + AI in 60 seconds
+# The Sherweb MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Sherweb
-> API. Not affiliated with, endorsed by, or sponsored by Sherweb Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Sherweb Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Sherweb. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Sherweb to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 MSPs resell Microsoft 365, Azure, and security through Sherweb, then spend the monthly close reconciling what they owe Sherweb against what they bill customers. Ask your AI "what's my net margin per customer," "which subscriptions am I paying for but not billing," or "what will this seat change cost," and get answers the Sherweb portal cannot compose: payable charges joined to receivable charges and subscriptions, computed offline from a local mirror in one query instead of a CSV export and a spreadsheet.
 
@@ -132,6 +139,14 @@ The skill drives the sherweb-cli and sherweb-mcp binaries, authenticating with S
 
 ## Frequently asked questions
 
+### Is there an MCP server for Sherweb?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Sherweb, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Sherweb MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Sherweb MCP server via a secure bridge. Step-by-step in the install guide.
@@ -161,9 +176,15 @@ After deep-sync, the analytics commands (margin, margin-trend, orphans, usage-le
 No. Provisioning, ordering, and subscription management stay in the portal. This skill answers the cross-entity margin and billing questions the portal cannot compose in one place, from your terminal or agent.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [AppDirect](/skills/appdirect/) · [Gradient MSP](/skills/gradient/) · [Pax8](/skills/pax8/) · [QuickBooks Online](/skills/quickbooks/) · [Xero](/skills/xero/)
+
 ## Status
 
 Beta. Validated against the Sherweb API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/skykick.md
+++ b/docs/skills/skykick.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "SkyKick MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "SkyKick MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Fleet-wide M365 backup assurance for SkyKick Cloud Backup - posture, stale snapshots, and coverage gaps no portal or wrapper can show."
 permalink: /skills/skykick/
 skill_name: "SkyKick MCP"
 image: /assets/social/skykick/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for SkyKick?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for SkyKick, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the SkyKick MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SkyKick MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -26,12 +30,15 @@ howto:
     text: "Ask your AI agent a SkyKick question in plain language; it runs skykick-cli for you."
 ---
 
-# SkyKick + AI in 60 seconds
+# The SkyKick MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the SkyKick
-> API. Not affiliated with, endorsed by, or sponsored by ConnectWise, LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by ConnectWise, LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for SkyKick. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects SkyKick to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Run one fleet-sync, then ask your AI which SkyKick customers have a backup gap right now. It reads every subscription's Exchange/SharePoint posture, snapshot recency, coverage, and retention from a local copy and answers across all your tenants at once - the cross-customer view the per-tenant SkyKick portal never rolls up.
 
@@ -128,6 +135,14 @@ The skill is read-first: every posture, staleness, coverage, retention, autodisc
 
 ## Frequently asked questions
 
+### Is there an MCP server for SkyKick?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for SkyKick, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the SkyKick MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SkyKick MCP server via a secure bridge. Step-by-step in the install guide.
@@ -149,9 +164,15 @@ Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 Yes - it authenticates with SkyKick Partner API client credentials (your API user ID and partner subscription key) from your SkyKick / ConnectWise Cloud Services partner account, and reads only what those credentials already permit. On rate limits: fleet-sync fans out per subscription with bounded concurrency and caches results in local SQLite, and SkyKick rate-limits the token endpoint aggressively, so the CLI mints and reuses cached tokens. Day-to-day questions run against the local store and never re-hit the API; you control --workers and --rate-limit.
 
 
+## More Backup/DR connectors
+
+Run more than one Backup/DR tool, or comparing options? These connectors work the same way: [Acronis Cyber Protect Cloud](/skills/acronis/) · [Afi](/skills/afi/) · [Axcient x360Recover](/skills/axcient/) · [Cove Data Protection](/skills/cove/) · [Datto BCDR](/skills/datto-bcdr/) · [Servosity](/skills/servosity/)
+
 ## Status
 
 Beta. Validated against the SkyKick API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/superops.md
+++ b/docs/skills/superops.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "SuperOps MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "SuperOps MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every SuperOps PSA+RMM entity in your terminal, plus a local SQLite mirror that answers cross-entity questions the web UI can't."
 permalink: /skills/superops/
 skill_name: "SuperOps MCP"
 image: /assets/social/superops/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for SuperOps?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for SuperOps, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the SuperOps MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SuperOps MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a SuperOps question in plain language; it runs superops-cli for you."
 ---
 
-# SuperOps + AI in 60 seconds
+# The SuperOps MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the SuperOps
-> API. Not affiliated with, endorsed by, or sponsored by SuperOps Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by SuperOps Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for SuperOps. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects SuperOps to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 SuperOps unifies PSA and RMM on one database, but the console still answers one entity at a time. Ask your AI "who's about to breach SLA, and on whose queue," "what's the full picture on Acme before the QBR," or "which endpoints are unpatched and actively alerting," and get cross-entity answers computed offline from a local SQLite mirror of your tenant - one query instead of five console screens or a scheduled report.
 
@@ -131,6 +138,14 @@ The skill drives the superops-cli and superops-mcp binaries, authenticating with
 
 ## Frequently asked questions
 
+### Is there an MCP server for SuperOps?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for SuperOps, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the SuperOps MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local SuperOps MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ The typed commands are read-only by design - inspection, export, sync, and analy
 Free. Apache-2.0 licensed. You pay only for whichever AI agent you already use.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [Autotask PSA](/skills/autotask/) · [ConnectWise PSA (Manage)](/skills/connectwise-manage/) · [HaloPSA](/skills/halopsa/) · [Kaseya BMS](/skills/kaseya-bms/) · [Syncro](/skills/syncro/)
+
 ## Status
 
 Beta. Validated against the SuperOps API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/syncro.md
+++ b/docs/skills/syncro.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Syncro MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Syncro MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Syncro PSA and RMM workflow in your terminal, plus a local database, offline search, and cross-entity reports no other Syncro tool has."
 permalink: /skills/syncro/
 skill_name: "Syncro MCP"
 image: /assets/social/syncro/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Syncro?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Syncro, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Syncro MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Syncro MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Syncro question in plain language; it runs syncro-cli for you."
 ---
 
-# Syncro + AI in 60 seconds
+# The Syncro MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Syncro
-> API. Not affiliated with, endorsed by, or sponsored by Servably, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Servably, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Syncro. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Syncro to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask your AI "which customers have logged time we never invoiced?" and get the unbilled hours ranked by customer in seconds - no report exports, no portal clicking. Syncro plus your agent answers billing-leakage, AR-aging, SLA-breach, and patch-gap questions across every customer at once, from one local mirror of your Syncro PSA and RMM data. Free, open source, runs on your laptop.
 
@@ -131,6 +138,14 @@ The skill is read-first: reporting, rollups, and cross-entity views can't change
 
 ## Frequently asked questions
 
+### Is there an MCP server for Syncro?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Syncro, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Syncro MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Syncro MCP server via a secure bridge. Step-by-step in the install guide.
@@ -160,9 +175,15 @@ You just need a Syncro account and an API token from your own portal (Admin area
 No. It reads from your Syncro account and is for the cross-customer questions and bulk analysis the portal makes tedious. You still run tickets, billing, and RMM day-to-day in Syncro; this is the fast lane for the questions an owner keeps re-asking.
 
 
+## More PSA connectors
+
+Run more than one PSA tool, or comparing options? These connectors work the same way: [Autotask PSA](/skills/autotask/) · [ConnectWise PSA (Manage)](/skills/connectwise-manage/) · [HaloPSA](/skills/halopsa/) · [Kaseya BMS](/skills/kaseya-bms/) · [SuperOps](/skills/superops/)
+
 ## Status
 
 Beta. Validated against the Syncro API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/tactical-rmm.md
+++ b/docs/skills/tactical-rmm.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Tactical RMM MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Tactical RMM MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Tactical RMM endpoint as a typed command, plus an offline SQLite mirror and cross-entity fleet queries the web UI can't express."
 permalink: /skills/tactical-rmm/
 skill_name: "Tactical RMM MCP"
 image: /assets/social/tactical-rmm/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Tactical RMM?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Tactical RMM, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Tactical RMM MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Tactical RMM MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a Tactical RMM question in plain language; it runs tactical-rmm-cli for you."
 ---
 
-# Tactical RMM + AI in 60 seconds
+# The Tactical RMM MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Tactical RMM
-> API. Not affiliated with, endorsed by, or sponsored by AmidaWare LLC.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by AmidaWare LLC.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Tactical RMM. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Tactical RMM to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask plain-English questions about your whole self-hosted Tactical RMM fleet and get answers the web UI can't assemble in one view: which agents went dark, where patches and reboots are pending across every client, what changed overnight, and which endpoints are unmonitored. `tactical-rmm-cli` mirrors your fleet into local SQLite, then answers cross-client rollups instantly and offline - and can fan a command across a filtered cohort, preview-first.
 
@@ -138,6 +145,14 @@ The skill reads everything across your fleet - agents, clients, sites, checks, a
 
 ## Frequently asked questions
 
+### Is there an MCP server for Tactical RMM?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Tactical RMM, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Tactical RMM MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Tactical RMM MCP server via a secure bridge. Step-by-step in the install guide.
@@ -171,9 +186,15 @@ Rarely. Most questions run against the local SQLite mirror after a one-time sync
 No - it complements it. The UI stays your system of record and remote-access console; this skill adds the cross-client query-and-automation layer it doesn't offer.
 
 
+## More RMM connectors
+
+Run more than one RMM tool, or comparing options? These connectors work the same way: [Action1](/skills/action1/) · [Atera](/skills/atera/) · [Datto RMM](/skills/datto-rmm/) · [Level](/skills/levelio/) · [N-able N-central](/skills/n-central/) · [Nerdio Manager](/skills/nerdio/) · [NinjaOne](/skills/ninjaone/)
+
 ## Status
 
 Beta. Validated against the Tactical RMM API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/threatlocker.md
+++ b/docs/skills/threatlocker.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "ThreatLocker MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "ThreatLocker MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every ThreatLocker Portal API feature, plus the write operations the read-only tools lack and a cross-tenant offline store no other ThreatLocker tool has."
 permalink: /skills/threatlocker/
 skill_name: "ThreatLocker MCP"
 image: /assets/social/threatlocker/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for ThreatLocker?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for ThreatLocker, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the ThreatLocker MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local ThreatLocker MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -32,12 +36,15 @@ howto:
     text: "Ask your AI agent a ThreatLocker question in plain language; it runs threatlocker-cli for you."
 ---
 
-# ThreatLocker + AI in 60 seconds
+# The ThreatLocker MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the ThreatLocker
-> API. Not affiliated with, endorsed by, or sponsored by ThreatLocker, Inc..
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by ThreatLocker, Inc..
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for ThreatLocker. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects ThreatLocker to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Running ThreatLocker across a whole book of customer tenants? Ask your AI "what approvals are pending everywhere," "which agents went dark this week," or "which clients are about to lose audit evidence," and get one cross-tenant answer the Portal can't compose. Every tenant is mirrored into a local store, so one approval queue, one audit archive, and one health rollup replace dozens of one-tenant-at-a-time Portal logins.
 
@@ -133,6 +140,14 @@ The skill drives the threatlocker-cli and threatlocker-mcp binaries, authenticat
 
 ## Frequently asked questions
 
+### Is there an MCP server for ThreatLocker?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for ThreatLocker, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the ThreatLocker MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local ThreatLocker MCP server via a secure bridge. Step-by-step in the install guide.
@@ -166,9 +181,15 @@ You need API access in your own ThreatLocker Portal. The cross-tenant features a
 No. The Portal stays best for authoring policies and the interactive approve/deny workflow. This skill adds cross-tenant queries and scriptable writes to your AI agent so you stop logging into each tenant to answer book-wide questions.
 
 
+## More Security connectors
+
+Run more than one Security tool, or comparing options? These connectors work the same way: [Abnormal Security](/skills/abnormal/) · [Blumira](/skills/blumira/) · [CIPP](/skills/cipp/) · [CrowdStrike Falcon](/skills/crowdstrike/) · [Huntress](/skills/huntress/) · [KnowBe4](/skills/knowbe4/) · [Microsoft Graph](/skills/microsoft-graph/) · [Proofpoint TAP](/skills/proofpoint/) · [RocketCyber](/skills/rocketcyber/) · [runZero](/skills/runzero/) · [SentinelOne](/skills/sentinelone/)
+
 ## Status
 
 Beta. Validated against the ThreatLocker API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/docs/skills/xero.md
+++ b/docs/skills/xero.md
@@ -1,12 +1,16 @@
 ---
 layout: default
-title: "Xero MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "Xero MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: "Every Xero Accounting read plus a local SQLite ledger  -  aging, reconciliation, and GL tie-out that no other Xero tool computes offline."
 permalink: /skills/xero/
 skill_name: "Xero MCP"
 image: /assets/social/xero/wide-1200x630.png
 verification: awaiting
 faqs:
+  - q: "Is there an MCP server for Xero?"
+    a: "Yes - this one. A free, open source MCP server and Claude Code Skill for Xero, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds."
+  - q: "Is the Xero MCP server safe for client data?"
+    a: "Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page."
   - q: "Does this work with ChatGPT?"
     a: "Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Xero MCP server via a secure bridge. Step-by-step in the install guide."
   - q: "Do I need to know how to code?"
@@ -30,12 +34,15 @@ howto:
     text: "Ask your AI agent a Xero question in plain language; it runs xero-cli for you."
 ---
 
-# Xero + AI in 60 seconds
+# The Xero MCP Server - free, local, built for MSPs
 
-> Unofficial. Community-built Claude Code Skill and MCP server for the Xero
-> API. Not affiliated with, endorsed by, or sponsored by Xero Limited.
+> Independent, open source, inspectable. Every line of code is on GitHub
+> under Apache-2.0 - built for the MSP community, vendor-neutral by design.
+> Not affiliated with, endorsed by, or sponsored by Xero Limited.
 
-**Awaiting live verification** - passes every mechanical gate (build, command-surface, claims, install). Be the first to confirm it against your tenant: [report it works](https://github.com/Servosity/msp-skills/issues/new?template=it-works.yml).
+**Passes all 4 mechanical gates** (build · command-surface · claims · install). Awaiting its first MSP receipt - [be the first, 60 seconds →](https://msp-skills.compoundingteams.com/verified/#receipt).
+
+Yes - there is an MCP server for Xero. It's free, open source, and runs on your own machine, so your client data never leaves your network. It connects Xero to Claude, ChatGPT, Copilot, or any MCP-capable agent, and installs in about 60 seconds.
 
 Ask in plain English who owes you and how overdue, which authorised invoices still have no payment applied, and whether the general ledger ties to outstanding invoices at close - for a Xero organisation, in one call. Xero plus your AI agent reads a local mirror of the org, so the aging, reconciliation, and tie-out questions the web reports make you export and pivot become one instant, offline answer.
 
@@ -133,6 +140,14 @@ Everything analytical reads from a local mirror - aging, exposure, reconcile, ba
 
 ## Frequently asked questions
 
+### Is there an MCP server for Xero?
+
+Yes - this one. A free, open source MCP server and Claude Code Skill for Xero, built for MSPs. It runs locally on your machine, works with Claude, ChatGPT, Copilot, and any MCP-capable agent, and installs in about 60 seconds.
+
+### Is the Xero MCP server safe for client data?
+
+Yes, by design. The CLI, the MCP server, and any local data mirror run on your own machine - nothing is sent to MSP Skills or any third party. Credentials stay in your environment, and every command is safety-tiered (read, write, destructive) so your agent only gets the permissions you grant. Full policy in the safety model on this page.
+
 ### Does this work with ChatGPT?
 
 Yes, on paid ChatGPT plans. ChatGPT connects to remote MCP servers over HTTPS, so you expose the local Xero MCP server via a secure bridge. Step-by-step in the install guide.
@@ -162,9 +177,15 @@ You mint an OAuth2 token in the Xero developer portal - a Custom Connection is t
 One organisation per XERO_TENANT_ID. The local mirror holds a single tenant; for a multi-entity portfolio, point the tenant id at each organisation in turn and loop.
 
 
+## More Billing connectors
+
+Run more than one Billing tool, or comparing options? These connectors work the same way: [AppDirect](/skills/appdirect/) · [Gradient MSP](/skills/gradient/) · [Pax8](/skills/pax8/) · [QuickBooks Online](/skills/quickbooks/) · [Sherweb](/skills/sherweb/)
+
 ## Status
 
 Beta. Validated against the Xero API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -368,6 +368,15 @@ def build_docs_catalog(skills: list[dict]) -> dict:
             "tagline": s.get("tagline", s.get("description", "")),
             "category": s.get("category", ""),
             "verification": s.get("verification", "awaiting"),
+            # Named verification: who confirmed it against a production tenant,
+            # and the public receipt (it-works issue) when one exists. Null
+            # until verify_live.py records them - the site renders the names.
+            "verified_by": (
+                (SKILL_META[s["name"]].get("live_verified") or {}).get("verified_by")
+            ),
+            "issue_url": (
+                (SKILL_META[s["name"]].get("live_verified") or {}).get("issue_url")
+            ),
             "url": f"/skills/{s['name']}/",
         }
         for s in skills

--- a/tools/maintainer/build-llms.py
+++ b/tools/maintainer/build-llms.py
@@ -194,9 +194,11 @@ def first_intro_paragraph(body: str) -> str:
         first = s.splitlines()[0].lstrip()
         if first.startswith(("#", ">", "<", "{%", "{{", "|", "---", "***")):
             continue
-        # Skip the badge notice + the "New to the term?" vocab one-liner.
-        if s.startswith("**Awaiting live verification**") or s.startswith(
-            "New to the term?"
+        # Skip the badge notice (both states) + the "New to the term?" vocab
+        # one-liner. Badge prefixes match render_docs_page.py's badge strings.
+        if s.startswith(
+            ("**Awaiting live verification**", "**Passes all 4 mechanical gates**",
+             "**✓ Live-verified", "New to the term?")
         ):
             continue
         # Skip pure button/link rows.
@@ -227,9 +229,13 @@ def summarize_safety(gov: str) -> str:
 def badge_state(meta: dict) -> str:
     lv = meta.get("live_verified") or {}
     # The canonical verified value is "live-verified" (verify_live.py writes it;
-    # build-catalog.py reads it) - not "verified".
+    # build-catalog.py reads it) - not "verified". Named verification: say WHO
+    # confirmed it against a production tenant, so AI engines can cite a real
+    # verifier instead of a bare badge.
     if isinstance(lv, dict) and lv.get("status") == "live-verified":
-        return "Live-verified"
+        by = lv.get("verified_by") or "a real MSP"
+        date = lv.get("date")
+        return f"Live-verified by {by}" + (f" ({date})" if date else "")
     return "Awaiting live verification"
 
 
@@ -292,8 +298,17 @@ def render_index(pages: list[dict]) -> str:
         "",
     ]
     for p in pages:
-        lines.append(f"- {p['name']} ({p['category']}) - {p['tagline']}")
-        lines.append(f"  Badge: {p['badge']}. Page: {p['url']}")
+        # Outcome-led: lead with the first real question the connector answers
+        # (outcomes[0] from page.json) - the concrete ask is what AI search
+        # engines match against; the tagline is the supporting summary.
+        q0 = p["outcomes"][0][0] if p["outcomes"] else ""
+        if q0:
+            lines.append(
+                f"- {p['name']} ({p['category']}) - ask \"{q0}\" - {p['tagline']}"
+            )
+        else:
+            lines.append(f"- {p['name']} ({p['category']}) - {p['tagline']}")
+        lines.append(f"  Verification: {p['badge']}. Page: {p['url']}")
         if p["install"]:
             lines.append(f"  Install: {p['install']}")
     lines += [
@@ -342,7 +357,7 @@ def render_full(pages: list[dict]) -> str:
         lines.append(f"### {p['name']} ({p['category']})")
         lines.append("")
         lines.append(f"Page: {p['url']}")
-        lines.append(f"Badge: {p['badge']}")
+        lines.append(f"Verification: {p['badge']}")
         if p["install"]:
             lines.append(f"Install: {p['install']}")
         lines.append("")

--- a/tools/maintainer/build-question-book.py
+++ b/tools/maintainer/build-question-book.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Generate docs/question-book.md - "The MSP AI Question Book".
+
+Aggregates every plain-English question the connectors can answer - the
+`instead_of_say[].say` prompts and `outcomes[].question` rows from every
+skills/<slug>/page.json - into one Jekyll page, grouped by tool category and
+connector. One page that shows an MSP owner, in their own vocabulary, what
+agentic AI can answer from the tools they already run.
+
+Output is DETERMINISTIC: categories sorted alphabetically, connectors sorted
+by slug, questions kept in page.json order with exact-string dedupe per
+connector. No timestamps. verify_all.sh regenerates the page and diffs it
+against the committed copy (same drift gate as the catalog), so a stale
+question book fails CI.
+
+The title promises "200+" questions; the script fails the build if the
+aggregate ever drops below MIN_QUESTIONS so the page can never overclaim.
+
+Pure stdlib. Run locally:  python3 tools/maintainer/build-question-book.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/ module)
+
+ROOT = registry.ROOT
+OUT = ROOT / "docs" / "question-book.md"
+
+MIN_QUESTIONS = 200  # the title says "200+" - never ship fewer
+
+
+def connector_questions() -> dict[str, list[tuple[str, dict, list[str]]]]:
+    """{category: [(slug, meta, questions)]}, deterministic ordering."""
+    by_cat: dict[str, list[tuple[str, dict, list[str]]]] = {}
+    for slug, meta in registry.skills().items():  # slug-sorted
+        if meta.get("markdown_only"):
+            continue
+        page_path = registry.skill_path(slug) / "page.json"
+        if not page_path.exists():
+            raise SystemExit(
+                f"build-question-book: skills/{meta.get('source_dir', slug)}/"
+                "page.json missing - every connector needs one."
+            )
+        pj = json.loads(page_path.read_text(encoding="utf-8"))
+        questions: list[str] = []
+        seen: set[str] = set()
+        for item in pj.get("instead_of_say", []):
+            q = (item.get("say") or "").strip()
+            if q and q not in seen:
+                seen.add(q)
+                questions.append(q)
+        for o in pj.get("outcomes", []):
+            q = (o.get("question") or "").strip()
+            if q and q not in seen:
+                seen.add(q)
+                questions.append(q)
+        if not questions:
+            raise SystemExit(f"build-question-book: '{slug}' has no questions.")
+        cat = meta.get("category") or "Other"
+        by_cat.setdefault(cat, []).append((slug, meta, questions))
+    return by_cat
+
+
+def render(by_cat: dict[str, list[tuple[str, dict, list[str]]]]) -> str:
+    total = sum(len(qs) for conns in by_cat.values() for _, _, qs in conns)
+    n_conn = sum(len(conns) for conns in by_cat.values())
+    if total < MIN_QUESTIONS:
+        raise SystemExit(
+            f"build-question-book: only {total} questions aggregated; the page "
+            f"promises {MIN_QUESTIONS}+. Add connectors or fix page.json data."
+        )
+
+    lines = [
+        "---",
+        "layout: default",
+        'title: "The MSP AI Question Book - 200+ plain-English questions your '
+        'AI can answer"',
+        f'description: "{total} plain-English questions your AI can answer '
+        "from the PSA, RMM, backup, security, and billing tools you already "
+        f'run - aggregated from all {n_conn} free MSP Skills connectors. No '
+        'code required, runs locally."',
+        "permalink: /question-book/",
+        "---",
+        "",
+        "# The MSP AI Question Book",
+        "",
+        f"{total} plain-English questions MSP owners ask their AI every day - "
+        f"aggregated from the {n_conn} free, open source connectors on this "
+        "site and grouped by tool category. Every question maps to a real, "
+        "gate-verified command your AI agent runs against your PSA, RMM, "
+        "backup, security, or billing stack - locally, without your data "
+        "leaving your network. Find your tools, steal the questions.",
+        "",
+        "Each connector installs in about 60 seconds and works with Claude, "
+        "ChatGPT, Copilot, and any MCP-capable agent. New to the term? "
+        "[What an MCP server is →](/what-is-an-mcp-server/)",
+        "",
+    ]
+
+    for cat in sorted(by_cat):
+        lines.append(f"## {cat}")
+        lines.append("")
+        for slug, meta, questions in by_cat[cat]:
+            display = meta.get("display_name") or meta.get("vendor", slug)
+            lines.append(f"### {display}")
+            lines.append("")
+            lines.append(
+                f"Free {display} MCP server: [install and ask →](/skills/{slug}/)"
+            )
+            lines.append("")
+            for q in questions:
+                lines.append(f"- {q}")
+            lines.append("")
+
+    lines += [
+        "---",
+        "",
+        "Want a question answered live? **[Build Sessions]"
+        "(https://compoundingteams.com/build-sessions)** are free every "
+        "Thursday - bring one of these questions and your own tenant.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    by_cat = connector_questions()
+    OUT.write_text(render(by_cat), encoding="utf-8")
+    total = sum(len(qs) for conns in by_cat.values() for _, _, qs in conns)
+    print(f"Wrote {OUT.relative_to(ROOT)} ({total} questions, "
+          f"{sum(len(c) for c in by_cat.values())} connectors, "
+          f"{len(by_cat)} categories).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/maintainer/check_aeo.py
+++ b/tools/maintainer/check_aeo.py
@@ -42,6 +42,14 @@ MAX_WORDS = 90
 # description. Resolved by permalink front matter where present.
 REQUIRE_TITLE_DESC_PERMALINKS = {"/why/", "/what-is-an-mcp-server/"}
 
+# Every docs/skills/*.md page must follow the generator's AEO formulas
+# (render_docs_page.py): the title carries the search keywords MSPs type
+# ("MCP Server", free/open-source/local), and the first answer paragraph is a
+# literal direct answer to "is there an MCP server for X?". These assertions
+# keep a hand edit or a generator regression from silently dropping either.
+SKILL_TITLE_REQUIRED = "MCP Server - Free, Open Source, Runs Locally | MSP Skills"
+SKILL_ANSWER_PREFIX = "Yes - there is an MCP server for"
+
 # Per-file answer-first allowlist. key = path relative to ROOT, value = reason.
 # Keep this list short and justified; each entry is a deferred-closure marker.
 # Currently EMPTY: every in-scope page (homepage, why, glossary, skills, guides)
@@ -85,6 +93,14 @@ def is_banner_block(block: str) -> bool:
     include div, a horizontal rule, or a Liquid include line."""
     s = block.strip()
     if not s:
+        return True
+    # The verification-badge paragraph render_docs_page.py emits above the
+    # direct answer (both states, current and legacy spellings) is chrome,
+    # not the answer.
+    if s.startswith(
+        ("**✓ Live-verified", "**Passes all 4 mechanical gates**",
+         "**Live-verified**", "**Awaiting live verification**")
+    ):
         return True
     first = s.splitlines()[0].lstrip()
     if first.startswith("#"):  # heading
@@ -172,6 +188,12 @@ def main() -> int:
                     )
                 else:
                     desc_seen[desc] = rel
+            # --- Assertion 3: skill pages follow the AEO title formula. ---
+            if is_skill and title and SKILL_TITLE_REQUIRED not in title:
+                errors.append(
+                    f"{rel}: skill-page title missing the AEO formula "
+                    f"({SKILL_TITLE_REQUIRED!r}): {title!r}"
+                )
 
         # --- Assertion 1: answer-first paragraph <= MAX_WORDS. ---
         if rel in ANSWER_FIRST_ALLOWLIST:
@@ -180,6 +202,13 @@ def main() -> int:
         if not para:
             errors.append(f"{rel}: no answer paragraph found after the title/banner")
             continue
+        # --- Assertion 4: skill pages open with the literal direct answer. ---
+        if is_skill and not para.startswith(SKILL_ANSWER_PREFIX):
+            preview = " ".join(para.split()[:12])
+            errors.append(
+                f"{rel}: skill-page first paragraph must start with "
+                f"{SKILL_ANSWER_PREFIX!r}: \"{preview} ...\""
+            )
         wc = word_count(para)
         if wc > MAX_WORDS:
             preview = " ".join(para.split()[:12])

--- a/tools/maintainer/render_docs_page.py
+++ b/tools/maintainer/render_docs_page.py
@@ -36,6 +36,10 @@ ROOT = registry.ROOT
 OWNER, REPO = registry.owner_repo()
 OWNER_TITLE = OWNER[:1].upper() + OWNER[1:]
 
+# The 60-second receipt form every "awaiting" badge invites MSPs to. ONE
+# constant so the real form URL can be swapped in a single edit when it ships.
+RECEIPT_FORM_URL = "https://msp-skills.compoundingteams.com/verified/#receipt"
+
 
 def banner(vendor: str, owner: str, first_party: bool) -> str:
     if first_party:
@@ -44,8 +48,34 @@ def banner(vendor: str, owner: str, first_party: bool) -> str:
             f"> {owner}. Apache-2.0 licensed."
         )
     return (
-        f"> Unofficial. Community-built Claude Code Skill and MCP server for the {vendor}\n"
-        f"> API. Not affiliated with, endorsed by, or sponsored by {owner}."
+        "> Independent, open source, inspectable. Every line of code is on GitHub\n"
+        "> under Apache-2.0 - built for the MSP community, vendor-neutral by design.\n"
+        f"> Not affiliated with, endorsed by, or sponsored by {owner}."
+    )
+
+
+def sibling_links_block(slug: str, entry: dict) -> str:
+    """Internal-links block: every OTHER connector in this skill's category,
+    rendered from the registry so it can never go stale as connectors ship.
+    Empty when the skill has no category or no category siblings."""
+    cat = entry.get("category")
+    if not cat:
+        return ""
+    sibs = [
+        (s, m)
+        for s, m in registry.skills().items()  # slug-sorted: deterministic
+        if s != slug and not m.get("markdown_only") and m.get("category") == cat
+    ]
+    if not sibs:
+        return ""
+    links = " · ".join(
+        f"[{m.get('display_name', m.get('vendor', s))}](/skills/{s}/)"
+        for s, m in sibs
+    )
+    return (
+        f"\n## More {cat} connectors\n\n"
+        f"Run more than one {cat} tool, or comparing options? "
+        f"These connectors work the same way: {links}\n"
     )
 
 
@@ -78,17 +108,56 @@ def render_page(slug: str) -> Path:
         desc = json.loads(mf.read_text()).get("description", "")
     lv = entry.get("live_verified") or {}
     if lv.get("status") == "live-verified":
-        badge = (f"**Live-verified** - confirmed by a real MSP against a live "
-                 f"{display} tenant ({lv.get('date', '')}).")
+        verified_by = lv.get("verified_by") or "a real MSP"
+        badge = (f"**✓ Live-verified by {verified_by}** against a production "
+                 f"tenant · {lv.get('date', '')}")
+        if lv.get("issue_url"):
+            badge += f" · [receipt →]({lv['issue_url']})"
+        badge += "."
     else:
-        badge = ("**Awaiting live verification** - passes every mechanical gate "
-                 "(build, command-surface, claims, install). Be the first to confirm "
-                 "it against your tenant: "
-                 f"[report it works](https://github.com/{OWNER_TITLE}/{REPO}/issues/new?template=it-works.yml).")
+        badge = ("**Passes all 4 mechanical gates** (build · command-surface · "
+                 "claims · install). Awaiting its first MSP receipt - "
+                 f"[be the first, 60 seconds →]({RECEIPT_FORM_URL}).")
+
+    # The literal direct answer AI search engines (and skimming MSP owners)
+    # reward: the page answers its own title before anything else. Rendered as
+    # the FIRST prose paragraph; check_aeo asserts it on every skill page.
+    direct_answer = (
+        f"Yes - there is an MCP server for {display}. It's free, open source, "
+        "and runs on your own machine, so your client data never leaves your "
+        f"network. It connects {display} to Claude, ChatGPT, Copilot, or any "
+        "MCP-capable agent, and installs in about 60 seconds."
+    )
+
+    # Two generator-level FAQs every skill page carries (AEO: the exact
+    # questions MSPs type into AI search), ahead of the page.json FAQs.
+    gen_faqs = [
+        {
+            "q": f"Is there an MCP server for {display}?",
+            "a": (
+                f"Yes - this one. A free, open source MCP server and Claude Code "
+                f"Skill for {display}, built for MSPs. It runs locally on your "
+                "machine, works with Claude, ChatGPT, Copilot, and any "
+                "MCP-capable agent, and installs in about 60 seconds."
+            ),
+        },
+        {
+            "q": f"Is the {display} MCP server safe for client data?",
+            "a": (
+                "Yes, by design. The CLI, the MCP server, and any local data "
+                "mirror run on your own machine - nothing is sent to MSP Skills "
+                "or any third party. Credentials stay in your environment, and "
+                "every command is safety-tiered (read, write, destructive) so "
+                "your agent only gets the permissions you grant. Full policy in "
+                "the safety model on this page."
+            ),
+        },
+    ]
+    faqs = gen_faqs + page.get("faqs", [])
 
     fm_faqs = "".join(
         f"  - q: {json.dumps(f['q'])}\n    a: {json.dumps(f['a'])}\n"
-        for f in page.get("faqs", [])
+        for f in faqs
     )
     fm_howto = (
         f'  - name: "Run the one-line installer"\n'
@@ -130,15 +199,16 @@ def render_page(slug: str) -> Path:
             "backups, restores, QBR reporting) to Servosity Backup and DR.\n"
         )
     pains = "\n".join(f"- {p}" for p in page.get("pain_points", []))
-    faq_md = "\n".join(f"### {f['q']}\n\n{f['a']}\n" for f in page.get("faqs", []))
+    faq_md = "\n".join(f"### {f['q']}\n\n{f['a']}\n" for f in faqs)
     tiers = "\n".join(
         f"| {t['tier']} | {t['examples']} | {t['policy']} |"
         for t in page.get("safety_tiers", [])
     )
+    siblings = sibling_links_block(slug, entry)
 
     text = f"""---
 layout: default
-title: "{display} MCP Server - for Claude, ChatGPT, Copilot, and any MCP agent"
+title: "{display} MCP Server - Free, Open Source, Runs Locally | MSP Skills"
 description: {json.dumps(desc or f"Free Claude Code Skill and MCP server for {display}. Built for MSP owners.")}
 permalink: /skills/{slug}/
 skill_name: "{display} MCP"
@@ -148,11 +218,13 @@ faqs:
 {fm_faqs}howto:
 {fm_howto}---
 
-# {display} + AI in 60 seconds
+# The {display} MCP Server - free, local, built for MSPs
 
 {banner(vendor, owner, first_party)}
 
 {badge}
+
+{direct_answer}
 
 {page.get('outcome_intro', '')}
 
@@ -221,10 +293,12 @@ iwr -useb https://raw.githubusercontent.com/{OWNER}/{REPO}/main/skills/{slug}/in
 ## Frequently asked questions
 
 {faq_md}
-
+{siblings}
 ## Status
 
 Beta. Validated against the {display} API surface and being validated with MSPs running it live against their own production tenants in our weekly **[Build Sessions](https://compoundingteams.com/build-sessions)**.
+
+Build Sessions are free and stay free - [The Build Room](https://compoundingteams.com) is where the deep work happens.
 
 ---
 

--- a/tools/maintainer/skills.json
+++ b/tools/maintainer/skills.json
@@ -22,7 +22,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "action1": {
@@ -45,7 +47,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "atera": {
@@ -68,7 +72,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "autotask": {
@@ -91,7 +97,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "axcient": {
@@ -114,7 +122,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "blumira": {
@@ -137,7 +147,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "cipp": {
@@ -160,7 +172,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "connectwise-manage": {
@@ -185,7 +199,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "crowdstrike": {
@@ -208,7 +224,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "datto-bcdr": {
@@ -231,7 +249,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "datto-rmm": {
@@ -254,7 +274,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "domotz": {
@@ -277,7 +299,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "halopsa": {
@@ -299,7 +323,9 @@
         "status": "live-verified",
         "date": "2026-06-05",
         "source": "self",
-        "evidence": "Damien: verified live (2026-06-05)"
+        "evidence": "Damien: verified live (2026-06-05)",
+        "verified_by": "Servosity (maintainer)",
+        "issue_url": null
       },
       "category": "PSA",
       "tagline": "Triage tickets, pre-empt SLA breaches, run cross-client analytics by asking.",
@@ -327,7 +353,9 @@
         "status": "live-verified",
         "date": "2026-06-05",
         "source": "self",
-        "evidence": "Damien: verified live against the Servosity HubSpot portal (2026-06-05)"
+        "evidence": "Damien: verified live against the Servosity HubSpot portal (2026-06-05)",
+        "verified_by": "Servosity (maintainer)",
+        "issue_url": null
       }
     },
     "hudu": {
@@ -350,7 +378,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "huntress": {
@@ -373,7 +403,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "itglue": {
@@ -396,7 +428,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "knowbe4": {
@@ -419,7 +453,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "levelio": {
@@ -442,7 +478,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "liongard": {
@@ -465,7 +503,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "microsoft-graph": {
@@ -488,7 +528,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "msp-skills-concierge": {
@@ -508,7 +550,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "mspbots": {
@@ -531,7 +575,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "n-central": {
@@ -554,7 +600,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "ninjaone": {
@@ -577,7 +625,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "pagerduty": {
@@ -600,7 +650,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "pandadoc": {
@@ -623,7 +675,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "pax8": {
@@ -646,7 +700,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "pipedrive": {
@@ -669,7 +725,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "proofpoint": {
@@ -692,7 +750,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "quickbooks": {
@@ -715,7 +775,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "rootly": {
@@ -738,7 +800,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "runzero": {
@@ -761,7 +825,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "salesbuildr": {
@@ -784,7 +850,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "sentinelone": {
@@ -807,7 +875,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "servosity": {
@@ -829,7 +899,9 @@
         "status": "live-verified",
         "date": "2026-06-05",
         "source": "self",
-        "evidence": "Damien: verified live against the Servosity partner tenant (2026-06-05)"
+        "evidence": "Damien: verified live against the Servosity partner tenant (2026-06-05)",
+        "verified_by": "Servosity (maintainer)",
+        "issue_url": null
       },
       "category": "Backup/DR",
       "tagline": "Fleet attention, stale backups, QBR reports, and restore watch for every client by asking.",
@@ -855,7 +927,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "skykick": {
@@ -878,7 +952,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "superops": {
@@ -901,7 +977,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "syncro": {
@@ -924,7 +1002,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "tactical-rmm": {
@@ -947,7 +1027,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "threatlocker": {
@@ -970,7 +1052,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       },
       "install_auth_hint": "Then set `THREATLOCKER_API_KEY` (Portal > Administrators > API Users > Generate API Token) and run `threatlocker-cli doctor`"
     },
@@ -994,7 +1078,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "nerdio": {
@@ -1017,7 +1103,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "betterstack": {
@@ -1040,7 +1128,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "rocketcyber": {
@@ -1063,7 +1153,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "abnormal": {
@@ -1086,7 +1178,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "afi": {
@@ -1109,7 +1203,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "cove": {
@@ -1132,7 +1228,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "kaseya-bms": {
@@ -1155,7 +1253,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "appdirect": {
@@ -1178,7 +1278,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     },
     "gradient": {
@@ -1201,7 +1303,9 @@
         "status": "awaiting",
         "date": null,
         "source": null,
-        "evidence": null
+        "evidence": null,
+        "verified_by": null,
+        "issue_url": null
       }
     }
   }

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -113,6 +113,17 @@ else
   fail "llms drift - regenerated; re-run was not a no-op (run build-llms.py and commit)"
 fi
 
+echo "== question-book idempotency =="
+cp docs/question-book.md /tmp/qbook.bak 2>/dev/null || : > /tmp/qbook.bak
+if ! python3 tools/maintainer/build-question-book.py >/tmp/qbook.out 2>&1; then
+  cat /tmp/qbook.out
+  fail "build-question-book.py failed during the idempotency check"
+elif diff -q docs/question-book.md /tmp/qbook.bak >/dev/null; then
+  pass "question-book already in sync (no drift)"
+else
+  fail "question-book drift - regenerated; re-run was not a no-op (run build-question-book.py and commit)"
+fi
+
 echo "== Install scripts resolve cleanly (dry run) =="
 for sh in skills/*/install.sh; do
   slug="$(basename "$(dirname "$sh")")"


### PR DESCRIPTION
Part 1 of 4 of the approved marketing-loop site reimagining (plan: 2026-06-12).

## What's in here (generator + data only — reprint-safe by construction)
- **render_docs_page.py**: per-skill H1/title now carry the "{Vendor} MCP Server" query term; literal direct-answer first paragraph for AI citation; banner rewritten ("Independent, open source, inspectable" — replaces "Unofficial. Community-built."); **named verification badges** (`✓ Live-verified by {name} … · receipt →` / "be the first, 60 seconds →" via a single `RECEIPT_FORM_URL` constant); 2 generator-level FAQs per skill; "More {category} connectors" internal links; Build Room one-liner in Status.
- **skills.json**: `live_verified` extended with `verified_by` + `issue_url` (surgical, byte-diff-verified; the 3 self-verifications honestly labeled "Servosity (maintainer)").
- **build-catalog.py / build-llms.py**: propagate verification names; outcome-led llms.txt lines.
- **check_aeo.py**: now asserts the new title formula + direct-answer prefix on all /skills/* pages (negative-tested).
- **NEW build-question-book.py** → `/question-book/`: 606 plain-English questions aggregated from all 51 page.json files (the lead-magnet source).

## Verification
`verify_all.sh` fully green (all hard gates incl. drift/idempotency, em-dash, vocabulary, claims, links, install dry-runs ×51). DCO signed.

## Notes for review
- `RECEIPT_FORM_URL` is a placeholder pending the receipt form (week-0 item) — one-line swap.
- Lands before PR-2 (layout/visual) and PR-3 (new pages) per the plan's sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)