### PR TITLE
fix(security-gate): use govulncheck exit code (not advisory-DB grep) + 2 vetted FPs

### DIFF
--- a/tools/maintainer/check_security_gate.py
+++ b/tools/maintainer/check_security_gate.py
@@ -329,10 +329,16 @@ def scan_external(slug: str, suppress: set[tuple[str, str]]) -> list[dict]:
         except json.JSONDecodeError:
             pass
     if have("govulncheck"):
-        _, out, _ = run(["govulncheck", "-format", "json", "./..."], cwd=str(mod))
-        if '"osv"' in out or "vulnerability" in out.lower():
+        # govulncheck exits 3 IFF a vulnerability is reachable from THIS module's
+        # code; 0 means none affect it (even when advisories exist for required-
+        # but-uncalled deps). The prior `'"osv"' in out` check matched the OSV
+        # advisory-DB dump govulncheck always emits in JSON, so it flagged every
+        # module unconditionally (no connector could ever pass govulncheck). Use
+        # the exit code, which is govulncheck's actual reachability verdict.
+        code, _, _ = run(["govulncheck", "-format", "json", "./..."], cwd=str(mod))
+        if code == 3:
             add("govulncheck", "known-vuln", "P1", f"skills/{slug}/cli/go.mod", 0,
-                "govulncheck reported a reachable vulnerability.")
+                "govulncheck reported a vulnerability reachable from this module's code.")
     if have("osv-scanner"):
         _, out, _ = run(["osv-scanner", "--lockfile", "go.mod", "--format", "json"], cwd=str(mod))
         try:

--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -13,6 +13,16 @@
       "reason": "FLEET (generated). RunCLICommand execs the resolved companion CLI binary path with an explicit argv slice via exec.CommandContext - no shell, no `sh -c`, so args are not shell-interpreted. binPath is the CLI's own resolved path, not user input. Standard printing-press MCP dispatch pattern."
     },
     {
+      "file": "cli/internal/mcp/cobratree/shellout.go",
+      "rule": "msp-exec-nonliteral-command",
+      "reason": "FLEET (generated). Same call site as the G204 entry above: semgrep's rule flags the identical exec.CommandContext(binPath, args...) MCP-dispatch pattern. No shell interpretation; binPath is the resolved companion CLI, args are an explicit argv slice. Vetted safe for the same reason."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5024",
+      "reason": "FLEET (press-pinned dep). Integer overflow in NewNTUnicodeString in golang.org/x/sys/windows (x/sys v0.31.0, pinned by the printing-press template). govulncheck (which does reachability) reports it does NOT affect these CLIs' code - the Windows syscall path is never called by a read-mostly accounting/MSP tool. osv-scanner has no reachability so it flags presence only. FOLLOW-UP: bump golang.org/x/sys to >= v0.46.0 at the PRESS level (durable fleet fix); this advisory-specific suppression is the interim, and govulncheck still gates any actually-reachable vuln."
+    },
+    {
       "file": "cli/internal/client/client.go",
       "rule": "G119",
       "reason": "FLEET (generated). CheckRedirect re-adds Authorization ONLY on a same-host redirect (req.URL.Host == via[0].URL.Host gate); cross-host hops explicitly delete it. Intentional and defended; without it nonce-bound auth schemes break on redirect."


### PR DESCRIPTION
Second gate bug (surfaced by #104, the first connector PR to run the gate): the govulncheck check matched `'"osv"' in out or "vulnerability" in out.lower()`, which is ALWAYS true (govulncheck JSON always dumps the OSV advisory DB + the words '0 vulnerabilities'). So **govulncheck flagged every connector unconditionally** - no connector could pass. Fixed to use govulncheck's **exit code** (3 = reachable vuln, 0 = none).

Plus two vetted base-owned suppressions: semgrep's version of the cobratree MCP-dispatch finding (already vetted for gosec G204), and osv-scanner GO-2026-5024 (x/sys/windows integer overflow that **govulncheck confirms is non-reachable**; press-bump to x/sys >= v0.46.0 is the durable follow-up).

Verified: quickbooks → **0 P1** (all 4 scanners); **acronis still BLOCKS** on its own findings (gate not neutered). Unblocks #104.

Gate-**logic** change → hard-fails its own gate by design (CODEOWNERS @Servosity review).