### PR TITLE
fix(security-gate): suppress 14 unreachable transitive-dep advisories (x/crypto/ssh + quic-go)

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -86,6 +86,76 @@
       "file": "cli/internal/cli/feedback.go",
       "rule": "G304",
       "reason": "FLEET (generated). Reads the local feedback log file at an app-determined path. Local, user-owned; no untrusted input."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GHSA-vvgj-x9jq-8cj9",
+      "reason": "FLEET (press-pinned indirect dep). quic-go v0.59.0 HTTP/3 QPACK trailer expansion memory exhaustion. These CLIs are REST/HTTP connectors; the HTTP/3 server path is not exercised - govulncheck (reachability) reports 'Your code is affected by 0 vulnerabilities'. osv-scanner has no reachability so it flags module presence only. FOLLOW-UP: bump quic-go at the PRESS level (durable fleet fix, tracked separately); interim suppression - govulncheck still gates any actually-reachable vuln."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5005",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh/agent advisory. golang.org/x/crypto/ssh* is NOT in these CLIs' import graph (verified via `go list -deps`); govulncheck reports 'Your code is affected by 0 vulnerabilities'. osv-scanner flags module presence only (no reachability). FOLLOW-UP: bump golang.org/x/crypto at the PRESS level (durable fleet fix, tracked separately); govulncheck still gates any reachable vuln."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5006",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh/agent advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5013",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5014",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5015",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5016",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5017",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5018",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5019",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5020",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5021",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh/knownhosts advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5023",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
+    },
+    {
+      "file": "cli/go.mod",
+      "rule": "GO-2026-5033",
+      "reason": "FLEET (press-pinned indirect dep). golang.org/x/crypto v0.51.0 ssh/agent advisory. ssh* not imported (go list -deps); govulncheck 0 affected. osv presence-only. FOLLOW-UP: bump x/crypto at the PRESS level; govulncheck still gates reachable vulns."
     }
   ]
 }


### PR DESCRIPTION
## What

Adds 14 BASE-OWNED suppressions to `tools/maintainer/security_suppressions.json` for `osv-scanner` advisories the gate flags in every connector's press-pinned `cli/go.mod`:
- **13× `golang.org/x/crypto` v0.51.0** ssh-subpackage advisories (GO-2026-5005/5006/5013-5021/5023/5033)
- **1× `quic-go` v0.59.0** HTTP/3 QPACK (GHSA-vvgj-x9jq-8cj9)

All fleet-scoped (`cli/go.mod`), mirroring the existing `golang.org/x/sys` GO-2026-5024 entry.

## Why these are safe (vetted)

- Both deps are `// indirect` (transitive), pinned by the printing-press template.
- `golang.org/x/crypto/ssh*` is **not in the import graph** (`go list -deps` shows no ssh packages — these are REST/HTTP connectors).
- **`govulncheck` (reachability-aware) reports `Your code is affected by 0 vulnerabilities`** (run locally on axcient; exit 0).
- `osv-scanner` has no reachability analysis, so it flags **module presence only**.
- govulncheck remains in the gate and still blocks any *actually-reachable* vuln.

These advisories are recent (2026-06), so they currently block **every** connector PR fleet-wide (e.g. axcient PR #102). This unblocks the fleet.

## Verification

With these suppressions as policy, the gate passes clean:
```
[pass] axcient (full): 0 P1 / 13 findings   (exit 0)
```
(The remaining 13 are pre-existing P2 gosec/plaintext-http baseline, which don't gate.)

A suppressions-only change touches no `skills/<slug>/` code, so this PR's own security-gate trivially passes; CODEOWNERS still gates the file.

## DURABLE FOLLOW-UP

Bump `golang.org/x/crypto` + `quic-go` at the **printing-press template level** so reprints carry patched deps fleet-wide (filing separately). This suppression is the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)