### PR TITLE
ci(security-gate): pre-warm module + build cache so gosec doesn't time out on heavy-dep connectors

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -70,6 +70,29 @@ jobs:
           python3 -m pip install --quiet semgrep || echo "semgrep install failed (non-fatal)"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Pre-warm module + build cache for changed connectors
+        if: steps.scope.outputs.relevant == 'true'
+        env:
+          SLUGS: ${{ steps.scope.outputs.slugs }}
+        run: |
+          set -uo pipefail
+          # gosec's go/packages loader downloads + compiles each connector before scanning.
+          # On a cold runner the FIRST (heaviest) connector's dependency fetch + build can
+          # exceed gosec's 300s budget and fail-close as a scanner timeout (exit 124) - NOT
+          # a real finding, just an infra flake that blocks heavy-dep connectors (e.g.
+          # axcient: surf + quic-go + utls + modernc/sqlite). Pre-build every changed
+          # connector here so the module AND build caches are warm; gosec then completes in
+          # ~1s (as it does locally). `go build` runs no connector code (pure Go, CGO off,
+          # no `go generate`), so it cannot weaken the gate - it only removes the cold-start
+          # cost from the scanners' timeout budget.
+          for s in $SLUGS; do
+            if [ -f "skills/$s/cli/go.mod" ]; then
+              echo "::group::pre-warm $s"
+              (cd "skills/$s/cli" && CGO_ENABLED=0 go build ./...) || echo "pre-warm failed for $s (non-fatal)"
+              echo "::endgroup::"
+            fi
+          done
+
       - name: Run the deterministic security gate (diff-scoped, base-trusted policy)
         if: steps.scope.outputs.relevant == 'true'
         env:


### PR DESCRIPTION
## Problem

The `security-gate` job fails on heavy-dependency connectors (e.g. **axcient**) with:

```
[BLOCK] axcient (diff): 1 P1 / 2 findings
    P1 gosec:scanner-error skills/axcient/cli/go.mod:0 - gosec did not complete (timeout, exit 124) (fail-closed).
```

**Not a real finding.** gosec's `go/packages` loader downloads + compiles each connector before scanning. On a cold CI runner the **first** (heaviest) connector — axcient pulls `github.com/enetx/surf` + `quic-go` + `utls` + `modernc/sqlite` — eats that cold-start cost **inside gosec's 300s budget** → exit 124 → the gate correctly fail-closes. Reruns don't help (every runner is cold); it blocks *any* axcient-touching PR. `connectwise-control` passed only because axcient's killed run had already warmed the shared deps; light REST connectors pass because their trees are small.

## Fix

Add a pre-warm step (`CGO_ENABLED=0 go build ./...` per changed slug) between scanner install and the gate loop. It warms the module **and** build caches so the scanners run warm. It runs **no connector code** (pure Go, CGO off, no `go generate`), so it **cannot weaken the gate** — it only moves the cold-start cost out of gosec's timeout budget. Fail-closed semantics unchanged.

## Receipt (cold-cache simulation, isolated GOMODCACHE/GOCACHE)

| step | time |
| --- | --- |
| pre-warm `go build ./...` (axcient, cold) | **38s** (its own uncapped step) |
| gosec after pre-warm (warm) | **6s** (exit 1 = ran, found issues) |

Without the step gosec must absorb the ~38s+ cold download+build *plus* its own analysis inside 300s — which the slower CI runner exceeds. With it, gosec runs in seconds.

## Note — this PR's own gate is expected-red by design

The gate's scope step hard-fails any PR that edits `.github/workflows/security-gate.yml` (gate-infra changes can't be self-approved). So this PR shows a **red `security-gate` check by design** and must be reviewed + merged by a security maintainer (CODEOWNERS `@Servosity`).

Unblocks #120 (the osv durable-fix dep bump for #112). After this merges, #120 is rebased onto main and its gate re-run goes green.