### PR TITLE
ci(security-gate): pre-warm via go vet + 600s scanner headroom (fixes axcient gosec timeout)

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -70,25 +70,25 @@ jobs:
           python3 -m pip install --quiet semgrep || echo "semgrep install failed (non-fatal)"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      - name: Pre-warm module + build cache for changed connectors
+      - name: Pre-warm scanner caches for changed connectors
         if: steps.scope.outputs.relevant == 'true'
         env:
           SLUGS: ${{ steps.scope.outputs.slugs }}
         run: |
           set -uo pipefail
-          # gosec's go/packages loader downloads + compiles each connector before scanning.
-          # On a cold runner the FIRST (heaviest) connector's dependency fetch + build can
-          # exceed gosec's 300s budget and fail-close as a scanner timeout (exit 124) - NOT
-          # a real finding, just an infra flake that blocks heavy-dep connectors (e.g.
-          # axcient: surf + quic-go + utls + modernc/sqlite). Pre-build every changed
-          # connector here so the module AND build caches are warm; gosec then completes in
-          # ~1s (as it does locally). `go build` runs no connector code (pure Go, CGO off,
-          # no `go generate`), so it cannot weaken the gate - it only removes the cold-start
-          # cost from the scanners' timeout budget.
+          # gosec + govulncheck load each connector through golang.org/x/tools/go/packages.
+          # On a cold runner the FIRST (heaviest) connector's load - download + typecheck of
+          # a large dependency tree (e.g. axcient: surf + quic-go + utls + modernc/sqlite ->
+          # modernc/libc) - can exceed a scanner's timeout and fail-close as scanner-error
+          # (exit 124), which is NOT a real finding. `go vet ./...` drives the SAME
+          # go/packages loader, so it warms the module + export-data caches the scanners
+          # reuse. (A plain `go build` warms only the compile cache, not the go/packages
+          # export data - which is the actual cold cost, why an earlier build-based pre-warm
+          # did not help.) vet runs no connector code, so it cannot weaken the gate.
           for s in $SLUGS; do
             if [ -f "skills/$s/cli/go.mod" ]; then
               echo "::group::pre-warm $s"
-              (cd "skills/$s/cli" && CGO_ENABLED=0 go build ./...) || echo "pre-warm failed for $s (non-fatal)"
+              (cd "skills/$s/cli" && go vet ./...) >/dev/null 2>&1 || echo "pre-warm vet for $s reported issues (non-fatal)"
               echo "::endgroup::"
             fi
           done

--- a/tools/maintainer/check_security_gate.py
+++ b/tools/maintainer/check_security_gate.py
@@ -451,7 +451,12 @@ def scan_external(slug: str, suppress: set[tuple[str, str]],
         # HEALTHY connectors while still analyzing them (30+ Issues), so gating on it is a
         # fleet-wide false-RED. A genuine build break is still caught by govulncheck
         # (fail-closed) and the always-on builtin pattern scan.
-        code, out, err = run(["gosec", "-quiet", "-fmt", "json", "./..."], cwd=str(mod), timeout=300)
+        # 600s (not 300): gosec loads the whole module through go/packages; a cold load of
+        # a heavy dep tree (e.g. axcient: surf + quic-go + utls + modernc/libc) on a 2-core
+        # CI runner exceeds 300s and fail-closes as a scanner-error (exit 124) - an infra
+        # flake, not a finding. The go-vet pre-warm step covers the cold path; this headroom
+        # is the backstop so a slow runner can't false-RED a healthy connector.
+        code, out, err = run(["gosec", "-quiet", "-fmt", "json", "./..."], cwd=str(mod), timeout=600)
         gj = None
         try:
             gj = json.loads(out or "{}")
@@ -473,7 +478,10 @@ def scan_external(slug: str, suppress: set[tuple[str, str]],
         # govulncheck never once fired a P1 (verified: a known-REACHABLE x/text vuln
         # exits 0 under -format json, 3 under text mode). Any OTHER nonzero is a
         # load/build/usage error and fails CLOSED under --require-scanners.
-        code, out, err = run(["govulncheck", "./..."], cwd=str(mod), timeout=300)
+        # 600s (not 300): same go/packages-driven cold-load cost as gosec on heavy-dep
+        # connectors; give the reachability analysis matching headroom so a slow runner
+        # can't fail-close a healthy connector.
+        code, out, err = run(["govulncheck", "./..."], cwd=str(mod), timeout=600)
         if code == 3:
             ev = next((ln.strip() for ln in out.splitlines() if ln.strip().startswith("Vulnerability #")),
                       "govulncheck: a vulnerability is reachable from this module's code.")


### PR DESCRIPTION
## Why a second infra PR (follow-up to #125)

#125's build-based pre-warm **did not fix** axcient's `gosec did not complete (timeout, exit 124)`. Diagnosed it properly this time:

- **Not compilation / CGO.** A `CGO_ENABLED=1` build reuses a `CGO_ENABLED=0` cache in ~1s locally, so the build cache is fine and shared.
- **The real cost is gosec's `go/packages` load** — download + typecheck of axcient's large dep tree (`surf` + `quic-go` + `utls` + `modernc/sqlite` → `modernc/libc`) on a 2-core CI runner. A plain `go build` warms the **compile** cache, not the **go/packages export-data** cache gosec actually reuses — so gosec still paid the full cold cost inside its 300s budget. `connectwise-control` passed only because axcient's run had already warmed the shared go/packages cache.

## Fix (two changes, neither weakens the gate)

1. **Pre-warm with `go vet ./...`** — drives the **same** `go/packages` loader as gosec, so the heaviest connector's cold load happens in the uncapped pre-warm step and the scanners reuse the warm export-data cache.
2. **Raise gosec + govulncheck timeouts 300 → 600s** — backstop so a slow runner can't false-RED a healthy connector even if the pre-warm under-covers.

`go vet` runs no connector code, and a non-completing required scanner still **fail-closes** (just with more patience). Gate still `[pass] 0 P1` locally on axcient.

## Expected-red by design

The scope step hard-fails any PR that edits `check_security_gate.py` / `security-gate.yml`, so this PR's own `security-gate` check is **red by design** and must be reviewed + merged by CODEOWNERS `@Servosity`.

Unblocks #120 (the osv durable-fix dep bump for #112). After merge I rebase #120 → its gate re-runs green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased security scanner execution timeouts to reduce false CI failures caused by slow module loads.
  * Improved build cache pre-warming strategy during security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->