### PR TITLE
fix(live-verified): badge the correct skill from it-works reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/it-works.yml
+++ b/.github/ISSUE_TEMPLATE/it-works.yml
@@ -1,3 +1,11 @@
+# NOTE: the "Which skill" dropdown options are GENERATED from tools/skills.json
+# by tools/maintainer/build-catalog.py (every connector, slug-sorted, plus
+# "other / not listed"). Do NOT edit the options by hand - register the skill
+# and run `python3 tools/maintainer/build-catalog.py`; CI (catalog.yml) fails
+# on drift. Listing every connector means a reporter can pick the exact skill
+# instead of being forced into "other", so the live-verified.yml automation can
+# badge the correct slug directly. (See live-verified.yml's parse step, which
+# also cross-checks the title/body and bails to a human on any disagreement.)
 name: "✅ Report: it works"
 description: Tell us a Skill or MCP server ran against your real tenant. We badge it "live-verified" and thank you.
 title: "[Works] "
@@ -14,9 +22,61 @@ body:
       label: Which skill
       description: The Skill / MCP server you ran.
       options:
+        - abnormal
+        - acronis
+        - action1
+        - afi
+        - appdirect
+        - atera
+        - autotask
+        - axcient
+        - betterstack
+        - blumira
+        - cipp
+        - connectwise-automate
+        - connectwise-control
+        - connectwise-manage
+        - cove
+        - crowdstrike
+        - datto-bcdr
+        - datto-rmm
+        - domotz
+        - gradient
         - halopsa
-        - servosity
         - hubspot
+        - hudu
+        - huntress
+        - itglue
+        - kaseya-bms
+        - knowbe4
+        - levelio
+        - liongard
+        - microsoft-graph
+        - mspbots
+        - n-central
+        - nerdio
+        - ninjaone
+        - pagerduty
+        - pandadoc
+        - pax8
+        - pipedrive
+        - proofpoint
+        - quickbooks
+        - rewst
+        - rocketcyber
+        - rootly
+        - runzero
+        - salesbuildr
+        - sentinelone
+        - servosity
+        - sherweb
+        - skykick
+        - superops
+        - syncro
+        - tactical-rmm
+        - threatlocker
+        - veeam
+        - xero
         - other / not listed
     validations:
       required: true

--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -64,34 +64,66 @@ jobs:
           import json, os, re
 
           event = json.load(open(os.environ["GITHUB_EVENT_PATH"]))
-          body = (event.get("issue") or {}).get("body") or ""
+          issue = event.get("issue") or {}
+          body = issue.get("body") or ""
+          title = issue.get("title") or ""
 
-          # Known slugs come from the registry; "hubspot" et al. only count once
-          # they are registered. verify_live.py is the final gate on unknown
-          # slugs, but we pre-check here so we can leave a helpful comment.
+          # Known slugs come from the registry; a slug only counts once it is
+          # registered. verify_live.py is the final gate, but we pre-check here
+          # so we can leave a helpful comment.
           reg = json.load(open("tools/maintainer/skills.json"))
           known = set(reg.get("skills", {}))
 
-          slug = ""
+          # 1) The dropdown value (the structured signal). GitHub renders the
+          # "Which skill" dropdown as a "### Which skill" heading followed by the
+          # value on the next non-empty line.
+          dropdown = ""
           lines = body.splitlines()
           for i, line in enumerate(lines):
               if re.match(r"^#{1,6}\s*Which skill\s*$", line.strip(), re.IGNORECASE):
-                  # The value is the next non-empty, non-heading line.
                   for nxt in lines[i + 1:]:
                       val = nxt.strip()
                       if val and not val.startswith("#"):
-                          slug = val
+                          dropdown = val
                           break
                   break
+          dropdown = dropdown.strip().lower()
+          if dropdown in ("other / not listed", "other", "not listed", ""):
+              dropdown = ""
 
-          # Normalize: the form's "other / not listed" option is not a slug.
-          slug = slug.strip().lower()
-          if slug in ("other / not listed", "other", "not listed", ""):
-              slug = ""
+          # 2) Independent evidence from the title + body free-text - HIGH-signal
+          # only: an explicit "<slug>-mcp"/"<slug>-cli" mention, or the slug (with
+          # separators stripped, >=5 chars to avoid short-slug noise) appearing in
+          # the normalized title. This is a SAFETY CROSS-CHECK, never an
+          # auto-picker: when it disagrees with the dropdown we refuse and defer
+          # to a human - we never badge from a guess. (A reporter once picked
+          # "servosity" for a SentinelOne report, #116; this catches that.)
+          hay = (title + "\n" + body).lower()
+          norm_title = re.sub(r"[^a-z0-9]", "", title.lower())
+          evidence = set()
+          for k in known:
+              kn = re.sub(r"[^a-z0-9]", "", k)
+              if f"{k}-mcp" in hay or f"{k}-cli" in hay:
+                  evidence.add(k)
+              elif len(kn) >= 5 and kn in norm_title:
+                  evidence.add(k)
 
