### PR TITLE
chore(security-gate): suppress 4 vetted gosec FPs surfaced by ninjaone #88

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -86,6 +86,26 @@
       "file": "cli/internal/cli/feedback.go",
       "rule": "G304",
       "reason": "FLEET (generated). Reads the local feedback log file at an app-determined path. Local, user-owned; no untrusted input."
+    },
+    {
+      "file": "cli/internal/cli/auth.go",
+      "rule": "G101",
+      "reason": "FLEET (generated). The flagged literal is the PUBLIC OAuth token ENDPOINT URL (e.g. https://app.ninjarmm.com/ws/oauth/token) assigned to a var named `tokenURL`; G101 false-positives on the 'token' substring in the identifier. Not a secret, no credential material. Surfaced by ninjaone #88."
+    },
+    {
+      "file": "cli/internal/client/client.go",
+      "rule": "G101",
+      "reason": "FLEET (generated). Same as auth.go: the literal is the public OAuth token endpoint URL fallback assigned to `tokenURL` (G101 matches the var name, not a real credential). Surfaced by ninjaone #88."
+    },
+    {
+      "file": "cli/internal/cli/jobs.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads/writes the CLI's own local jobs ledger at jobsFilePath() (and its .tmp) under the per-user data dir; the path is app-determined, not user- or network-tainted. Same class as the cache.go/config.go/import.go entries. Surfaced by ninjaone #88."
+    },
+    {
+      "file": "cli/internal/cli/jobs.go",
+      "rule": "G404",
+      "reason": "FLEET (generated). math/rand is used only to add timing jitter to a job-status poll backoff (interval + rand.Int63n(...)); no token, nonce, or key is derived from it, so crypto/rand is unnecessary. Surfaced by ninjaone #88."
     }
   ]
 }


### PR DESCRIPTION
## Why

The fleet suppression sweep (#105/#107) curated the common generated files but missed two byte-identical generated patterns plus one NinjaOne-specific generated file. Surfaced while triaging ninjaone #88 (PR #106), whose `security-gate` is red **only** on these pre-existing baseline findings (zero in the #106 diff). Suppressions are base-owned, so they must land on `main` before #106's gate (which reads policy from base) can honor them.

## What — 4 entries, each vetted by reading the code

| file | rule | why it's a false positive |
|---|---|---|
| `cli/internal/cli/auth.go` | G101 | flagged literal is the **public OAuth token endpoint URL** (`…/ws/oauth/token`) assigned to a var named `tokenURL`; gosec matches the `token` substring, not a secret |
| `cli/internal/client/client.go` | G101 | same `tokenURL` public-endpoint fallback |
| `cli/internal/cli/jobs.go` | G304 | reads/writes the CLI's own local **jobs ledger** at `jobsFilePath()` (app-determined path, not user/network-tainted) — same class as the existing cache.go/config.go/import.go entries |
| `cli/internal/cli/jobs.go` | G404 | `math/rand` used only for **poll-backoff timing jitter**; no token/nonce/key derived from it |

## Scope

**FLEET** (`cli/internal/…` paths), matching the existing 17 entries and the byte-identical printing-press generated files — so other connectors carrying the same OAuth/jobs patterns don't re-hit this wall. Happy to narrow to `skills/ninjaone/…` if you'd prefer per-connector scoping.

## Verification

`check_security_gate.py --slug ninjaone` → **`[pass] 0 P1 / 13 findings`** (remaining 13 are non-gating P2 unhandled-error findings). No code changed; no `go.mod` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>