### PR TITLE
fix(security-gate): honor base-owned suppressions for gosec/external scanners

### DIFF
--- a/tools/maintainer/check_security_gate.py
+++ b/tools/maintainer/check_security_gate.py
@@ -277,34 +277,70 @@ def scan_dependencies(slug: str, allow: set[str], only: list[Path] | None) -> li
     return findings
 
 
-def scan_external(slug: str) -> list[dict]:
+def _external_rel(file_path: str, slug: str) -> tuple[str, str]:
+    """Normalize a scanner-reported file path to (repo_relative, slug_relative).
+
+    External scanners (gosec especially) emit ABSOLUTE paths; some emit
+    module-relative ones. Return both the repo-relative form
+    (skills/<slug>/cli/...) the other scanners use, and a slug-relative form
+    (cli/...). A suppression entry may then be written repo-relative (scopes to
+    one connector) OR slug-relative (fleet-wide, for the byte-identical
+    printing-press generated files every connector carries)."""
+    if not file_path:
+        return "", ""
+    skill_prefix = f"skills/{slug}/"        # slug-relative is relative to the skill dir -> cli/...
+    cli_prefix = f"skills/{slug}/cli/"      # reconstruct repo-relative from a module-relative path
+    p = Path(file_path)
+    if p.is_absolute():
+        try:
+            repo_rel = str(p.relative_to(REPO))
+        except ValueError:
+            repo_rel = file_path
+    elif file_path.startswith("skills/"):
+        repo_rel = file_path
+    else:
+        repo_rel = cli_prefix + file_path
+    slug_rel = repo_rel[len(skill_prefix):] if repo_rel.startswith(skill_prefix) else repo_rel
+    return repo_rel, slug_rel
+
+
+def scan_external(slug: str, suppress: set[tuple[str, str]]) -> list[dict]:
     findings = []
     mod = REPO / "skills" / slug / "cli"
+
+    # Same base-owned suppression model as scan_go_patterns / scan_install_scripts
+    # (the module docstring promises "a finding is suppressed only if its
+    # (file, rule) is listed"); previously the external scanners ignored it, so
+    # gosec findings were unsuppressable. Now normalized + filtered here.
+    def add(tool: str, rule: str, sev: str, file_path: str, line, evidence: str) -> None:
+        repo_rel, slug_rel = _external_rel(file_path, slug)
+        if (repo_rel, rule) in suppress or (slug_rel, rule) in suppress:
+            return
+        findings.append({"tool": tool, "rule": rule, "severity": sev,
+                         "file": repo_rel or file_path, "line": line, "evidence": evidence})
+
     if have("gosec"):
         _, out, _ = run(["gosec", "-quiet", "-fmt", "json", "./..."], cwd=str(mod))
         try:
             for iss in json.loads(out or "{}").get("Issues", []):
                 sev = "P1" if iss.get("severity", "").upper() in ("HIGH", "MEDIUM") else "P2"
-                findings.append({"tool": "gosec", "rule": iss.get("rule_id"), "severity": sev,
-                                 "file": iss.get("file", ""), "line": iss.get("line", 0),
-                                 "evidence": iss.get("details", "")[:120]})
+                add("gosec", iss.get("rule_id"), sev, iss.get("file", ""),
+                    iss.get("line", 0), iss.get("details", "")[:120])
         except json.JSONDecodeError:
             pass
     if have("govulncheck"):
         _, out, _ = run(["govulncheck", "-format", "json", "./..."], cwd=str(mod))
         if '"osv"' in out or "vulnerability" in out.lower():
-            findings.append({"tool": "govulncheck", "rule": "known-vuln", "severity": "P1",
-                             "file": f"skills/{slug}/cli/go.mod", "line": 0,
-                             "evidence": "govulncheck reported a reachable vulnerability."})
+            add("govulncheck", "known-vuln", "P1", f"skills/{slug}/cli/go.mod", 0,
+                "govulncheck reported a reachable vulnerability.")
     if have("osv-scanner"):
         _, out, _ = run(["osv-scanner", "--lockfile", "go.mod", "--format", "json"], cwd=str(mod))
         try:
             for res in json.loads(out or "{}").get("results", []):
                 for pkg in res.get("packages", []):
                     for v in pkg.get("vulnerabilities", []):
