### PR TITLE
fix(axcient): MCP forwards the per-command client fleet filter (#130)

### DIFF
--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.6] - unreleased
+
+### Fixed
+- MCP server now forwards the `client` fleet filter to the underlying CLI. The
+  client-scoped fleet commands (`health`, `compliance`, `rpo`, `appliance-map`)
+  advertise a `client` parameter in their MCP tool schema but the shell-out layer
+  silently dropped it, so every MCP call returned the whole fleet regardless of the
+  value passed. The CLI binary applied `--client` correctly, only the MCP path did
+  not. Cause: the generated `blockedRootFlags` denylist (meant for root
+  credential/base-url/config/delivery flags) included `client`, but `client` is not
+  a root flag on this connector: it is a per-command Int64 fleet filter. Removed
+  `client` from the denylist; the genuine control-plane flags
+  (`base-url`/`token`/`config`/`deliver`/`profile`/`args`) remain blocked. Added a
+  regression test asserting `client` forwards as `--client <id>` while control-plane
+  flags stay dropped. (reported by @Xenith-B, #130)
+
 ## [0.2.5] - unreleased
 
 ### Fixed

--- a/skills/axcient/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/shellout.go
@@ -45,14 +45,24 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
-// caller swap auth credentials, redirect the API base URL, select a different
-// per-client filesystem, load a malicious config file, or change the delivery
-// target, all of which sit outside the per-command surface the agent is
-// supposed to be calling.
+// caller swap auth credentials, redirect the API base URL, load a malicious
+// config file, or change the delivery target, all of which sit outside the
+// per-command surface the agent is supposed to be calling.
+//
+// Hand-fix (issue #130, reported by @Xenith-B): `client` is intentionally NOT
+// blocked on this connector. There is no root/persistent `--client` flag here;
+// `client` is a per-command Int64 fleet filter (`--client <id>`, 0 = all
+// clients) defined locally on health/compliance/rpo/appliance-map. The press
+// template blocks `client` by name on the assumption it selects a per-client
+// filesystem/credential scope; that root flag does not exist in axcient, so
+// blocking it protected nothing and silently discarded the legitimate filter
+// (advertised in the tool schema, then dropped), unscoping every MCP fleet call
+// to the whole fleet. The genuine control-plane flags below stay blocked.
+// DO NOT re-add a "client" entry on reprint. Durable fix tracked upstream:
+// make this blocklist context-aware (block only inherited/root flags).
 var blockedRootFlags = map[string]bool{
 	"args":     true,
 	"base-url": true,
-	"client":   true,
 	"config":   true,
 	"deliver":  true,
 	"profile":  true,

--- a/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
@@ -49,13 +49,15 @@ func TestSplitShellArgs(t *testing.T) {
 // flag in the structured args map (instead of the free-form "args"
 // string), the root flags listed in blockedRootFlags must be dropped
 // before they reach exec.CommandContext. A regression here would let a
-// caller redirect --base-url, swap --token, switch --client filesystems, or
-// load a malicious --config.
+// caller redirect --base-url, swap --token, or load a malicious --config.
+//
+// Note: `client` is deliberately absent from blockedRootFlags on this
+// connector: it is a per-command fleet filter, not a control-plane flag
+// (see TestCliArgsFromMCP_ForwardsClientFilter and issue #130).
 func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
 		"args":     "contacts",
 		"base-url": "https://evil.example.com",
-		"client":   "attacker-client",
 		"config":   "/tmp/evil.yaml",
 		"deliver":  "fd:3",
 		"profile":  "attacker",
@@ -68,12 +70,38 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
-	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--profile", "--token", "--args"} {
+	for _, blocked := range []string{"--base-url", "--config", "--deliver", "--profile", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
 				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)
 			}
 		}
+	}
+}
+
+// TestCliArgsFromMCP_ForwardsClientFilter is the regression oracle for issue
+// #130: the per-command `client` fleet filter on health/compliance/rpo/
+// appliance-map (a local Int64 flag, surfaced to MCP as a number → float64)
+// must forward to the CLI as `--client <id>`. Before the fix, `client` sat in
+// blockedRootFlags and was silently dropped, so every MCP fleet call ran
+// unscoped (whole fleet) regardless of the value passed. This pins that the
+// filter now reaches exec.CommandContext while the control-plane flags above
+// stay blocked.
+func TestCliArgsFromMCP_ForwardsClientFilter(t *testing.T) {
+	got := cliArgsFromMCP(map[string]any{"client": float64(42)})
+	want := []string{"--client", "42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("client filter not forwarded: got %v, want %v", got, want)
+	}
+	// Control-plane flags must still be dropped even alongside a client filter.
+	mixed := cliArgsFromMCP(map[string]any{"client": float64(7), "token": "stolen", "base-url": "https://evil.example.com"})
+	for _, tok := range mixed {
+		if tok == "--token" || tok == "--base-url" {
+			t.Errorf("control-plane flag leaked alongside client filter: %q in %v", tok, mixed)
+		}
+	}
+	if !reflect.DeepEqual(mixed, []string{"--client", "7"}) {
+		t.Fatalf("mixed args: got %v, want [--client 7]", mixed)
 	}
 }
 