-          ok = "true" if slug and slug in known else "false"
+          # 3) Decide. Auto-badge ONLY when the dropdown names a known slug AND
+          # the independent evidence does not point at a DIFFERENT one. Unknown/
+          # "other" dropdown, or a dropdown-vs-evidence conflict, bails to the
+          # manual path - fail-safe, never a wrong badge.
+          conflict = bool(
+              dropdown and dropdown in known and evidence and dropdown not in evidence
+          )
+          ok = "true" if (dropdown and dropdown in known and not conflict) else "false"
+          # A single unambiguous inferred slug makes the maintainer's manual flip
+          # trivial; surface it for the bail-path comment.
+          inferred = next(iter(evidence)) if len(evidence) == 1 else ""
+
           print(f"ok={ok}")
-          print(f"slug={slug}")
+          print(f"slug={dropdown}")
+          print(f"inferred={inferred}")
+          print(f"conflict={'true' if conflict else 'false'}")
           PY
 
       - name: Comment that a maintainer must verify manually (parse failed)
@@ -100,15 +132,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ISSUE: ${{ github.event.issue.number }}
           SLUG: ${{ steps.parse.outputs.slug }}
+          INFERRED: ${{ steps.parse.outputs.inferred }}
+          CONFLICT: ${{ steps.parse.outputs.conflict }}
         run: |
           set -euo pipefail
-          if [ -n "$SLUG" ]; then
+          if [ "$CONFLICT" = "true" ]; then
+            note="the report's \"Which skill\" dropdown says '$SLUG' but the title/body looks like '$INFERRED' - they disagree, so we did not badge automatically"
+          elif [ -n "$SLUG" ]; then
             note="the skill '$SLUG' from this report is not a registered skill yet"
+          elif [ -n "$INFERRED" ]; then
+            note="the report did not pick a listed skill, but the title/body looks like '$INFERRED'"
           else
             note="we could not read the skill from this report"
           fi
-          gh issue comment "$ISSUE" --body "Thanks for the report. Automation could not badge this automatically: $note. A maintainer will run \`python3 tools/maintainer/verify_live.py\` by hand. No action needed from you."
-          echo "Parse failed or unknown slug; commented and exiting cleanly."
+          hint="\`python3 tools/maintainer/verify_live.py\`"
+          if [ -n "$INFERRED" ]; then
+            hint="\`python3 tools/maintainer/verify_live.py --slug $INFERRED --source github --evidence <this issue URL>\`"
+          fi
+          gh issue comment "$ISSUE" --body "Thanks for the report. Automation did not badge this automatically: $note. A maintainer will verify by hand ($hint). No action needed from you."
+          echo "Bailed to manual path (ok!=true); commented and exiting cleanly."
 
       - name: Flip the badge to live-verified
         if: steps.parse.outputs.ok == 'true'

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -34,6 +34,7 @@ SKILLS_DIR = ROOT / "skills"
 README = ROOT / "README.md"
 CATALOG = ROOT / "catalog.json"
 DOCS_CATALOG = ROOT / "docs" / "_data" / "catalog.json"
+IT_WORKS_FORM = ROOT / ".github" / "ISSUE_TEMPLATE" / "it-works.yml"
 
 # Owner/repo and per-skill metadata are the single source of truth in
 # tools/skills.json (loaded via registry). Every install URL is built from
@@ -210,6 +211,36 @@ def replace_block(content: str, marker_start: str, marker_end: str, block: str) 
             "cannot regenerate the generated blocks."
         )
     return pattern.sub(rf"\1\n{block}\n\3", content)