-                        findings.append({"tool": "osv-scanner", "rule": v.get("id", "OSV"), "severity": "P1",
-                                         "file": f"skills/{slug}/cli/go.mod", "line": 0,
-                                         "evidence": (v.get("summary", "") or "known vulnerability")[:120]})
+                        add("osv-scanner", v.get("id", "OSV"), "P1", f"skills/{slug}/cli/go.mod", 0,
+                            (v.get("summary", "") or "known vulnerability")[:120])
         except json.JSONDecodeError:
             pass
     cfg = REPO / ".semgrep.yml"
@@ -312,9 +348,8 @@ def scan_external(slug: str) -> list[dict]:
         _, out, _ = run(["semgrep", "--config", str(cfg), "--json", "--quiet", str(mod)])
         try:
             for r in json.loads(out or "{}").get("results", []):
-                findings.append({"tool": "semgrep", "rule": r.get("check_id"), "severity": "P1",
-                                 "file": r.get("path", ""), "line": r.get("start", {}).get("line", 0),
-                                 "evidence": (r.get("extra", {}).get("message", ""))[:120]})
+                add("semgrep", r.get("check_id"), "P1", r.get("path", ""),
+                    r.get("start", {}).get("line", 0), (r.get("extra", {}).get("message", ""))[:120])
         except json.JSONDecodeError:
             pass
     return findings
