### PR TITLE
fix(servosity): send MSP token with required DRF "Token " auth scheme (#78)

### DIFF
--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.3.0] - unreleased
+## [0.3.1] - 2026-06-16
+
+### Fixed
+- Authentication: `servosity-cli` / `servosity-mcp` now send the partner token
+  with the required `Token ` scheme on the `Authorization` header. The Servosity
+  API authenticates `SERVOSITY_MSP_TOKEN` via Django REST Framework's
+  `TokenAuthentication`, which rejects a bare token value with HTTP 403 on every
+  data endpoint; the documented bare-token setup now works as written. The MSP
+  token path normalizes to the `Token ` scheme, so a value that already carries
+  a scheme prefix (the `SERVOSITY_MSP_TOKEN="Token <token>"` workaround) is not
+  double-prefixed. Thanks to @sonofcar102 for the detailed report (#78).
 
 ### Changed
 - Regenerated the vendored `servosity-cli` / `servosity-mcp` source from

--- a/skills/servosity/cli/internal/config/config.go
+++ b/skills/servosity/cli/internal/config/config.go
@@ -107,10 +107,28 @@ func (c *Config) AuthHeader() string {
 	if token == "" {
 		return ""
 	}
-	if c.ServosityMspToken == "" {
-		return ""
+	// The Servosity API authenticates the MSP partner token via Django REST
+	// Framework's TokenAuthentication, which requires the "Token " scheme on
+	// the Authorization header; a bare value is rejected with HTTP 403 on every
+	// data endpoint. The MSP partner token is always a DRF token, so normalize
+	// to the "Token " scheme: strip any scheme the user may have prefixed (the
+	// documented SERVOSITY_MSP_TOKEN="Token <token>" workaround, or a mistaken
+	// "Bearer " that the API would otherwise route to OAuth2 introspection) and
+	// re-apply "Token ". A caller needing a different scheme sets the
+	// auth_header override, which is returned verbatim above.
+	return "Token " + stripAuthScheme(token)
+}
+
+// stripAuthScheme removes a leading HTTP Authorization scheme (e.g. "Token " or
+// "Bearer ", case-insensitive) from v and returns the bare credential. A value
+// with no recognized scheme is returned unchanged.
+func stripAuthScheme(v string) string {
+	for _, scheme := range []string{"token ", "bearer "} {
+		if len(v) >= len(scheme) && strings.EqualFold(v[:len(scheme)], scheme) {
+			return strings.TrimLeft(v[len(scheme):], " ")
+		}
 	}
-	return token
+	return v
 }
 
 func applyAuthFormat(format string, replacements map[string]string) string {

--- a/skills/servosity/cli/internal/config/config_test.go
+++ b/skills/servosity/cli/internal/config/config_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import "testing"
+
+// TestAuthHeader_TokenScheme guards the fix for issue #78: the Servosity API
+// authenticates the MSP partner token via Django REST Framework's
+// TokenAuthentication, which requires the "Token " scheme on the Authorization
+// header. A bare token value is rejected with HTTP 403. AuthHeader() must
+// prepend the scheme, while tolerating a value that already carries a
+// recognized scheme (the historical SERVOSITY_MSP_TOKEN="Token <t>" workaround).
+func TestAuthHeader_TokenScheme(t *testing.T) {
+	cases := []struct {
+		name      string
+		cfg       Config
+		want      string
+	}{
+		{
+			name: "bare token gets the Token scheme",
+			cfg:  Config{ServosityMspToken: "abc123"},
+			want: "Token abc123",
+		},
+		{
+			name: "value already carrying Token scheme is not double-prefixed",
+			cfg:  Config{ServosityMspToken: "Token abc123"},
+			want: "Token abc123",
+		},
+		{
+			name: "lowercase token scheme is normalized to canonical Token",
+			cfg:  Config{ServosityMspToken: "token abc123"},
+			want: "Token abc123",
+		},
+		{
+			name: "mistaken Bearer scheme is normalized to the DRF Token scheme",
+			cfg:  Config{ServosityMspToken: "Bearer abc123"},
+			want: "Token abc123",
+		},
+		{
+			name: "empty token yields an empty header",
+			cfg:  Config{ServosityMspToken: ""},
+			want: "",
+		},
+		{
+			name: "explicit AuthHeaderVal override is returned verbatim",
+			cfg:  Config{AuthHeaderVal: "Token override", ServosityMspToken: "abc123"},
+			want: "Token override",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.AuthHeader(); got != tc.want {
+				t.Fatalf("AuthHeader() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -1,7 +1,7 @@
 {
   "slug": "servosity",
   "doc": "docs/reprint-survival.md",
-  "_comment": "servosity is a SPECIAL case: it is engine-swapped from the servosity-msp mint via a staging strip + de-msp rename ritual that is RE-APPLIED on every reprint, so most of its divergence from a stock print is re-derived, not lost. These entries pin the load-bearing engine-swap invariants so a NAIVE reprint (one that bypassed the ritual) is caught. NOTE: a full reprint-diff would surface more; this records the auth/identity invariants that matter most. Separately, issue #78 (bare SERVOSITY_MSP_TOKEN lacks the required 'Token ' auth-scheme prefix) is an OPEN bug, not a hand-fix to preserve.",
+  "_comment": "servosity is a SPECIAL case: it is engine-swapped from the servosity-msp mint via a staging strip + de-msp rename ritual that is RE-APPLIED on every reprint, so most of its divergence from a stock print is re-derived, not lost. These entries pin the load-bearing engine-swap invariants so a NAIVE reprint (one that bypassed the ritual) is caught. NOTE: a full reprint-diff would surface more; this records the auth/identity invariants that matter most. Issue #78 (bare SERVOSITY_MSP_TOKEN lacked the required 'Token ' DRF auth-scheme prefix -> HTTP 403 on every data endpoint) is FIXED in AuthHeader() and pinned below; the servosity-msp engine still emits a bare token, so a reprint that bypassed re-applying this prefix would reintroduce the bug.",
   "handfixes": [
     {
       "id": "msp-token-auth-plumbing",
@@ -11,6 +11,18 @@
       "asserts": [
         {"file": "cli/internal/config/config.go", "contains": "SERVOSITY_MSP_TOKEN", "min_count": 1},
         {"file": "cli/internal/config/config.go", "contains": "ServosityMspToken", "min_count": 1}
+      ]
+    },
+    {
+      "id": "msp-token-auth-scheme-prefix",
+      "summary": "AuthHeader() prepends the DRF 'Token ' scheme to the MSP partner token (issue #78)",
+      "why": "The Servosity API authenticates the MSP partner token via Django REST Framework's TokenAuthentication, which requires the 'Token ' scheme on the Authorization header; a bare value 403s on every data endpoint. The stock servosity-msp engine emits the token verbatim, so the de-msp ritual must re-apply this scheme prefix on every reprint or the bug returns. hasAuthScheme tolerates an already-prefixed value for backward compatibility with the SERVOSITY_MSP_TOKEN='Token <t>' workaround.",
+      "status": "active",
+      "issue": 78,
+      "asserts": [
+        {"file": "cli/internal/config/config.go", "contains": "stripAuthScheme", "min_count": 1},
+        {"file": "cli/internal/config/config.go", "contains": "\"Token \" + stripAuthScheme", "min_count": 1},
+        {"file": "cli/internal/config/config_test.go", "contains": "TestAuthHeader_TokenScheme", "min_count": 1}
       ]
     }
   ]


### PR DESCRIPTION
## Summary

`servosity-cli` / `servosity-mcp` sent `SERVOSITY_MSP_TOKEN` verbatim as the
`Authorization` header. The Servosity API authenticates the partner token via
Django REST Framework's `TokenAuthentication`, which requires the `Token `
scheme prefix; a bare value (or a `Bearer ` prefix, which the API routes to the
custom Hydra OAuth2-introspection path) is rejected with **HTTP 403 on every
data endpoint** — so the documented bare-token setup failed for all users, and
`doctor` masked it.

## Fix

`config.AuthHeader()` now normalizes the MSP-token path to the DRF `Token `
scheme via `stripAuthScheme()`: it strips any user-supplied scheme (the
documented `SERVOSITY_MSP_TOKEN="Token <token>"` workaround, or a mistaken
`Bearer `) and re-applies `Token `. So:

- the documented **bare token** now works as written;
- the historical `Token <token>` **workaround** is not double-prefixed;
- the explicit `auth_header` override is still returned verbatim for callers
  needing a different scheme.

The `doctor` authenticated probe (`/reports/account/`) routes through the same
`AuthHeader()`, so it now reports healthy with a valid token.

The fix was **derived independently** from the `servosity-api` backend source
(DRF `TokenAuthentication` + the custom `HydraAccessTokenAuthentication` Bearer
path), not from the reporter's suggested patch.

## Verification

- New behavioral unit test `TestAuthHeader_TokenScheme` (bare → `Token <t>`;
  `Token`/`token`/`Bearer` prefixes normalized; empty → empty; `auth_header`
  override verbatim). `go build` + `go vet` + full `go test ./...` green.
- Scheme normalization pinned in `handfixes.json` so a reprint from the
  still-bare `servosity-msp` engine re-applies it.
- Layer-3 adversarial security review (codex + fresh-context Claude): no P1.

## Impact

Bug-fix-only (Class A): no new command/flag/output/permission. Docs unchanged
(the documented bare-token setup simply starts working).

Fixes #78

Thanks to @sonofcar102 for the detailed, root-caused report.