--- a/skills/axcient/handfixes.json
+++ b/skills/axcient/handfixes.json
@@ -150,6 +150,18 @@
         {"file": "cli/internal/cli/sync.go", "contains": "flattenRestorePointGroups", "min_count": 2},
         {"file": "cli/internal/cli/restore_point_sync_wiring_test.go", "contains": "TestSyncDependentResource_RestorePointFlattensVaultGroupsAndPopulates", "min_count": 1}
       ]
+    },
+    {
+      "id": "mcp-client-filter-forward",
+      "summary": "MCP shell-out must forward the per-command `client` fleet filter; the generic blockedRootFlags denylist wrongly dropped it",
+      "why": "health/compliance/rpo/appliance-map define `--client <id>` as a command-local Int64 fleet filter (0 = all clients). The cobratree MCP shell-out advertises it (toolOptionsForFlags walks NonInheritedFlags -> WithNumber) but cliArgsFromMCP discarded it because the press template hardcodes \"client\" in blockedRootFlags - a denylist meant for root credential/base-url/config/delivery flags. axcient has NO root/persistent --client flag, so the block protected nothing and silently unscoped every MCP fleet call to the whole fleet (issue #130, reported by @Xenith-B). Removed \"client\" from blockedRootFlags; base-url/token/config/deliver/profile/args stay blocked. Added TestCliArgsFromMCP_ForwardsClientFilter asserting {client:42} -> --client 42 while control-plane flags stay dropped.",
+      "status": "active",
+      "spec_encode_followup": "Belongs in the press: make blockedRootFlags context-aware - block a flag only when it is a genuine root/persistent (inherited) flag on the command, not a command-local flag of the same name. Printing-press retro filed alongside #130.",
+      "asserts": [
+        {"file": "cli/internal/mcp/cobratree/shellout.go", "contains": "Hand-fix (issue #130", "min_count": 1},
+        {"file": "cli/internal/mcp/cobratree/shellout.go", "not_contains": "\"client\":   true"},
+        {"file": "cli/internal/mcp/cobratree/shellout_test.go", "contains": "TestCliArgsFromMCP_ForwardsClientFilter", "min_count": 1}
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #130 (reported by @Xenith-B). The `axcient` MCP server advertised a `client` parameter on the fleet commands (`health`, `compliance`, `rpo`, `appliance-map`) but silently dropped it, so every MCP call returned the whole fleet regardless of the value passed — while the CLI binary applied `--client` correctly. The value was being taken in and discarded before the command ran.

## Root cause
The MCP shell-out layer walks each command's flags to build the tool schema (`toolOptionsForFlags` → `cmd.NonInheritedFlags()`), so the command-local `--client` Int64 filter **is** advertised. But `cliArgsFromMCP` then drops any key listed in the generated `blockedRootFlags` denylist, which hardcodes `"client"`. That denylist is meant for genuine root credential / base-url / config / delivery flags — but axcient has **no** root/persistent `--client` flag (only command-local `Int64` fleet filters on the four fleet commands), so blocking it protected nothing and unscoped every MCP fleet call.

## Fix
- Remove `"client"` from `blockedRootFlags` (`cli/internal/mcp/cobratree/shellout.go`). The genuine control-plane flags (`base-url`, `token`, `config`, `deliver`, `profile`, `args`) remain blocked.
- Update the control-plane-injection guard test and add `TestCliArgsFromMCP_ForwardsClientFilter` — the offline regression oracle, asserting `{client: 42}` → `--client 42` while `--token`/`--base-url` stay dropped even when supplied alongside it. Verified it **fails** on the pre-fix code.
- Record a hand-fix ledger entry (`mcp-client-filter-forward`) so a reprint can't silently re-block `client`. Durable fix tracked upstream: make the denylist context-aware (block only genuinely inherited/root flags).

## Impact
Bug-fix-only — restores already-advertised, documented behavior. No new flag/command/output/permission. Patch release → `axcient-v0.2.6`.

## Verification
- `go test ./...` green; `go vet` clean; both `axcient-cli` and `axcient-mcp` binaries build.
- `check_handfixes.py --slug axcient` PASS (new ledger entry verified).
- Local security gate: `check_security_gate.py --base origin/main` → **0 P1**; fresh-context adversarial review → **PASS (0 P1)**; second-model (codex) adversarial review in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an MCP regression where the per-command client fleet filter was not forwarded, causing MCP calls to run unscoped. The client filter now correctly reaches the underlying CLI, while existing control-plane restrictions remain enforced.

* **Tests**
  * Added a regression test asserting MCP `client` values are passed through as `--client <id>`, and verified control-plane flags remain blocked even when a client filter is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->