@@ -332,7 +367,7 @@ def gate_slug(slug: str, base: str | None, allow: set[str], suppress: set[tuple[
     findings += scan_go_patterns(go_files(slug, only), suppress)
     findings += scan_install_scripts(slug, only, suppress)
     findings += scan_dependencies(slug, allow, only)
-    findings += scan_external(slug)
+    findings += scan_external(slug, suppress)
     p1 = [f for f in findings if f["severity"] == "P1"]
     return {"slug": slug, "base": base, "scope": "diff" if only is not None else "full",
             "findings": findings, "p1_count": len(p1),

--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -1,10 +1,81 @@
 {
-  "_comment": "BASE-OWNED suppressions for check_security_gate.py. A finding is suppressed ONLY if its (file, rule) pair is listed here. This is intentionally NOT self-grantable from a PR diff: inline `// #nosec` is no longer honored by the gate, and a change to THIS file is a glaring, reviewed diff line (the security-gate workflow watches it) \u2014 same trust model as dep_allowlist.json. Add an entry only after a human has vetted that the flagged pattern is safe.",
+  "_comment": "BASE-OWNED suppressions for check_security_gate.py. A finding is suppressed ONLY if its (file, rule) pair is listed here. This is intentionally NOT self-grantable from a PR diff: inline `// #nosec` is no longer honored by the gate, and a change to THIS file is a glaring, reviewed diff line (the security-gate workflow watches it). Add an entry only after a human has vetted that the flagged pattern is safe. The `file` may be repo-relative (skills/<slug>/cli/..., scopes to one connector) OR slug-relative (cli/..., applies fleet-wide to the byte-identical printing-press generated file every connector carries). All scanners (builtin patterns, install scripts, and the external gosec/govulncheck/osv/semgrep set) honor these entries.",
   "suppress": [
     {
       "file": "skills/servosity/cli/internal/qbrreport/qbrreport.go",
       "rule": "exec-nonliteral-cmd",
       "reason": "chrome binary path is allowlist-resolved (not user input) before exec; pre-vetted, also annotated // #nosec G204 at the call site. servosity is an internal-only connector."
+    },
+
+    {
+      "file": "cli/internal/mcp/cobratree/shellout.go",
+      "rule": "G204",
+      "reason": "FLEET (generated). RunCLICommand execs the resolved companion CLI binary path with an explicit argv slice via exec.CommandContext - no shell, no `sh -c`, so args are not shell-interpreted. binPath is the CLI's own resolved path, not user input. Standard printing-press MCP dispatch pattern."
+    },
+    {
+      "file": "cli/internal/client/client.go",
+      "rule": "G119",
+      "reason": "FLEET (generated). CheckRedirect re-adds Authorization ONLY on a same-host redirect (req.URL.Host == via[0].URL.Host gate); cross-host hops explicitly delete it. Intentional and defended; without it nonce-bound auth schemes break on redirect."
+    },
+    {
+      "file": "cli/internal/client/client.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads the local HTTP response-cache file at an app-determined path under the user's own ~/.cache; no untrusted path. Operating on the local user's own machine."
+    },
+    {
+      "file": "cli/internal/config/config.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads the user's own config TOML at QUICKBOOKS_CONFIG or ~/.config/<cli>/config.toml. Operator-controlled local path on the user's own machine, not attacker input."
+    },
+    {
+      "file": "cli/internal/config/config.go",
+      "rule": "G703",
+      "reason": "FLEET (generated). 'Taint' flows from operator-set env vars (config path / base URL / realm) into a local path/URL the operator themselves chose. Single-user local CLI; the operator is not their own attacker."
+    },
+    {
+      "file": "cli/internal/config/config.go",
+      "rule": "G117",
+      "reason": "FLEET (generated). The OAuth access_token field is persisted to the user's local config TOML by design (written 0600). Storing the user's own token on their own machine is the intended auth-persistence behavior, not a leak."
+    },
+    {
+      "file": "cli/internal/cache/cache.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads local cache files at app-determined paths under the user's own cache dir. Local, user-owned."
+    },
+    {
+      "file": "cli/internal/store/store.go",
+      "rule": "G201",
+      "reason": "FLEET (generated). The Sprintf'd token is a field name guarded by validIdentifierRE (rejected otherwise) and the column set is generated, not user-derived; all user values are bound via ? placeholders. Not injectable. Target is a local SQLite file."
+    },
+    {
+      "file": "cli/internal/store/store.go",
+      "rule": "G301",
+      "reason": "FLEET (generated). MkdirAll 0o755 on the local per-user data dir. Low risk on a single-user machine. FOLLOW-UP: tighten to 0700 at the press level (the local mirror can hold financial data); tracked as a press hardening, not a blocker."
+    },
+    {
+      "file": "cli/internal/cli/deliver.go",
+      "rule": "G301",
+      "reason": "FLEET (generated). MkdirAll 0o755 on a user-chosen output directory. Same low-risk local rationale + 0700 press follow-up as store.go G301."
+    },
+    {
+      "file": "cli/internal/cli/import.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Opens the JSONL file the user explicitly passes to `import`. The user choosing which of their own files to import is the intended behavior, not path traversal."
+    },
+    {
+      "file": "cli/internal/cli/export.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Opens the output file the user explicitly passes to `export`. User-chosen local destination on their own machine."
+    },
+    {
+      "file": "cli/internal/cli/profile.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads the named-profile (saved flag sets) file at an app-determined path under the user's own config dir. Local, user-owned."
+    },
+    {
+      "file": "cli/internal/cli/feedback.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads the local feedback log file at an app-determined path. Local, user-owned; no untrusted input."
     }
   ]
 }


### PR DESCRIPTION
## Why

The security-gate's own docstring says *"a finding is suppressed only if its (file, rule) is listed in `security_suppressions.json`"* — but `scan_external` (gosec, govulncheck, osv-scanner, semgrep) was called **without** the suppress set and filtered nothing. So **gosec P1s were structurally unsuppressable.**

After the fleet was re-vendored to printing-press 4.24.0 (#96), every connector now carries ~17 standard gosec P1s in **generated** files. The release-blocking gate landed *after* that reprint, so it blocks **every connector's next release**. `quickbooks` v0.1.3 (PR #104) is the first to hit it — and nothing can clear it until this lands.

## What

- `scan_external` now applies the **same base-owned suppression model** as `scan_go_patterns`/`scan_install_scripts`, normalizing each scanner's path (gosec emits absolute) to repo-relative and matching either a **repo-relative** entry (one connector) or a **slug-relative** entry (`cli/...`, fleet-wide for the byte-identical generated file every connector carries).
- `security_suppressions.json` gains 14 vetted slug-relative entries for the standard generated-file patterns, each with a one-line justification (local user-owned file reads, env-derived config paths, regex-validated SQL identifiers with `?`-bound values, same-host-gated redirect auth, token in 0600 config, MCP explicit-argv dispatch).

## Vetting / limits

- **Fully clears `quickbooks` (0 P1)** and the shared generated baseline fleet-wide.
- The gate **still blocks** — connectors with findings in their **own** files still fail and need per-connector vetting (e.g. `acronis` `jobs.go` G404 weak-random, which may be a *real* fix rather than a suppression). Proof it is not neutered.
- `store.go`/`deliver.go` G301 (`0o755` dirs) suppressed as low-risk on a single-user machine; **tightening to `0700` is flagged as a press-level hardening follow-up**, not a false-positive.

## Review note

This touches gate **logic** (`check_security_gate.py`), so the gate hard-fails this PR **by design** until a CODEOWNERS (@Servosity) security review — that failing check is expected here, not a regression. The suppression *data* is read from the trusted base, so it can't self-grant.

Unblocks #104 (quickbooks v0.1.3) once merged.
