### PR TITLE
fix(superops): request scalar GraphQL fields without sub-selections (#114)

### DIFF
--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this skill are documented here. Format follows
 
 ## [0.1.1] - unreleased
 
+### Fixed
+- Typed `list`/`get` commands (`clients`, `assets`, `tickets`, and every other entity) no longer fail with GraphQL `SubSelectionNotAllowed` errors. The queries requested association/enum fields (`accountManager`, `primaryContact`, `hqSite`, `client`, `site`, `status`, `priority`, `requester`, `technician`, and others) with object sub-selections, but the SuperOps schema returns those fields as scalar leaf types (JSON/String); they are now requested as the scalars they are. Thanks to @AvlCompCo for the detailed report (#114).
+
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 

--- a/skills/superops/cli/internal/client/queries.go
+++ b/skills/superops/cli/internal/client/queries.go
@@ -39,7 +39,7 @@ const AlertsListQuery = `query($first: Int, $page: Int) {
       status
       createdTime
       resolvedTime
-      asset { assetId name hostName }
+      asset
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -64,8 +64,8 @@ const AssetsGetQuery = `query($id: ID!) {
     agentVersion
     lastCommunicatedTime
     warrantyExpiryDate
-    client { accountId name }
-    site { id name }
+    client
+    site
   }
 }`
 
@@ -89,8 +89,8 @@ const AssetsListQuery = `query($first: Int, $page: Int) {
       agentVersion
       lastCommunicatedTime
       warrantyExpiryDate
-      client { accountId name }
-      site { id name }
+      client
+      site
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -103,9 +103,9 @@ const ClientsGetQuery = `query($id: ID!) {
     stage
     status
     emailDomains
-    accountManager { userId name }
-    primaryContact { userId name email }
-    hqSite { id name }
+    accountManager
+    primaryContact
+    hqSite
   }
 }`
 
@@ -117,9 +117,9 @@ const ClientsListQuery = `query($first: Int, $page: Int) {
       stage
       status
       emailDomains
-      accountManager { userId name }
-      primaryContact { userId name email }
-      hqSite { id name }
+      accountManager
+      primaryContact
+      hqSite
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -133,7 +133,7 @@ const ContractsListQuery = `query($first: Int, $page: Int) {
       contractType
       startDate
       endDate
-      client { accountId name }
+      client
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -151,8 +151,8 @@ const InvoicesGetQuery = `query($id: ID!) {
     discountAmount
     paymentDate
     paymentMethod
-    client { accountId name }
-    site { id name }
+    client
+    site
   }
 }`
 
@@ -169,8 +169,8 @@ const InvoicesListQuery = `query($first: Int, $page: Int) {
       discountAmount
       paymentDate
       paymentMethod
-      client { accountId name }
-      site { id name }
+      client
+      site
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -214,7 +214,7 @@ const ServiceItemsListQuery = `query($first: Int, $page: Int) {
       unitPrice
       afterHoursUnitPrice
       salesTaxEnabled
-      category { categoryId name }
+      category
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -233,7 +233,7 @@ const SitesListQuery = `query($first: Int, $page: Int) {
       contactNumber
       timezoneCode
       hq
-      client { accountId name }
+      client
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -252,8 +252,8 @@ const TasksGetQuery = `query($id: ID!) {
     overdue
     actualStartDate
     actualEndDate
-    technician { userId name }
-    ticket { ticketId displayId }
+    technician
+    ticket
   }
 }`
 
@@ -271,8 +271,8 @@ const TasksListQuery = `query($first: Int, $page: Int) {
       overdue
       actualStartDate
       actualEndDate
-      technician { userId name }
-      ticket { ticketId displayId }
+      technician
+      ticket
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -285,9 +285,9 @@ const TechniciansListQuery = `query($first: Int, $page: Int) {
       name
       email
       contactNumber
-      designation { designationId name }
-      role { roleId name }
-      team { teamId name }
+      designation
+      role
+      team
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -299,14 +299,14 @@ const TicketsGetQuery = `query($id: ID!) {
     displayId
     subject
     ticketType
-    status { statusId name }
-    priority { priorityId name }
-    client { accountId name }
-    site { id name }
-    requester { userId name email }
-    technician { userId name }
-    techGroup { groupId name }
-    sla { slaId name }
+    status
+    priority
+    client
+    site
+    requester
+    technician
+    techGroup
+    sla
     createdTime
     updatedTime
     resolutionDueTime
@@ -322,14 +322,14 @@ const TicketsListQuery = `query($first: Int, $page: Int) {
       displayId
       subject
       ticketType
-      status { statusId name }
-      priority { priorityId name }
-      client { accountId name }
-      site { id name }
-      requester { userId name email }
-      technician { userId name }
-      techGroup { groupId name }
-      sla { slaId name }
+      status
+      priority
+      client
+      site
+      requester
+      technician
+      techGroup
+      sla
       createdTime
       updatedTime
       resolutionDueTime
@@ -349,9 +349,9 @@ const UsersListQuery = `query($first: Int, $page: Int) {
       lastName
       email
       contactNumber
-      role { roleId name }
-      site { id name }
-      client { accountId name }
+      role
+      site
+      client
     }
     listInfo { totalCount hasMore page pageSize }
   }
@@ -367,8 +367,8 @@ const WorklogsListQuery = `query($first: Int, $page: Int) {
       afterHours
       startTime
       endTime
-      technician { userId name }
-      ticket { ticketId displayId }
+      technician
+      ticket
     }
     listInfo { totalCount hasMore page pageSize }
   }

--- a/skills/superops/cli/internal/client/queries_issue114_test.go
+++ b/skills/superops/cli/internal/client/queries_issue114_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// HAND-AUTHORED regression test for issue #114 (NOT generated — do not delete on reprint).
+//
+// Bug: every typed list/get query requested association/enum fields
+// (accountManager, client, status, site, ...) with object sub-selections
+// "{ ... }", but the live SuperOps GraphQL schema returns those fields as
+// scalar leaf types (JSON/String). The server rejected every typed command
+// with `SubSelectionNotAllowed`. The fix strips those sub-selections so each
+// field is requested as the bare scalar it already unmarshals into — note
+// every one of these fields is declared `string` (or json.RawMessage) in
+// internal/types, so the bare-scalar form is the only shape consistent with
+// the generated output contract.
+//
+// These tests pin that contract so a future reprint cannot silently
+// re-introduce the sub-selections (the source spec.yaml carried the spurious
+// `selection:` keys that produced them).
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"superops-pp-cli/internal/config"
+)
+
+// allListQueries is every typed query constant the bug touched.
+var allListQueries = map[string]string{
+	"AlertsListQuery":       AlertsListQuery,
+	"AssetsGetQuery":        AssetsGetQuery,
+	"AssetsListQuery":       AssetsListQuery,
+	"ClientsGetQuery":       ClientsGetQuery,
+	"ClientsListQuery":      ClientsListQuery,
+	"ContractsListQuery":    ContractsListQuery,
+	"InvoicesGetQuery":      InvoicesGetQuery,
+	"InvoicesListQuery":     InvoicesListQuery,
+	"ItDocsListQuery":       ItDocsListQuery,
+	"KbListQuery":           KbListQuery,
+	"ServiceItemsListQuery": ServiceItemsListQuery,
+	"SitesListQuery":        SitesListQuery,
+	"TasksGetQuery":         TasksGetQuery,
+	"TasksListQuery":        TasksListQuery,
+	"TechniciansListQuery":  TechniciansListQuery,
+	"TicketsGetQuery":       TicketsGetQuery,
+	"TicketsListQuery":      TicketsListQuery,
+	"UsersListQuery":        UsersListQuery,
+	"WorklogsListQuery":     WorklogsListQuery,
+}
+
+// scalarFields are the association/enum fields the live schema returns as
+// leaf scalars (5 confirmed by the reporter in #114; the rest are declared
+// scalar in internal/types and so must be requested bare too).
+var scalarFields = []string{
+	"accountManager", "primaryContact", "hqSite", "client", "site", "status",
+	"priority", "requester", "technician", "techGroup", "sla", "asset",
+	"category", "designation", "role", "team", "ticket",
+}
+
+// TestQueries_NoScalarSubSelections asserts no scalar field is requested with
+// an object sub-selection. A field followed by optional whitespace and "{" is
+// the exact shape that triggered SubSelectionNotAllowed.
+func TestQueries_NoScalarSubSelections(t *testing.T) {
+	for _, f := range scalarFields {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(f) + `\s*\{`)
+		for name, q := range allListQueries {
+			if re.MatchString(q) {
+				t.Errorf("%s requests scalar field %q with a sub-selection { ... } "+
+					"— this re-introduces the issue #114 SubSelectionNotAllowed bug", name, f)
+			}
+		}
+	}
+}
+
+// TestQueries_PreserveStructuralWrappers guards against an over-strip: the
+// listInfo pagination object and the nodes: entity alias must remain.
+func TestQueries_PreserveStructuralWrappers(t *testing.T) {
+	for name, q := range allListQueries {
+		isList := strings.HasSuffix(name, "ListQuery")
+		if isList && !strings.Contains(q, "listInfo {") {
+			t.Errorf("%s lost its `listInfo { ... }` pagination wrapper", name)
+		}
+		if isList && !strings.Contains(q, "nodes:") {
+			t.Errorf("%s lost its `nodes:` entity alias", name)
+		}
+	}
+}
+
+// captureRoundTripper records the last request body and returns a canned 200.
+type captureRoundTripper struct {
+	lastBody []byte
+	respBody string
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		c.lastBody, _ = io.ReadAll(req.Body)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(c.respBody)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+// TestClientsList_ScalarResponseRoundTrips proves the corrected ClientsListQuery
+// (a) sends accountManager/primaryContact/hqSite as bare scalars, and (b) a
+// scalar-shaped getClientList response parses cleanly via the normal Query path.
+func TestClientsList_ScalarResponseRoundTrips(t *testing.T) {
+	// A realistic SuperOps response: associations are JSON-scalar blobs, not
+	// typed objects; status is a String.
+	resp := `{"data":{"getClientList":{"nodes":[{` +
+		`"accountId":"1","name":"Acme","stage":"ACTIVE","status":"ACTIVE",` +
+		`"emailDomains":["acme.com"],` +
+		`"accountManager":{"userId":"u1","name":"Pat"},` +
+		`"primaryContact":{"userId":"u2","name":"Sam"},` +
+		`"hqSite":{"id":"s1","name":"HQ"}}],` +
+		`"listInfo":{"totalCount":1,"hasMore":false,"page":1,"pageSize":100}}}}`
+
+	rt := &captureRoundTripper{respBody: resp}
+	cfg := &config.Config{BaseURL: "http://superops.test"}
+	c := New(cfg, time.Second, 0)
+	c.HTTPClient = &http.Client{Transport: rt}
+	c.NoCache = true
+
+	data, err := c.Query(context.Background(), ClientsListQuery, map[string]any{"first": 100})
+	if err != nil {
+		t.Fatalf("Query returned error on a scalar response: %v", err)
+	}
+
+	// (a) the outgoing query must request the scalars bare.
+	sent := string(rt.lastBody)
+	for _, f := range []string{"accountManager", "primaryContact", "hqSite"} {
+		if !strings.Contains(sent, f) {
+			t.Errorf("outgoing query missing field %q", f)
+		}
+		if regexp.MustCompile(`\b` + f + `\s*\{`).MatchString(sent) {
+			t.Errorf("outgoing query still sub-selects %q (would 400 with SubSelectionNotAllowed)", f)
+		}
+	}
+
+	// (b) the scalar payload survives the normal decode path intact.
+	if !bytes.Contains(data, []byte("Acme")) {
+		t.Errorf("parsed data missing client name; got %s", data)
+	}
+	var probe struct {
+		GetClientList struct {
+			Nodes []json.RawMessage `json:"nodes"`
+		} `json:"getClientList"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		t.Fatalf("unmarshal getClientList: %v", err)
+	}
+	if len(probe.GetClientList.Nodes) != 1 {
+		t.Errorf("expected 1 node, got %d", len(probe.GetClientList.Nodes))
+	}
+}

--- a/skills/superops/handfixes.json
+++ b/skills/superops/handfixes.json
@@ -1,0 +1,35 @@
+{
+  "slug": "superops",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "Connector-specific edits a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every `contains` marker is still present and every `not_contains` marker is still absent, failing CI if a reprint regressed one.",
+  "handfixes": [
+    {
+      "id": "graphql-scalar-field-selections-issue-114",
+      "summary": "Stripped object sub-selections from association/enum fields in queries.go - the live SuperOps schema returns them as scalar leaf types (JSON/String), so the `{ ... }` sub-selections caused SubSelectionNotAllowed on every typed list/get command (issue #114, reported by @AvlCompCo).",
+      "why": "The CLI was minted from published docs without live introspection (auth-gated → HTTP 400); the queries.go header literally warned VERIFY-ON-FIRST-USE. The source spec.yaml declared every association field `type: string` (→ a scalar Go struct field in internal/types) yet ALSO carried a `selection:` key, so the generator emitted a sub-selection that contradicts its own scalar output contract. All 46 such fields across 18 entities are scalar in internal/types, so the bare-scalar form is the only consistent shape. A full reprint re-runs the generator against the un-fixed spec.yaml and would re-introduce the bug. The not_contains markers below ban each buggy shape; queries_issue114_test.go is the behavioral guard.",
+      "status": "active",
+      "spec_encode_followup": "In the press source spec.yaml (~/printing-press/library/superops/spec.yaml, types: section), remove the `selection:` key from every association/enum field (status, priority, client, site, requester, technician, techGroup, sla, accountManager, primaryContact, hqSite, asset, category, designation, role, team, ticket). They are JSON/String scalars, not objects. Done on the press copy 2026-06-16; re-confirm before any reprint.",
+      "asserts": [
+        {"file": "cli/internal/client/queries_issue114_test.go", "contains": "TestQueries_NoScalarSubSelections", "min_count": 1},
+        {"file": "cli/internal/client/queries.go", "contains": "listInfo { totalCount hasMore page pageSize }", "min_count": 14},
+        {"file": "cli/internal/client/queries.go", "not_contains": "accountManager { userId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "primaryContact { userId name email }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "hqSite { id name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "client { accountId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "site { id name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "status { statusId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "priority { priorityId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "requester { userId name email }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "technician { userId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "techGroup { groupId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "sla { slaId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "asset { assetId name hostName }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "category { categoryId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "designation { designationId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "role { roleId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "team { teamId name }"},
+        {"file": "cli/internal/client/queries.go", "not_contains": "ticket { ticketId displayId }"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Typed `list`/`get` commands on the SuperOps connector (`clients list`, `assets list`, `tickets list`, and every other entity) failed with GraphQL `SubSelectionNotAllowed` validation errors. The hardcoded queries requested association/enum fields with object sub-selections, e.g.:

```graphql
accountManager { userId name }
client { accountId name }
status { statusId name }
```

but the live SuperOps schema returns those fields as **scalar leaf types** (JSON / String), so the server rejected the sub-selection. This strips the sub-selections so each field is requested as the bare scalar it is.

## Why this is the correct (and complete) fix

The CLI was minted from published docs without live introspection (auth-gated → HTTP 400), and the `queries.go` header literally warned `VERIFY-ON-FIRST-USE`. The root cause is an internal contradiction the generator produced from the source spec:

- **Every** one of these 46 association/enum fields (across all 18 entities) is already declared a scalar `string` (or `json.RawMessage`) in `internal/types/types.go` — the generator's own output contract.
- Yet `queries.go` requested them as objects with sub-selections.

So the bare-scalar form is the only shape consistent with the structs the responses unmarshal into. The reporter confirmed 5 fields against a live tenant; the remaining fields are proven-scalar by the type contract. Stripping requires **zero type-layer changes**.

## Changes

- `skills/superops/cli/internal/client/queries.go` — strip 46 spurious object sub-selections (list + get queries); `nodes:` aliases and `listInfo { … }` pagination wrappers preserved.
- `skills/superops/cli/internal/client/queries_issue114_test.go` — **new** regression test: a static guard that no scalar field is sub-selected + the `listInfo`/`nodes` wrappers survive, plus a fixture round-trip that captures the outgoing query and parses a scalar-shaped `getClientList` response.
- `skills/superops/handfixes.json` — **new** reprint-survival ledger that bans every buggy sub-selection shape and pins the regression test (a full reprint re-runs the generator against the un-fixed spec). The source `spec.yaml`'s spurious `selection:` keys are removed on the press copy (recorded as `spec_encode_followup`).
- `skills/superops/CHANGELOG.md` — `0.1.1` Fixed entry crediting the reporter.

## Verification

- `go build ./...` and `go test ./...` green (incl. the new `queries_issue114_test.go`; the guard is proven non-vacuous — it fires on the old buggy shape and not the fixed shape).
- Deterministic security gate (`check_security_gate.py --base origin/main`): **0 P1**; the P2s are pre-existing baseline gosec G104s + a transitive presence-only osv finding, none introduced here.
- Adversarial security review (Codex + a fresh-context reviewer): no findings — the change strictly narrows what is requested, touches no auth/TLS/network/dependency, and adds no exec/secret paths.

**Closure = the reporter's re-test against a live tenant** (offline introspection is auth-gated, so the live schema's acceptance of every field can only be confirmed there).

Fixes #114. Reported by @AvlCompCo — thank you for the precise, well-scoped report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
