### PR TITLE
chore(connectwise-control,rewst): pin toolchain go1.26.4 (patched stdlib)

### DIFF
--- a/skills/connectwise-control/cli/go.mod
+++ b/skills/connectwise-control/cli/go.mod
@@ -2,6 +2,8 @@ module connectwise-control-pp-cli
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/enetx/http v1.0.28
 	github.com/enetx/surf v1.0.199

--- a/skills/rewst/cli/go.mod
+++ b/skills/rewst/cli/go.mod
@@ -2,6 +2,8 @@ module rewst-pp-cli
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/mark3labs/mcp-go v0.47.0
 	github.com/pelletier/go-toml/v2 v2.2.4


### PR DESCRIPTION
## Why

Follow-up to #113. With the reachability gate now live, `govulncheck` flags **GO-2026-5039** (`net/textproto`) and **GO-2026-5037** (`crypto/x509`) as reachable in `connectwise-control` and `rewst` when they build against the **go1.26.3** standard library. Both are fixed in **go1.26.4**.

Unlike `axcient` (which pins `toolchain go1.26.4`), these two carried no `toolchain` directive, so they floated to whatever Go was installed - patched in CI (`go-version: "1.26"` resolves to the latest 1.26.x), but go1.26.3 on an older local toolchain, which is where the gate flagged them.

## What

Add `toolchain go1.26.4` to both `go.mod` files (matching axcient). This:
- guarantees the **shipped binary's** stdlib is the patched stdlib the gate analyzes (closes the build-vs-gate toolchain mismatch),
- clears the govulncheck flag - **verified locally: `No vulnerabilities found. Your code is affected by 0 vulnerabilities.` (exit 0)** with the pin,
- restores fleet consistency with axcient.

## Scope / honesty

This is **not** an active CI/release vulnerability - CI already floats to the latest patched 1.26.x. It is the deterministic, defense-in-depth fix so a manual or older-local-Go build can't ship vulnerable stdlib. Only the two `go.mod` files change (no `go.sum`; the `toolchain` directive is not a module requirement). The durable fleet-wide fix is a consistent toolchain directive emitted at the printing-press template level (tracks with cli-printing-press #3012).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