+
+
+# The "Which skill" dropdown in the it-works issue form. Anchored on the FIRST
+# `options:` block (the `id: skill` dropdown precedes `id: agent` in the file)
+# up to its `validations:`. We rewrite the option LIST in place - same line
+# shape that already ships (`        - <slug>`) - rather than fencing with
+# YAML comments inside the sequence, which the GitHub form parser is fussier
+# about and which we cannot validate locally (no PyYAML in CI's catalog job).
+_FORM_OPTIONS_RE = re.compile(
+    r"(      options:\n)(?:        - .*\n)+?(    validations:\n)"
+)
+
+
+def render_it_works_form(content: str, skills: list[dict]) -> str:
+    """Regenerate the it-works form's skill dropdown from the registry: every
+    connector (markdown-only meta excluded), slug-sorted, plus the
+    "other / not listed" escape hatch. Returns the new file content."""
+    connectors = sorted(s["name"] for s in skills if not s.get("markdown_only"))
+    options = [f"        - {slug}" for slug in connectors]
+    options.append("        - other / not listed")
+    block = "\n".join(options) + "\n"
+    new_content, n = _FORM_OPTIONS_RE.subn(rf"\g<1>{block}\g<2>", content, count=1)
+    if n != 1:
+        raise SystemExit(
+            f"build-catalog: could not find the skill dropdown options block in "
+            f"{IT_WORKS_FORM.relative_to(ROOT)} (expected `      options:` followed "
+            f"by `        - ...` lines and `    validations:`). The form structure "
+            f"changed; update _FORM_OPTIONS_RE."
+        )
+    return new_content
 
 
 # --------------------------------------------------------------------------- #
@@ -456,6 +487,14 @@ def main() -> int:
         new_readme,
     )
     README.write_text(new_readme)
+
+    # Regenerate the it-works issue form's skill dropdown so a reporter can pick
+    # the exact connector (not be forced into "other"); the catalog.yml drift
+    # gate keeps it in lockstep with the registry. Skipped gracefully if the
+    # form is absent (e.g. a partial checkout).
+    if IT_WORKS_FORM.exists():
+        form = IT_WORKS_FORM.read_text()
+        IT_WORKS_FORM.write_text(render_it_works_form(form, skills))
 
     # Re-render every connector's docs page in the same pass, so a registry
     # change (live-verified flip, display rename) or a page.json edit shows up


### PR DESCRIPTION
## Motivation

Issue #116 was a genuine SentinelOne `[Works]` report, but the form's *Which skill* dropdown only listed `halopsa / servosity / hubspot / other`, so the reporter picked **`servosity`**. `live-verified.yml` parses **only** that dropdown — so a naive `confirmed-works` label would have badged the **wrong skill**. Two complementary fixes:

## (a) Generate the dropdown from the registry

`build-catalog.py` now regenerates the it-works form's *Which skill* options from `tools/skills.json` — every connector (55), slug-sorted, plus `other / not listed`. Reporters can pick the exact skill instead of being forced into "other", so the automation can badge the right slug directly. The existing **`catalog.yml` drift gate** keeps the dropdown in lockstep with the registry (add a skill → regenerate → CI fails on drift), so it can't rot. Generated via an anchored replacement that emits the same line shape already shipping (no fragile inline YAML comments — there's no PyYAML in the catalog CI job to validate them).

## (b) Cross-check the dropdown — fail-safe

The parse step in `live-verified.yml` now also scans the **title + body** for `<slug>-mcp`/`<slug>-cli` mentions and a normalized-title slug match. It auto-badges **only** when the dropdown names a known slug **AND** independent evidence doesn't point at a *different* one. Any unknown/"other"/conflict bails to the existing *"a maintainer will verify by hand"* path — now naming the **inferred** slug so the manual `verify_live.py` is trivial.

This is a **safety cross-check, never an auto-picker**: the worst case is deferring to a human, never a wrong badge.

### Verified offline (the exact heredoc Python, 6 cases)

| Case | Result |
|---|---|
| #116 (dropdown=servosity, body=sentinelone-mcp) | `ok=false conflict=true inferred=sentinelone` ✓ |
| clean halopsa report | `ok=true slug=halopsa` ✓ |
| "other" + `ninjaone-cli` in body | `ok=false inferred=ninjaone` ✓ |
| correct dropdown, no body evidence | `ok=true slug=hubspot` ✓ (no over-refusal) |
| unknown dropdown slug | `ok=false` ✓ |
| dropdown + evidence agree | `ok=true slug=sentinelone` ✓ |

## Why both

(a) without (b) still mis-badges on a fat-finger; (b) without (a) keeps 53 connectors on the manual path forever.

## Scope

Docs/CI-plumbing only — **no Go changes, no release, no tag**. `build-catalog.py` run locally; the only product diff is the regenerated form (idempotent; catalog/README/docs were already in sync). `live-verified.yml` is **not** on the security-gate hard-fail list (only `security-gate.yml`/`release.yml`/gate scripts are), so this lands once `security-gate` is green.

Follow-up (deliberately **not** here): making the docs site render shields-style badges — that's a brand/design decision against the site's intentional warm-editorial CSS pills, tracked separately.