### PR TITLE
fix(site): wire footer email form to Brevo (custom no-cors submit)

### DIFF
--- a/docs/_includes/email-capture.html
+++ b/docs/_includes/email-capture.html
@@ -1,16 +1,87 @@
 {%- comment -%}
-Reusable email-capture block. Used in the footer (every page) and on PR-3
-content pages.
+Reusable email-capture block. Used in the footer (every page) and on content pages.
 
-The form currently points at /question-book/ as a placeholder.
-TODO: swap action to Brevo form endpoint when creds land.
+Captures into the Brevo list (form 252473a9.sibforms.com, which has no CAPTCHA) and then sends the
+visitor to /question-book/. Field contract is verbatim from the live Brevo form:
+  FIRSTNAME, LASTNAME, EMAIL (required), email_address_check (anti-bot honeypot, must stay empty),
+  locale (hidden, "en").
+
+Why a custom submit instead of Brevo's main.js embed: Brevo's v2 endpoint only accepts
+multipart/form-data and returns no Access-Control-Allow-Origin header, so Brevo's own main.js XHR is
+CORS-blocked when the form is self-hosted on this domain (it would need the domain authorized in
+Brevo first). A native submit with mode:"no-cors" is a CORS "simple request" (multipart is
+safelisted): it delivers the POST and the contact registers, but we can't read the opaque response,
+so we redirect on settle. The
+endpoint carries ?isAjax=1 (Brevo's own success path → 200 {"success":true}) so it returns a clean
+result instead of a 303 thank-you redirect. No external JS, nothing to lazy-load.
+
+No-JS fallback: the form's native action (GET /question-book/) still lands the visitor on the
+content; that rare submission simply isn't captured.
+TODO (optional follow-on): a Brevo automation that emails the Question Book on list-join.
 {%- endcomment -%}
+<style>
+  .email-capture .ec-form { display: grid; gap: 0.6rem; max-width: 440px; margin-top: 0.25rem; }
+  .email-capture .ec-names { display: grid; gap: 0.6rem; grid-template-columns: 1fr 1fr; }
+  @media (max-width: 420px) { .email-capture .ec-names { grid-template-columns: 1fr; } }
+  .email-capture .ec-form input[type="text"]:not(.ec-hp),
+  .email-capture .ec-form input[type="email"] {
+    font-family: inherit; font-size: 1rem; width: 100%; box-sizing: border-box;
+    padding: 0.55rem 0.7rem; border: 1px solid var(--rule); border-radius: 6px;
+    background: #fff; color: var(--fg);
+  }
+  .email-capture .ec-form input::placeholder { color: #aab1bd; }
+  .email-capture .ec-form input:focus { outline: 2px solid var(--accent); outline-offset: 0; border-color: var(--accent); }
+  .email-capture .ec-form button {
+    font-family: inherit; font-size: 1rem; font-weight: 600; cursor: pointer;
+    background: var(--accent); color: #fff; border: 0; border-radius: 6px;
+    padding: 0.6rem 1.1rem; justify-self: start;
+  }
+  .email-capture .ec-form button:hover { background: var(--accent-d); }
+  .email-capture .ec-form button[disabled] { opacity: 0.6; cursor: default; }
+  .email-capture .ec-hp { position: absolute !important; left: -9999px !important; width: 1px; height: 1px; overflow: hidden; }
+  .email-capture .ec-msg { font-size: 0.88rem; color: var(--muted); min-height: 1em; }
+</style>
 <div class="email-capture">
   <p class="ec-title">Get the MSP AI Question Book</p>
   <p>200+ plain-English questions your AI can already answer from the tools you run - no code required.</p>
-  <!-- TODO: swap action to Brevo form endpoint when creds land -->
-  <form action="/question-book/" method="get">
-    <input type="email" name="email" placeholder="you@yourmsp.com" aria-label="Your work email" autocomplete="email">
+  <form class="ec-form" method="get" action="/question-book/"
+        data-brevo-endpoint="https://252473a9.sibforms.com/v2/serve/MUIFACaFxI5474ebF6s3lqBIkHV0xZBYZfvyL_Z3S8qDB4_AFRK20m2JCLC6e2e7PYc8awlpAHqEt-TGbCplHcrTT4mITPweNwJmXsPCajB1xCuJ-t8fTrJHyPnp4PvOn_hLkC9D1uWzVgTl1934_6E4tNfzdLBvQHmWv8IfowlA34S3gq3Zjf3DexFgoSdR7x7Gka5_OF4UXlrmWQ==?isAjax=1"
+        data-redirect="/question-book/">
+    <div class="ec-names">
+      <input type="text" name="FIRSTNAME" placeholder="First name" aria-label="First name" autocomplete="given-name" maxlength="200" required>
+      <input type="text" name="LASTNAME" placeholder="Last name" aria-label="Last name" autocomplete="family-name" maxlength="200" required>
+    </div>
+    <input type="email" name="EMAIL" placeholder="you@yourmsp.com" aria-label="Work email" autocomplete="email" required>
+    {%- comment -%} Brevo anti-bot honeypot: keep empty, off-screen, out of the tab order. {%- endcomment -%}
+    <input type="text" name="email_address_check" value="" class="ec-hp" tabindex="-1" autocomplete="off" aria-hidden="true">
+    <input type="hidden" name="locale" value="en">
     <button type="submit">Send me the Question Book</button>
+    <span class="ec-msg" role="status" aria-live="polite"></span>
   </form>
 </div>
+<script>
+(function () {
+  var forms = document.querySelectorAll('.ec-form[data-brevo-endpoint]');
+  Array.prototype.forEach.call(forms, function (form) {
+    form.addEventListener('submit', function (e) {
+      var endpoint = form.getAttribute('data-brevo-endpoint');
+      if (!endpoint) { return; } // no endpoint -> native fallback (GET /question-book/)
+      e.preventDefault();
+      if (!form.checkValidity()) { form.reportValidity(); return; }
+      var redirect = form.getAttribute('data-redirect') || '/question-book/';
+      var btn = form.querySelector('button[type="submit"]');
+      var msg = form.querySelector('.ec-msg');
+      if (btn) { btn.disabled = true; }
+      if (msg) { msg.textContent = 'Sending…'; }
+      // no-cors: the multipart POST is delivered (contact registers) but the response is opaque,
+      // so we redirect once it settles. .then fires when sent; .catch only on real network failure.
+      fetch(endpoint, { method: 'POST', mode: 'no-cors', body: new FormData(form) })
+        .then(function () { window.location.assign(redirect); })
+        .catch(function () {
+          if (btn) { btn.disabled = false; }
+          if (msg) { msg.textContent = "Sorry - that didn't go through. Please try again."; }
+        });
+    });
+  });
+})();
+</script>


### PR DESCRIPTION
## What & why

The email-capture form at the bottom of every page (`docs/_includes/email-capture.html`, in the footer of all 81 pages) was **connected to no marketing system**. It was a `method="get"` form pointing at `/question-book/`, so submitting just navigated the browser to `/question-book/?email=…` and the email was **discarded** — no backend, no analytics capture (GoatCounter is an unconfigured `YOURCODE` placeholder). The code even carried the TODO `swap action to Brevo form endpoint when creds land`.

This wires it to the Brevo list (form `252473a9.sibforms.com`).

## How

A lightweight **custom native form** (no Brevo `main.js`, no external scripts, nothing to lazy-load):
- `mode:"no-cors"` multipart POST to the Brevo v2 serve endpoint with `?isAjax=1` (Brevo's success path → `200 {"success":true}`). `no-cors` is a CORS "simple request", so it delivers the POST and the contact registers even though Brevo returns no `Access-Control-Allow-Origin` (which is why Brevo's own `main.js` XHR can't be self-hosted here without authorizing the domain).
- On settle, redirect to `/question-book/` (preserves the lead-magnet flow). No-JS fallback: native `GET /question-book/` still lands the visitor on the content.
- Fields: `FIRSTNAME`, `LASTNAME`, `EMAIL` (required) + Brevo anti-bot honeypot `email_address_check` (off-screen, empty) + hidden `locale`.
- Restyled to the warm-editorial palette (terracotta `--accent`), First/Last side-by-side.

reCAPTCHA was disabled on the Brevo form; the honeypot remains as basic bot protection.

## Verification

End-to-end headless (Playwright, against the **live** Brevo endpoint):
- ✅ Multipart POST returns **`200`** — contact captured
- ✅ Page redirects to `/question-book/`
- ✅ Zero external scripts, zero console errors, honeypot off-screen
- ✅ Native look reviewed via screenshot

**Final closure (after merge + Pages rebuild):** one real submit on the live page landing in the Brevo list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)