### PR TITLE
fix(ninjaone): correctly store + paginate device-scoped /v2/queries/* reports (#136)

### DIFF
--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -4,7 +4,39 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.3] - unreleased
+
+### Fixed
+- `sync` now stores correct rows for the device-scoped `/v2/queries/*` report
+  endpoints. Every row in this family is keyed by its `deviceId` first, so rows no
+  longer collapse. This fixes two distinct symptoms:
+  - The endpoints the reporter hit - `queries-antivirus-status`,
+    `queries-device-health`, `queries-network-interfaces`,
+    `queries-logged-on-users`, `queries-policy-overrides`,
+    `queries-raid-controllers`, `queries-raid-drives` - return objects with no
+    top-level `id`, so they cached **zero** rows (`all_items_failed_id_extraction`).
+  - A second, broader set silently dropped rows **across devices** because the
+    generic key fell back to a patch `id` or a `name`: `queries-os-patches`,
+    `queries-os-patch-installs`, `queries-software-patches`,
+    `queries-software-patch-installs`, `queries-software`,
+    `queries-operating-systems`, `queries-computer-systems`, `queries-processors`,
+    `queries-volumes`, `queries-windows-services`, `queries-antivirus-threats`
+    (e.g. every device running "Windows 11" collapsed to one stored row).
+  Each row now keys on `deviceId` plus a per-row discriminator where the resource
+  returns many rows per device (`productName`, `threatId`, `interfaceIndex`,
+  `userName`, `controllerIndex`, `driveId`, the patch `id`, or `name`); single-row
+  reports key on `deviceId` alone. Offline SQL, full-text `search`, and rollups
+  like `av-sweep`, `software-audit`, `patch-compliance`, and `os-eol` now see the
+  full per-device data. (The four `queries-custom-fields*` report variants are
+  tracked separately - their row shape is not yet confirmed, see #137.)
+- `sync` now follows the **object-valued** pagination cursor these same
+  `/v2/queries/*` endpoints return (`"cursor": {"name": "<token>", …}`). The loop
+  previously read only a string cursor, so it stopped after the first page and
+  capped each resource at 100 rows (`pagination_cursor_missing`); it now follows
+  the `cursor.name` token. String-cursor endpoints are unaffected.
+  Thanks to @Xenith-B for the report (#136).
+
+## [0.1.2]
 
 ### Fixed
 - `sync` now fetches **every** page for NinjaOne's after-id (keyset) endpoints

--- a/skills/ninjaone/cli/internal/cli/queries_cursor_test.go
+++ b/skills/ninjaone/cli/internal/cli/queries_cursor_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Regression tests for issue #136 (pagination half): NinjaOne /v2/queries/*
+// returns an OBJECT-valued cursor, "cursor":{"name":"<token>",...}. The old
+// findCursorInMap only unmarshalled a string cursor, so the next-page token was
+// never found and sync stopped after the first 100 rows (pagination_cursor_missing).
+// extractPageItems must now surface cursor.name as the next cursor, while plain
+// string cursors keep working unchanged.
+
+func TestExtractPageItemsFollowsObjectCursor(t *testing.T) {
+	data := json.RawMessage(`{
+		"cursor": {"name":"PAGE_TOKEN_2","offset":0,"count":"250","expires":"2026-01-01T00:00:00Z"},
+		"results": [
+			{"deviceId":1001,"productName":"SentinelOne"},
+			{"deviceId":1002,"productName":"Microsoft Defender Antivirus"}
+		]
+	}`)
+	items, nextCursor, hasMore := extractPageItems(data, "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if nextCursor != "PAGE_TOKEN_2" {
+		t.Errorf("want nextCursor PAGE_TOKEN_2 (cursor.name), got %q - pagination would truncate at 100 rows", nextCursor)
+	}
+	if !hasMore {
+		t.Errorf("want hasMore=true when a next cursor is present")
+	}
+}
+
+// A terminal page whose cursor object carries no usable token must not advance.
+func TestExtractPageItemsObjectCursorEmptyTokenStops(t *testing.T) {
+	data := json.RawMessage(`{"cursor":{"offset":250,"count":"250"},"results":[{"deviceId":1003}]}`)
+	_, nextCursor, _ := extractPageItems(data, "cursor")
+	if nextCursor != "" {
+		t.Errorf("want empty nextCursor when cursor object has no token, got %q", nextCursor)
+	}
+}
+
+// Regression guard: a plain STRING cursor must still resolve (object-cursor
+// support runs only after the string attempt fails).
+func TestExtractPageItemsStringCursorUnaffected(t *testing.T) {
+	data := json.RawMessage(`{"next_cursor":"STRING_TOKEN","results":[{"id":1}]}`)
+	_, nextCursor, hasMore := extractPageItems(data, "cursor")
+	if nextCursor != "STRING_TOKEN" {
+		t.Errorf("string cursor regressed: want STRING_TOKEN, got %q", nextCursor)
+	}
+	if !hasMore {
+		t.Errorf("want hasMore=true for a present string cursor")
+	}
+}
+
+func TestCursorTokenFromObject(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"ninjaone name field", `{"name":"abc","offset":0}`, "abc"},
+		{"next_cursor field", `{"next_cursor":"xyz"}`, "xyz"},
+		{"empty name", `{"name":"","offset":0}`, ""},
+		{"no token fields", `{"offset":0,"count":"5"}`, ""},
+		{"not an object", `"a-plain-string"`, ""},
+		{"numeric token ignored", `{"name":12345}`, ""},
+	}
+	for _, c := range cases {
+		if got := cursorTokenFromObject(json.RawMessage(c.raw)); got != c.want {
+			t.Errorf("%s: cursorTokenFromObject(%s) = %q, want %q", c.name, c.raw, got, c.want)
+		}
+	}
+}

--- a/skills/ninjaone/cli/internal/cli/sync.go
+++ b/skills/ninjaone/cli/internal/cli/sync.go
@@ -1450,6 +1450,42 @@ func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
 		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
 			return s
 		}
+		// Object-valued cursor (#136): NinjaOne /v2/queries/* paginates via
+		// "cursor":{"name":"<token>","offset":0,"count":"N","expires":...} - an
+		// object, not a string, so the scalar unmarshal above fails and the
+		// next-page token was never found (the loop stopped after 100 rows and
+		// emitted pagination_cursor_missing). Descend and take the first
+		// non-empty string token field. This runs ONLY after the string attempt
+		// fails, so APIs whose cursor is a plain string are unaffected.
+		if c := cursorTokenFromObject(raw); c != "" {
+			return c
+		}
+	}
+	return ""
+}
+
+// cursorTokenFromObject extracts a next-page token from an object-valued cursor
+// (e.g. NinjaOne's {"name":...}). It probes the common token field names in a
+// fixed order and returns the first non-empty string; nested non-string values
+// are ignored. Returns "" when raw is not an object or holds no string token.
+func cursorTokenFromObject(raw json.RawMessage) string {
+	var inner map[string]json.RawMessage
+	if json.Unmarshal(raw, &inner) != nil {
+		return ""
+	}
+	// Probe only genuine next-page-token field names. NinjaOne uses "name";
+	// the rest are standard cursor-token spellings. Deliberately excludes
+	// generic keys like "id"/"after" that commonly name non-paging fields, so
+	// an object cursor carrying an unrelated id is never mistaken for a token.
+	for _, k := range []string{"name", "next_cursor", "nextCursor", "next", "cursor", "token"} {
+		v, ok := inner[k]
+		if !ok {
+			continue
+		}
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			return s
+		}
 	}
 	return ""
 }

--- a/skills/ninjaone/cli/internal/store/queries_composite_key_test.go
+++ b/skills/ninjaone/cli/internal/store/queries_composite_key_test.go
@@ -1,0 +1,142 @@
+package store
+
+import "testing"
+
+// Regression tests for issue #136: the /v2/queries/* report endpoints return
+// objects with no top-level id, so ExtractResourceID returned "" and every row
+// was skipped (all_items_failed_id_extraction -> zero rows stored). The fix
+// keys these device-scoped resources on deviceId, plus a secondary
+// discriminator for the resources that return many rows per device. These tests
+// drive the REAL production decode path (DecodeJSONObject, UseNumber) so the
+// numeric-id formatting and composite-key joins are exercised exactly as sync
+// does, not via hand-built maps.
+
+func decodeOrFatal(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	obj, err := DecodeJSONObject([]byte(raw))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return obj
+}
+
+func storageKey(t *testing.T, resource, raw string) string {
+	t.Helper()
+	obj := decodeOrFatal(t, raw)
+	id := ExtractResourceID(resource, obj)
+	if id == "" {
+		t.Fatalf("%s: ExtractResourceID returned \"\" (bug #136 not fixed)", resource)
+	}
+	return resourceStorageID(resource, id, obj)
+}
+
+// Every affected queries-* resource must now yield a non-empty primary id.
+func TestQueriesPrimaryIDResolves(t *testing.T) {
+	cases := map[string]string{
+		"queries-antivirus-status":   `{"productName":"SentinelOne","productState":"ON","deviceId":1001}`,
+		"queries-device-health":      `{"healthStatus":"UNHEALTHY","criticalVulnerabilityCount":6,"deviceId":1001}`,
+		"queries-network-interfaces": `{"deviceId":1001,"interfaceIndex":"4","interfaceName":"NDIS"}`,
+		"queries-logged-on-users":    `{"deviceId":1001,"userName":"acme\\jdoe","logonTime":1700000000}`,
+		"queries-policy-overrides":   `{"deviceId":1001,"overrides":{"foo":"bar"}}`,
+		"queries-raid-controllers":   `{"deviceId":1001,"controllerIndex":0,"model":"PERC"}`,
+		"queries-raid-drives":        `{"deviceId":1001,"driveId":"naa.500","controllerIndex":0}`,
+	}
+	for resource, raw := range cases {
+		if id := ExtractResourceID(resource, decodeOrFatal(t, raw)); id != "1001" {
+			t.Errorf("%s: want primary id 1001, got %q", resource, id)
+		}
+	}
+}
+
+// Multi-row-per-device resources must produce DISTINCT storage keys so rows do
+// not collapse (clobber) onto a single deviceId.
+func TestQueriesCompositeKeysDoNotCollide(t *testing.T) {
+	type pair struct{ resource, a, b string }
+	pairs := []pair{
+		{"queries-antivirus-status",
+			`{"deviceId":1001,"productName":"SentinelOne"}`,
+			`{"deviceId":1001,"productName":"Microsoft Defender Antivirus"}`},
+		{"queries-network-interfaces",
+			`{"deviceId":1001,"interfaceIndex":"4"}`,
+			`{"deviceId":1001,"interfaceIndex":"7"}`},
+		{"queries-logged-on-users",
+			`{"deviceId":1001,"userName":"acme\\jdoe"}`,
+			`{"deviceId":1001,"userName":"acme\\asmith"}`},
+		{"queries-raid-controllers",
+			`{"deviceId":1001,"controllerIndex":0}`,
+			`{"deviceId":1001,"controllerIndex":1}`},
+		{"queries-raid-drives",
+			`{"deviceId":1001,"driveId":"naa.500"}`,
+			`{"deviceId":1001,"driveId":"naa.501"}`},
+	}
+	for _, p := range pairs {
+		ka := storageKey(t, p.resource, p.a)
+		kb := storageKey(t, p.resource, p.b)
+		if ka == kb {
+			t.Errorf("%s: two rows on one device collided on key %q (rows would clobber)", p.resource, ka)
+		}
+		// The deviceId must be the leading key segment.
+		if want := "1001"; len(ka) < len(want) || ka[:len(want)] != want {
+			t.Errorf("%s: composite key %q does not lead with deviceId %q", p.resource, ka, want)
+		}
+	}
+}
+
+// Single-row-per-device resources key on deviceId alone (no discriminator).
+func TestQueriesSingleRowResourcesKeyOnDeviceID(t *testing.T) {
+	for _, resource := range []string{
+		"queries-device-health", "queries-policy-overrides",
+		"queries-operating-systems", "queries-computer-systems",
+	} {
+		raw := `{"deviceId":1001,"name":"Windows 11","healthStatus":"OK","overrides":{}}`
+		if got := storageKey(t, resource, raw); got != "1001" {
+			t.Errorf("%s: want bare deviceId key 1001, got %q", resource, got)
+		}
+	}
+}
+
+// The core #136-adversarial-review regression: report rows that share an id or
+// a name ACROSS devices must NOT collapse to one stored row. Before the fix,
+// queries-os-patches keyed on the patch `id` (same KB on every device -> one
+// row) and queries-operating-systems keyed on `name` ("Windows 11" everywhere
+// -> one row). deviceId must now lead every key so two devices never collide.
+func TestQueriesNoCrossDeviceCollapse(t *testing.T) {
+	type c struct{ resource, dev1, dev2 string }
+	cases := []c{
+		// same patch id on two devices
+		{"queries-os-patches", `{"deviceId":1001,"id":"KB5034123"}`, `{"deviceId":2002,"id":"KB5034123"}`},
+		{"queries-software-patches", `{"deviceId":1001,"id":"PCH-9"}`, `{"deviceId":2002,"id":"PCH-9"}`},
+		// same OS / CPU / volume / service name on two devices
+		{"queries-operating-systems", `{"deviceId":1001,"name":"Windows 11"}`, `{"deviceId":2002,"name":"Windows 11"}`},
+		{"queries-processors", `{"deviceId":1001,"name":"Intel i7"}`, `{"deviceId":2002,"name":"Intel i7"}`},
+		{"queries-volumes", `{"deviceId":1001,"name":"C:"}`, `{"deviceId":2002,"name":"C:"}`},
+		{"queries-windows-services", `{"deviceId":1001,"name":"Spooler"}`, `{"deviceId":2002,"name":"Spooler"}`},
+		{"queries-software", `{"deviceId":1001,"name":"Chrome"}`, `{"deviceId":2002,"name":"Chrome"}`},
+		{"queries-antivirus-threats", `{"deviceId":1001,"threatId":7}`, `{"deviceId":2002,"threatId":7}`},
+		{"queries-computer-systems", `{"deviceId":1001,"name":"HOST"}`, `{"deviceId":2002,"name":"HOST"}`},
+	}
+	for _, tc := range cases {
+		k1 := storageKey(t, tc.resource, tc.dev1)
+		k2 := storageKey(t, tc.resource, tc.dev2)
+		if k1 == k2 {
+			t.Errorf("%s: rows on devices 1001 and 2002 collapsed to one key %q (cross-device data loss)", tc.resource, k1)
+		}
+		if want := "1001"; len(k1) < len(want) || k1[:len(want)] != want {
+			t.Errorf("%s: key %q does not lead with deviceId 1001", tc.resource, k1)
+		}
+		if want := "2002"; len(k2) < len(want) || k2[:len(want)] != want {
+			t.Errorf("%s: key %q does not lead with deviceId 2002", tc.resource, k2)
+		}
+	}
+}
+
+// Large integer deviceIds (JSON numbers) must format as plain integers, never
+// scientific notation or a trailing .0 - they are the storage key.
+func TestQueriesNumericDeviceIDFormatting(t *testing.T) {
+	raw := `{"deviceId":123456789,"productName":"SentinelOne"}`
+	key := storageKey(t, "queries-antivirus-status", raw)
+	const wantPrefix = "123456789"
+	if len(key) < len(wantPrefix) || key[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("numeric deviceId mis-formatted: key=%q want prefix %q", key, wantPrefix)
+	}
+}

--- a/skills/ninjaone/cli/internal/store/store.go
+++ b/skills/ninjaone/cli/internal/store/store.go
@@ -4303,14 +4303,46 @@ var resourceIDFieldOverrides = map[string]string{
 	"knowledgebase-organization-articles": "id",
 	"organization":                        "organizationId",
 	"organization-checklists":             "id",
-	"queries-backup-usage":                "id",
-	"related-items":                       "id",
-	"tag":                                 "id",
-	"ticketing-app-user-contact":          "id",
-	"user":                                "id",
-	"user-end-users":                      "id",
-	"user-technicians":                    "id",
-	"vulnerability":                       "id",
+	// /v2/queries/* report endpoints are device-scoped: every row carries a
+	// deviceId and the report family carries no globally-unique top-level id
+	// (where an `id` exists it is a PATCH id that repeats across devices). So
+	// deviceId is forced as the PRIMARY key for the whole family - without it
+	// the generic fallback keyed on a patch `id` or a `name` and silently
+	// collapsed rows ACROSS devices (every "Windows 11" device -> one row).
+	// Resources that return many rows per device add a secondary discriminator
+	// via resourceCompositeKeyColumns below (#136). Single-row-per-device
+	// resources (device-health, policy-overrides, operating-systems,
+	// computer-systems) key on deviceId alone. queries-backup-usage keeps its
+	// own `id` (pre-existing, working). The four queries-custom-fields* report
+	// variants are intentionally NOT listed: their row shape (nodeId vs
+	// deviceId, per-device vs per-field) is not confirmable from the connector
+	// source, and a wrong override would zero them out - tracked as a follow-up.
+	"queries-antivirus-status":        "deviceId",
+	"queries-antivirus-threats":       "deviceId",
+	"queries-backup-usage":            "id",
+	"queries-computer-systems":        "deviceId",
+	"queries-device-health":           "deviceId",
+	"queries-logged-on-users":         "deviceId",
+	"queries-network-interfaces":      "deviceId",
+	"queries-operating-systems":       "deviceId",
+	"queries-os-patch-installs":       "deviceId",
+	"queries-os-patches":              "deviceId",
+	"queries-policy-overrides":        "deviceId",
+	"queries-processors":              "deviceId",
+	"queries-raid-controllers":        "deviceId",
+	"queries-raid-drives":             "deviceId",
+	"queries-software":                "deviceId",
+	"queries-software-patch-installs": "deviceId",
+	"queries-software-patches":        "deviceId",
+	"queries-volumes":                 "deviceId",
+	"queries-windows-services":        "deviceId",
+	"related-items":                   "id",
+	"tag":                             "id",
+	"ticketing-app-user-contact":      "id",
+	"user":                            "id",
+	"user-end-users":                  "id",
+	"user-technicians":                "id",
+	"vulnerability":                   "id",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did
@@ -4493,16 +4525,63 @@ func scalarIDString(value any) string {
 	}
 }
 
+// resourceCompositeKeyColumns supplies the secondary discriminator for FLAT,
+// device-scoped /v2/queries/* resources that return MANY rows per device (#136).
+// The storage key is the primary key (deviceId, via resourceIDFieldOverrides)
+// joined with this field. Without it, rows that share a deviceId collapse onto
+// the bare deviceId and only the last survives. The discriminator is whatever
+// makes a row unique WITHIN a device: a per-row id where one exists (patch id
+// for queries-os-patches / queries-software-patches and their *-installs), else
+// a natural attribute (productName, threatId, interfaceIndex, userName,
+// controllerIndex, driveId, name). Field names are the exact camelCase JSON keys
+// (LookupFieldValue also tolerates snake_case). Single-row-per-device query
+// resources (queries-device-health, queries-policy-overrides,
+// queries-operating-systems, queries-computer-systems) need only the deviceId
+// override and are absent here.
+//
+// This is distinct from resourceParentKeyColumns: there the appended field is a
+// genuine PARENT id for a dependent child resource; here both the primary and
+// the discriminator come from the same flat row.
+//
+// DURABLE FIX belongs in cli-printing-press: the id/pagination profiler should
+// detect id-less device-scoped report endpoints and emit a composite key. Until
+// then this hand-fix must survive every reprint (recorded in handfixes.json).
+var resourceCompositeKeyColumns = map[string]string{
+	"queries-antivirus-status":        "productName",     // one row per AV product
+	"queries-antivirus-threats":       "threatId",        // one row per detected threat
+	"queries-network-interfaces":      "interfaceIndex",  // one row per NIC
+	"queries-logged-on-users":         "userName",        // one row per user
+	"queries-os-patches":              "id",              // one row per patch (id is the patch id)
+	"queries-os-patch-installs":       "id",              // one row per patch install
+	"queries-processors":              "name",            // one row per CPU
+	"queries-raid-controllers":        "controllerIndex", // one row per controller
+	"queries-raid-drives":             "driveId",         // one row per drive
+	"queries-software":                "name",            // one row per installed product
+	"queries-software-patches":        "id",              // one row per patch (id is the patch id)
+	"queries-software-patch-installs": "id",              // one row per patch install
+	"queries-volumes":                 "name",            // one row per volume
+	"queries-windows-services":        "name",            // one row per service
+	// operating-systems and computer-systems are one-row-per-device -> keyed on
+	// deviceId alone (no discriminator); they are in resourceIDFieldOverrides only.
+}
+
 func resourceStorageID(resourceType, id string, obj map[string]any) string {
-	parentKey := resourceParentKeyColumns[resourceType]
-	if parentKey == "" {
-		return id
+	// Parent context for dependent (parent-child) resources keeps every
+	// parent association distinct instead of collapsing onto the child id.
+	if parentKey := resourceParentKeyColumns[resourceType]; parentKey != "" {
+		if parentValue := ResourceIDString(lookupFieldValue(obj, parentKey)); parentValue != "" && parentValue != "<nil>" {
+			id = id + string([]byte{0}) + parentValue
+		}
 	}
-	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
-	if parentValue == "" || parentValue == "<nil>" {
-		return id
+	// Secondary discriminator for flat, id-less, multi-row-per-device
+	// /v2/queries/* resources (#136): deviceId alone would collide across the
+	// many rows a single device contributes.
+	if discrimKey := resourceCompositeKeyColumns[resourceType]; discrimKey != "" {
+		if discrimValue := ResourceIDString(lookupFieldValue(obj, discrimKey)); discrimValue != "" && discrimValue != "<nil>" {
+			id = id + string([]byte{0}) + discrimValue
+		}
 	}
-	return id + string([]byte{0}) + parentValue
+	return id
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -1,7 +1,7 @@
 {
   "slug": "ninjaone",
   "doc": "docs/reprint-survival.md",
-  "_comment": "Connector-specific edits to GENERATED (\"DO NOT EDIT\") files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #88 (reporter @AndrewITLive), fixed 2026-06-15 on press 4.24.0.",
+  "_comment": "Connector-specific edits to GENERATED (\"DO NOT EDIT\") files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #88 (reporter @AndrewITLive), fixed 2026-06-15 on press 4.24.0; issues #136 queries-* composite-key + object-cursor (reporter @Xenith-B), fixed 2026-06-17.",
   "handfixes": [
     {
       "id": "after-id-pagination",
@@ -38,6 +38,79 @@
         {
           "file": "cli/internal/cli/sync_after_id_test.go",
           "contains": "func TestExtractLastItemID",
+          "min_count": 1
+        }
+      ]
+    },
+    {
+      "id": "queries-composite-key-extraction",
+      "summary": "The device-scoped /v2/queries/* report family stored wrong/zero rows because the generic key path mis-keyed it. Two sub-symptoms: (a) the id-less reports (queries-antivirus-status, queries-device-health, queries-network-interfaces, queries-logged-on-users, queries-policy-overrides, queries-raid-controllers, queries-raid-drives) returned objects with NO top-level id -> ExtractResourceID returned \"\" -> every row skipped (all_items_failed_id_extraction, zero stored); (b) a broader set (queries-os-patches, queries-os-patch-installs, queries-software-patches, queries-software-patch-installs, queries-software, queries-operating-systems, queries-computer-systems, queries-processors, queries-volumes, queries-windows-services, queries-antivirus-threats) fell to genericIDFieldFallbacks and keyed on a PATCH id or a name WITHOUT a deviceId prefix, collapsing rows ACROSS devices (every 'Windows 11' device -> one stored row). Fix forces deviceId as the PRIMARY key for the whole family via resourceIDFieldOverrides, plus a per-row discriminator (productName/threatId/interfaceIndex/userName/controllerIndex/driveId/patch id/name) via the resourceCompositeKeyColumns map consulted by resourceStorageID for multi-row-per-device resources; single-row reports (operating-systems, computer-systems, device-health, policy-overrides) key on deviceId alone. The four queries-custom-fields* variants are deferred (shape unconfirmable offline) and tracked in #137.",
+      "why": "The press id profiler derives resourceIDFieldOverrides from the spec's x-resource-id / response-schema id field. NinjaOne's /v2/queries/* schemas either declare no id (so the generic fallback id/name/slug missed entirely) or declare an `id` that is a per-patch identifier shared across devices (so the fallback keyed on it and collapsed cross-device). A plain reprint regenerates the same gap. Every key/discriminator is grounded in the connector's own internal/types/types.go structs (DeviceOSPatch.id, DeviceSoftwarePatch.id, DeviceAntivirusThreat.threatId, DeviceProcessor.name, DeviceVolume.name, DeviceWindowsService.name, DeviceOperatingSystem/DeviceComputerSystem single-row, plus the #136 reporter's confirmed live shapes), never from the issue's suggested-fix text. resourceStorageID was refactored to append the resourceCompositeKeyColumns discriminator in addition to the existing resourceParentKeyColumns parent value; existing dependent-resource behavior is byte-equivalent (appends only when the field is present and non-empty). deviceId always leads the key so cross-device collapse is structurally impossible.",
+      "status": "active",
+      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the id profiler to detect device-scoped report endpoints and emit a composite key (scope id + a per-row discriminator) rather than keying on a non-unique id/name. File via printing-press-retro alongside the after-id/keyset profiler gap. Until the press learns it, this hand-fix must survive every reprint. Known bounded residual (deviceId always leads, so NO cross-device loss): for queries-software/queries-processors/queries-volumes the single within-device discriminator (name) can collide on rare duplicate-name rows (dual-socket identical CPUs, dup-named software variants, blank-named volumes); a multi-field composite would tighten this if a report arrives. queries-software's row shape (assumed DeviceApplication) is the one discriminator not confirmed by a typed struct. The four queries-custom-fields* variants are deferred (shape unconfirmable offline) and tracked in #137.",
+      "asserts": [
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "var resourceCompositeKeyColumns",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "resourceCompositeKeyColumns[resourceType]",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-antivirus-status\"",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-device-health\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-os-patches\"",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-operating-systems\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/queries_composite_key_test.go",
+          "contains": "func TestQueriesCompositeKeysDoNotCollide",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/queries_composite_key_test.go",
+          "contains": "func TestQueriesNoCrossDeviceCollapse",
+          "min_count": 1
+        }
+      ]
+    },
+    {
+      "id": "queries-object-cursor-pagination",
+      "summary": "NinjaOne /v2/queries/* endpoints paginate via an OBJECT-valued cursor: \"cursor\":{\"name\":\"<token>\",\"offset\":0,\"count\":\"N\",\"expires\":...}. findCursorInMap only unmarshalled a string cursor, so the next-page token was never found; sync stopped after the first page and capped each queries resource at 100 rows (sync_warning pagination_cursor_missing). Fix adds cursorTokenFromObject, consulted by findCursorInMap only after the string unmarshal fails, which descends into the object and returns the first non-empty string token field (name/next_cursor/...).",
+      "why": "determinePaginationDefaults() emits cursorParam/cursorType \"cursor\" but the press models a string cursor only; it does not model an object cursor whose token is nested under a field. The natural-end (len<limit), sticky-cursor, and empty-page guards already in the loop make object-cursor advance terminate safely. String-cursor APIs are unaffected because the object descent runs only after the scalar unmarshal fails. A plain reprint regenerates the string-only findCursorInMap.",
+      "status": "active",
+      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the pagination profiler to detect object-valued cursors (cursor field is an object; token nested under name/next/cursor) and emit the descent natively. File via printing-press-retro. Until then this hand-fix must survive every reprint. Verification residual: multi-page completeness assumes NinjaOne returns a FRESH cursor.name per page; if a live tenant ever shows truncation (~2 pages then the sticky-cursor guard fires) the cursor.name is a stable session token and the fix must ALSO thread the cursor object's `offset`. This is monotonic vs main regardless (worst case == the prior 100-row single-page cap; the sticky-cursor + max-pages guards prevent any hang).",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "func cursorTokenFromObject",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "cursorTokenFromObject(raw)",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/queries_cursor_test.go",
+          "contains": "func TestExtractPageItemsFollowsObjectCursor",
           "min_count": 1
         }
       ]


### PR DESCRIPTION
## What

Fixes #136 (reported by @Xenith-B). The NinjaOne `/v2/queries/*` report endpoints fetched data but did not mirror it correctly to the local SQLite store, so offline SQL, full-text `search`, and rollups (`av-sweep`, `software-audit`, `patch-compliance`, `os-eol`) were blind or wrong.

Two distinct defects on the same `/v2/queries/*` path:

1. **Zero rows stored** for the id-less reports the reporter hit (`antivirus-status`, `device-health`, `network-interfaces`, `logged-on-users`, `policy-overrides`, `raid-controllers`, `raid-drives`): their objects have no top-level `id`, so `ExtractResourceID` returned `""` and every row was skipped (`all_items_failed_id_extraction`).
2. **Cross-device collapse** for a broader set (`os-patches`, `software-patches`, `operating-systems`, `processors`, `volumes`, `windows-services`, `software`, `antivirus-threats`, `computer-systems`, + the `*-patch-installs`): the generic key fell back to a patch `id` or a `name` **without** a deviceId prefix, so e.g. every device running "Windows 11" collapsed to one stored row. (Surfaced by adversarial review of the initial fix.)

## How

- Force `deviceId` as the **primary** storage key for the whole device-scoped `/v2/queries/*` family (`resourceIDFieldOverrides`), so cross-device collapse is structurally impossible.
- New `resourceCompositeKeyColumns` adds a per-row discriminator (the patch `id`, or `productName`/`threatId`/`interfaceIndex`/`userName`/`controllerIndex`/`driveId`/`name`) for resources that return many rows per device; single-row reports key on `deviceId` alone. Every field is grounded in the connector's own `internal/types`.
- `resourceStorageID` appends the discriminator; the existing parent-key path is byte-equivalent (the two maps are disjoint).
- Follow NinjaOne's **object-valued** pagination cursor (`cursor.name`) so each resource pages past 100 rows; runs only after the string-cursor attempt fails, so string-cursor APIs are unaffected.
- Regression tests assert no cross-device collapse, distinct within-device keys, clean numeric-id formatting, and object-cursor following (string cursor unchanged).
- Both hand-fixes recorded in `handfixes.json`; the durable fix belongs in cli-printing-press.

## Scope notes

- The four `queries-custom-fields*` report variants are deferred to #137 — their row shape is not confirmable from the connector source offline and a wrong key would zero them out.
- Object-cursor multi-page completeness assumes NinjaOne returns a fresh `cursor.name` per page (monotonic vs today regardless; cannot hang). @Xenith-B — if you can confirm a large `queries-*` resource now syncs >100 rows on a live tenant, that closes the loop.

## Verification

- `go build`, `go vet`, full `internal/store` + `internal/cli` suites: green.
- `check_handfixes.py`: PASS. Deterministic security gate (`check_security_gate.py --base origin/main`): **0 P1**. Adversarial multi-agent review (supply-chain / data-integrity / scope lenses): **PASS, 0 P1** after the cross-device expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination handling for query endpoints where the cursor is formatted as an object, preventing premature page termination.
  * Corrected device-scoped data storage to properly key rows and prevent cross-device data loss or row collapsing.

* **Tests**
  * Added comprehensive test coverage for object-valued cursor pagination and device-scoped composite key storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->