### PR TITLE
chore(security-gate): suppress vetted gosec G101 FP in servosity store.go (#78)

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -57,6 +57,11 @@
       "reason": "FLEET (generated). MkdirAll 0o755 on the local per-user data dir. Low risk on a single-user machine. FOLLOW-UP: tighten to 0700 at the press level (the local mirror can hold financial data); tracked as a press hardening, not a blocker."
     },
     {
+      "file": "skills/servosity/cli/internal/store/store.go",
+      "rule": "G101",
+      "reason": "servosity (generated). gosec G101 LOW-confidence false-positive on the variable NAME 'resourceParentKeyColumns' (the 'Key' substring); the value is a generated map of resource table -> parent foreign-key COLUMN names (e.g. agent_logs -> agent_sessions_id), not credential material. Same class as the auth.go/client.go G101 'tokenURL' FPs (#109). Repo-relative (scoped to servosity only). Surfaced by servosity #78."
+    },
+    {
       "file": "cli/internal/cli/deliver.go",
       "rule": "G301",
       "reason": "FLEET (generated). MkdirAll 0o755 on a user-chosen output directory. Same low-risk local rationale + 0700 press follow-up as store.go G301."


### PR DESCRIPTION
## What

Adds one **base-owned** suppression entry to `tools/maintainer/security_suppressions.json`:

```json
{
  "file": "skills/servosity/cli/internal/store/store.go",
  "rule": "G101",
  "reason": "servosity (generated). gosec G101 LOW-confidence false-positive on the variable NAME 'resourceParentKeyColumns' (the 'Key' substring); the value is a generated map of resource table -> parent foreign-key COLUMN names (e.g. agent_logs -> agent_sessions_id), not credential material. Same class as the auth.go/client.go G101 'tokenURL' FPs (#109). Repo-relative (scoped to servosity only). Surfaced by servosity #78."
}
```

## Why this is a false positive

`gosec` G101 fires at **LOW confidence** on the *identifier* `resourceParentKeyColumns` (the `Key` substring), not on any literal secret. The flagged value is a generated lookup table mapping resource tables → their parent foreign-key **column** names:

```go
var resourceParentKeyColumns = map[string]string{
    "agent_logs":           "agent_sessions_id",
    "install_imagemanager": "agent_sessions_id",
    ...
}
```

No credential material. This is the **same class** as the `auth.go` / `client.go` G101 `tokenURL` false positives vetted and suppressed in #109.

## Scope / safety

- `store.go` is **generated** and byte-identical to the released servosity CLI; this baseline FP is not introduced by any code change.
- Entry is **repo-relative** → scoped to **servosity only** (least-privilege), not fleet-wide.
- Verified locally: with this entry, `check_security_gate.py --slug servosity` returns `[pass] 0 P1 / 15 findings` (down from `1 P1`).

## Unblocks

The servosity #78 auth fix (#122), which does not touch `store.go`. After this merges, #122 rebases → its `security-gate` check goes green.

Requires CODEOWNER approval (this file is intentionally not self-grantable from a feature PR).