### PR TITLE
fix(ninjaone): store the queries-custom-fields* report variants (#137)

### DIFF
--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.3] - unreleased
+## [0.1.4] - unreleased
+
+### Fixed
+- `sync` now stores correct rows for the four `/v2/queries/custom-fields*` report
+  variants, which previously cached **zero** rows. Like the rest of the
+  `/v2/queries/*` family these rows carry no top-level `id`, so the generic key
+  path skipped every one of them (`all_items_failed_id_extraction`). The source
+  API schema confirms the row shapes:
+  - `queries-custom-fields` / `queries-custom-fields-detailed` return one row per
+    device (all values packed into a `fields` map/array), so each now keys on
+    `deviceId`.
+  - `queries-scoped-custom-fields` / `queries-scoped-custom-fields-detailed`
+    return one row per (`scope`, `entityId`); since `entityId` is unique only
+    within a scope, each now keys on `entityId` plus a `scope` discriminator so a
+    device and an organization sharing an id never collapse together.
+  Offline SQL and full-text `search` now see these custom-field reports. This
+  completes the `/v2/queries/*` storage fix begun in 0.1.3. (#137)
+
+## [0.1.3]
 
 ### Fixed
 - `sync` now stores correct rows for the device-scoped `/v2/queries/*` report

--- a/skills/ninjaone/cli/internal/store/queries_custom_fields_key_test.go
+++ b/skills/ninjaone/cli/internal/store/queries_custom_fields_key_test.go
@@ -1,0 +1,90 @@
+package store
+
+import "testing"
+
+// Regression tests for issue #137: the four queries-custom-fields* report
+// variants were deferred from the #136 fix because their row shape was not
+// confirmable from the connector source. The source OpenAPI schema (spec.yaml)
+// confirms it:
+//
+//   - custom-fields / custom-fields-detailed (NodeAttributes /
+//     NodeAttributesDetailed): one row per device, all values packed into a
+//     `fields` map/array -> key on deviceId alone.
+//   - scoped-custom-fields / scoped-custom-fields-detailed (ScopedAttributes /
+//     ScopedAttributesDetailed): one row per (scope, entityId). entityId is
+//     unique only WITHIN a scope, so the key is entityId + a `scope`
+//     discriminator.
+//
+// Like the #136 group these rows carry no top-level id/name, so before this fix
+// ExtractResourceID returned "" and zero rows were stored. These tests drive the
+// REAL production decode path (DecodeJSONObject) so numeric formatting and the
+// composite-key join are exercised exactly as sync does.
+
+// Non-scoped custom-fields rows resolve to their deviceId and store one row per
+// device (the `fields` map/array means a single row carries all of a device's
+// fields, so deviceId alone is the unique key - no discriminator).
+func TestCustomFieldsKeyOnDeviceID(t *testing.T) {
+	cases := map[string]string{
+		// NodeAttributes: deviceId + fields map
+		"queries-custom-fields": `{"deviceId":1001,"fields":{"AssetTag":"A-1","Owner":"jdoe"}}`,
+		// NodeAttributesDetailed: deviceId + entityType + fields array
+		"queries-custom-fields-detailed": `{"deviceId":1001,"entityType":"NODE","fields":[{"name":"AssetTag","value":"A-1"}]}`,
+	}
+	for resource, raw := range cases {
+		if id := ExtractResourceID(resource, decodeOrFatal(t, raw)); id != "1001" {
+			t.Errorf("%s: want primary id 1001, got %q", resource, id)
+		}
+		if got := storageKey(t, resource, raw); got != "1001" {
+			t.Errorf("%s: want bare deviceId key 1001 (one row per device), got %q", resource, got)
+		}
+	}
+}
+
+// Two devices' custom-fields rows must not collapse onto one key.
+func TestCustomFieldsNoCrossDeviceCollapse(t *testing.T) {
+	for _, resource := range []string{"queries-custom-fields", "queries-custom-fields-detailed"} {
+		k1 := storageKey(t, resource, `{"deviceId":1001,"fields":{"Owner":"a"}}`)
+		k2 := storageKey(t, resource, `{"deviceId":2002,"fields":{"Owner":"b"}}`)
+		if k1 == k2 {
+			t.Errorf("%s: device 1001 and 2002 collapsed to one key %q", resource, k1)
+		}
+	}
+}
+
+// Scoped custom-fields rows key on entityId. The `scope` discriminator is what
+// makes the key correct: entityId is unique only WITHIN a scope, so the SAME
+// entityId under two scopes (e.g. a device #5 and an organization #5) must NOT
+// collapse onto one stored row. This is the core #137 correctness property.
+func TestScopedCustomFieldsKeyDisambiguatesScope(t *testing.T) {
+	for _, resource := range []string{"queries-scoped-custom-fields", "queries-scoped-custom-fields-detailed"} {
+		// entityId resolves as the primary id.
+		if id := ExtractResourceID(resource, decodeOrFatal(t, `{"scope":"NODE","entityId":5,"fields":{}}`)); id != "5" {
+			t.Errorf("%s: want primary id 5 (entityId), got %q", resource, id)
+		}
+		// Same entityId, different scope -> distinct storage keys.
+		node := storageKey(t, resource, `{"scope":"NODE","entityId":5,"fields":{"k":"v"}}`)
+		org := storageKey(t, resource, `{"scope":"ORGANIZATION","entityId":5,"fields":{"k":"v"}}`)
+		if node == org {
+			t.Errorf("%s: entityId 5 under NODE and ORGANIZATION collapsed to one key %q (cross-scope data loss)", resource, node)
+		}
+		// Different entities in the same scope are also distinct.
+		a := storageKey(t, resource, `{"scope":"NODE","entityId":5,"fields":{}}`)
+		b := storageKey(t, resource, `{"scope":"NODE","entityId":6,"fields":{}}`)
+		if a == b {
+			t.Errorf("%s: entityId 5 and 6 in NODE scope collided on key %q", resource, a)
+		}
+	}
+}
+
+// Safe-by-construction guard: the spec marks NodeAttributesDetailed.deviceId
+// writeOnly (request-only), so the live response MAY omit it. When it does,
+// ExtractResourceID falls through to "" and the row is skipped - exactly the
+// zero-rows behavior the resource already has today. The override can therefore
+// only add rows or stay neutral; it can never collapse or corrupt existing data.
+func TestCustomFieldsDetailedWriteOnlyDeviceIDFallsThroughCleanly(t *testing.T) {
+	// deviceId absent (writeOnly omitted from the response), no other id/name.
+	raw := `{"entityType":"NODE","fields":[{"name":"AssetTag","value":"A-1"}]}`
+	if id := ExtractResourceID("queries-custom-fields-detailed", decodeOrFatal(t, raw)); id != "" {
+		t.Errorf("expected clean fallthrough to \"\" when writeOnly deviceId is absent, got %q", id)
+	}
+}

--- a/skills/ninjaone/cli/internal/store/store.go
+++ b/skills/ninjaone/cli/internal/store/store.go
@@ -4313,36 +4313,53 @@ var resourceIDFieldOverrides = map[string]string{
 	// via resourceCompositeKeyColumns below (#136). Single-row-per-device
 	// resources (device-health, policy-overrides, operating-systems,
 	// computer-systems) key on deviceId alone. queries-backup-usage keeps its
-	// own `id` (pre-existing, working). The four queries-custom-fields* report
-	// variants are intentionally NOT listed: their row shape (nodeId vs
-	// deviceId, per-device vs per-field) is not confirmable from the connector
-	// source, and a wrong override would zero them out - tracked as a follow-up.
-	"queries-antivirus-status":        "deviceId",
-	"queries-antivirus-threats":       "deviceId",
-	"queries-backup-usage":            "id",
-	"queries-computer-systems":        "deviceId",
-	"queries-device-health":           "deviceId",
-	"queries-logged-on-users":         "deviceId",
-	"queries-network-interfaces":      "deviceId",
-	"queries-operating-systems":       "deviceId",
-	"queries-os-patch-installs":       "deviceId",
-	"queries-os-patches":              "deviceId",
-	"queries-policy-overrides":        "deviceId",
-	"queries-processors":              "deviceId",
-	"queries-raid-controllers":        "deviceId",
-	"queries-raid-drives":             "deviceId",
-	"queries-software":                "deviceId",
-	"queries-software-patch-installs": "deviceId",
-	"queries-software-patches":        "deviceId",
-	"queries-volumes":                 "deviceId",
-	"queries-windows-services":        "deviceId",
-	"related-items":                   "id",
-	"tag":                             "id",
-	"ticketing-app-user-contact":      "id",
-	"user":                            "id",
-	"user-end-users":                  "id",
-	"user-technicians":                "id",
-	"vulnerability":                   "id",
+	// own `id` (pre-existing, working).
+	//
+	// The four queries-custom-fields* report variants (#137) were deferred from
+	// #136 pending their row shape; the source OpenAPI schema confirms it:
+	//   - custom-fields / custom-fields-detailed (NodeAttributes /
+	//     NodeAttributesDetailed): one row per device packing all values into a
+	//     `fields` map/array -> key on deviceId alone, no discriminator. The
+	//     detailed variant marks deviceId writeOnly in the spec, so if the live
+	//     response omits it the override is a no-op and the resource stays at the
+	//     zero rows it already stores today - never a regression.
+	//   - scoped-custom-fields / scoped-custom-fields-detailed (ScopedAttributes
+	//     / ScopedAttributesDetailed): one row per (scope, entityId). entityId is
+	//     unique only WITHIN a scope (a device id and an org id can collide), so
+	//     these key on entityId + a `scope` discriminator (resourceCompositeKey
+	//     Columns below).
+	// All four store ZERO rows today (id-less rows fail extraction), so these
+	// overrides can only add rows or stay neutral - they cannot collapse.
+	"queries-antivirus-status":              "deviceId",
+	"queries-antivirus-threats":             "deviceId",
+	"queries-backup-usage":                  "id",
+	"queries-computer-systems":              "deviceId",
+	"queries-custom-fields":                 "deviceId",
+	"queries-custom-fields-detailed":        "deviceId",
+	"queries-device-health":                 "deviceId",
+	"queries-logged-on-users":               "deviceId",
+	"queries-network-interfaces":            "deviceId",
+	"queries-operating-systems":             "deviceId",
+	"queries-os-patch-installs":             "deviceId",
+	"queries-os-patches":                    "deviceId",
+	"queries-policy-overrides":              "deviceId",
+	"queries-processors":                    "deviceId",
+	"queries-raid-controllers":              "deviceId",
+	"queries-raid-drives":                   "deviceId",
+	"queries-scoped-custom-fields":          "entityId",
+	"queries-scoped-custom-fields-detailed": "entityId",
+	"queries-software":                      "deviceId",
+	"queries-software-patch-installs":       "deviceId",
+	"queries-software-patches":              "deviceId",
+	"queries-volumes":                       "deviceId",
+	"queries-windows-services":              "deviceId",
+	"related-items":                         "id",
+	"tag":                                   "id",
+	"ticketing-app-user-contact":            "id",
+	"user":                                  "id",
+	"user-end-users":                        "id",
+	"user-technicians":                      "id",
+	"vulnerability":                         "id",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did
@@ -4547,20 +4564,27 @@ func scalarIDString(value any) string {
 // detect id-less device-scoped report endpoints and emit a composite key. Until
 // then this hand-fix must survive every reprint (recorded in handfixes.json).
 var resourceCompositeKeyColumns = map[string]string{
-	"queries-antivirus-status":        "productName",     // one row per AV product
-	"queries-antivirus-threats":       "threatId",        // one row per detected threat
-	"queries-network-interfaces":      "interfaceIndex",  // one row per NIC
-	"queries-logged-on-users":         "userName",        // one row per user
-	"queries-os-patches":              "id",              // one row per patch (id is the patch id)
-	"queries-os-patch-installs":       "id",              // one row per patch install
-	"queries-processors":              "name",            // one row per CPU
-	"queries-raid-controllers":        "controllerIndex", // one row per controller
-	"queries-raid-drives":             "driveId",         // one row per drive
-	"queries-software":                "name",            // one row per installed product
-	"queries-software-patches":        "id",              // one row per patch (id is the patch id)
-	"queries-software-patch-installs": "id",              // one row per patch install
-	"queries-volumes":                 "name",            // one row per volume
-	"queries-windows-services":        "name",            // one row per service
+	"queries-antivirus-status":   "productName",     // one row per AV product
+	"queries-antivirus-threats":  "threatId",        // one row per detected threat
+	"queries-network-interfaces": "interfaceIndex",  // one row per NIC
+	"queries-logged-on-users":    "userName",        // one row per user
+	"queries-os-patches":         "id",              // one row per patch (id is the patch id)
+	"queries-os-patch-installs":  "id",              // one row per patch install
+	"queries-processors":         "name",            // one row per CPU
+	"queries-raid-controllers":   "controllerIndex", // one row per controller
+	"queries-raid-drives":        "driveId",         // one row per drive
+	// scoped-custom-fields (#137): primary key is entityId, but entityId is only
+	// unique WITHIN a scope (a device id and an org id can collide), so `scope`
+	// (NODE/END_USER/LOCATION/ORGANIZATION) is the discriminator. Unlike the
+	// rows above this is not a multi-row-per-device case - it disambiguates the
+	// id namespace, one row per (scope, entityId).
+	"queries-scoped-custom-fields":          "scope",
+	"queries-scoped-custom-fields-detailed": "scope",
+	"queries-software":                      "name", // one row per installed product
+	"queries-software-patches":              "id",   // one row per patch (id is the patch id)
+	"queries-software-patch-installs":       "id",   // one row per patch install
+	"queries-volumes":                       "name", // one row per volume
+	"queries-windows-services":              "name", // one row per service
 	// operating-systems and computer-systems are one-row-per-device -> keyed on
 	// deviceId alone (no discriminator); they are in resourceIDFieldOverrides only.
 }

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -44,10 +44,10 @@
     },
     {
       "id": "queries-composite-key-extraction",
-      "summary": "The device-scoped /v2/queries/* report family stored wrong/zero rows because the generic key path mis-keyed it. Two sub-symptoms: (a) the id-less reports (queries-antivirus-status, queries-device-health, queries-network-interfaces, queries-logged-on-users, queries-policy-overrides, queries-raid-controllers, queries-raid-drives) returned objects with NO top-level id -> ExtractResourceID returned \"\" -> every row skipped (all_items_failed_id_extraction, zero stored); (b) a broader set (queries-os-patches, queries-os-patch-installs, queries-software-patches, queries-software-patch-installs, queries-software, queries-operating-systems, queries-computer-systems, queries-processors, queries-volumes, queries-windows-services, queries-antivirus-threats) fell to genericIDFieldFallbacks and keyed on a PATCH id or a name WITHOUT a deviceId prefix, collapsing rows ACROSS devices (every 'Windows 11' device -> one stored row). Fix forces deviceId as the PRIMARY key for the whole family via resourceIDFieldOverrides, plus a per-row discriminator (productName/threatId/interfaceIndex/userName/controllerIndex/driveId/patch id/name) via the resourceCompositeKeyColumns map consulted by resourceStorageID for multi-row-per-device resources; single-row reports (operating-systems, computer-systems, device-health, policy-overrides) key on deviceId alone. The four queries-custom-fields* variants are deferred (shape unconfirmable offline) and tracked in #137.",
+      "summary": "The device-scoped /v2/queries/* report family stored wrong/zero rows because the generic key path mis-keyed it. Two sub-symptoms: (a) the id-less reports (queries-antivirus-status, queries-device-health, queries-network-interfaces, queries-logged-on-users, queries-policy-overrides, queries-raid-controllers, queries-raid-drives) returned objects with NO top-level id -> ExtractResourceID returned \"\" -> every row skipped (all_items_failed_id_extraction, zero stored); (b) a broader set (queries-os-patches, queries-os-patch-installs, queries-software-patches, queries-software-patch-installs, queries-software, queries-operating-systems, queries-computer-systems, queries-processors, queries-volumes, queries-windows-services, queries-antivirus-threats) fell to genericIDFieldFallbacks and keyed on a PATCH id or a name WITHOUT a deviceId prefix, collapsing rows ACROSS devices (every 'Windows 11' device -> one stored row). Fix forces deviceId as the PRIMARY key for the whole family via resourceIDFieldOverrides, plus a per-row discriminator (productName/threatId/interfaceIndex/userName/controllerIndex/driveId/patch id/name) via the resourceCompositeKeyColumns map consulted by resourceStorageID for multi-row-per-device resources; single-row reports (operating-systems, computer-systems, device-health, policy-overrides) key on deviceId alone. The four queries-custom-fields* variants are now keyed too (#137): the source OpenAPI schema confirmed their shapes - custom-fields/custom-fields-detailed (NodeAttributes/NodeAttributesDetailed) are one row per device keyed on deviceId alone; scoped-custom-fields/scoped-custom-fields-detailed (ScopedAttributes/ScopedAttributesDetailed) are one row per (scope, entityId) keyed on entityId plus a `scope` discriminator (entityId is unique only WITHIN a scope, so a device #5 and an org #5 would otherwise collide). All four stored ZERO rows before the fix (id-less), so the overrides can only add rows.",
       "why": "The press id profiler derives resourceIDFieldOverrides from the spec's x-resource-id / response-schema id field. NinjaOne's /v2/queries/* schemas either declare no id (so the generic fallback id/name/slug missed entirely) or declare an `id` that is a per-patch identifier shared across devices (so the fallback keyed on it and collapsed cross-device). A plain reprint regenerates the same gap. Every key/discriminator is grounded in the connector's own internal/types/types.go structs (DeviceOSPatch.id, DeviceSoftwarePatch.id, DeviceAntivirusThreat.threatId, DeviceProcessor.name, DeviceVolume.name, DeviceWindowsService.name, DeviceOperatingSystem/DeviceComputerSystem single-row, plus the #136 reporter's confirmed live shapes), never from the issue's suggested-fix text. resourceStorageID was refactored to append the resourceCompositeKeyColumns discriminator in addition to the existing resourceParentKeyColumns parent value; existing dependent-resource behavior is byte-equivalent (appends only when the field is present and non-empty). deviceId always leads the key so cross-device collapse is structurally impossible.",
       "status": "active",
-      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the id profiler to detect device-scoped report endpoints and emit a composite key (scope id + a per-row discriminator) rather than keying on a non-unique id/name. File via printing-press-retro alongside the after-id/keyset profiler gap. Until the press learns it, this hand-fix must survive every reprint. Known bounded residual (deviceId always leads, so NO cross-device loss): for queries-software/queries-processors/queries-volumes the single within-device discriminator (name) can collide on rare duplicate-name rows (dual-socket identical CPUs, dup-named software variants, blank-named volumes); a multi-field composite would tighten this if a report arrives. queries-software's row shape (assumed DeviceApplication) is the one discriminator not confirmed by a typed struct. The four queries-custom-fields* variants are deferred (shape unconfirmable offline) and tracked in #137.",
+      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the id profiler to detect device-scoped report endpoints and emit a composite key (scope id + a per-row discriminator) rather than keying on a non-unique id/name. File via printing-press-retro alongside the after-id/keyset profiler gap. Until the press learns it, this hand-fix must survive every reprint. Known bounded residual (deviceId always leads, so NO cross-device loss): for queries-software/queries-processors/queries-volumes the single within-device discriminator (name) can collide on rare duplicate-name rows (dual-socket identical CPUs, dup-named software variants, blank-named volumes); a multi-field composite would tighten this if a report arrives. queries-software's row shape (assumed DeviceApplication) is the one discriminator not confirmed by a typed struct. The four queries-custom-fields* variants are now keyed too (#137), grounded in the source OpenAPI schemas (NodeAttributes.deviceId; ScopedAttributes.scope+entityId), not the issue text. One bounded residual: NodeAttributesDetailed.deviceId is marked writeOnly in the spec, so if the live response omits it the override is a no-op and queries-custom-fields-detailed stays at the zero rows it already stored (never a regression); a captured live /v2/queries/custom-fields-detailed response would confirm it definitively. Second bounded residual (same class as the name-discriminator note above): the scoped variants rely on a populated `scope` to disambiguate entityId across scopes - resourceStorageID appends the discriminator only when non-empty (the shared #136 conditional-append shape), so an empty/absent scope would collapse same-id entities; this is contract-dependent (scope is the report's always-set grouping dimension) and still strictly more than today's zero rows, not a regression.",
       "asserts": [
         {
           "file": "cli/internal/store/store.go",
@@ -87,6 +87,31 @@
         {
           "file": "cli/internal/store/queries_composite_key_test.go",
           "contains": "func TestQueriesNoCrossDeviceCollapse",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-custom-fields\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-custom-fields-detailed\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"queries-scoped-custom-fields-detailed\"",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/store/queries_custom_fields_key_test.go",
+          "contains": "func TestScopedCustomFieldsKeyDisambiguatesScope",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/queries_custom_fields_key_test.go",
+          "contains": "func TestCustomFieldsKeyOnDeviceID",
           "min_count": 1
         }
       ]


### PR DESCRIPTION
## Summary

Fixes #137 — the four `/v2/queries/custom-fields*` report variants that were intentionally **deferred** from the #136 fix because their row shape wasn't confirmable from the connector source offline. The source OpenAPI schema (`spec.yaml`) confirms the shapes, so the keys are grounded, not guessed:

| resource | row schema | storage key |
|---|---|---|
| `queries-custom-fields` | `NodeAttributes` (`deviceId` + `fields` map) | `deviceId` |
| `queries-custom-fields-detailed` | `NodeAttributesDetailed` (`deviceId`* + `fields` array) | `deviceId` |
| `queries-scoped-custom-fields` | `ScopedAttributes` (`scope` + `entityId` + `fields`) | `entityId` + `scope` |
| `queries-scoped-custom-fields-detailed` | `ScopedAttributesDetailed` (`scope` + `entityId` + `fields`) | `entityId` + `scope` |

Like the rest of the `/v2/queries/*` family these rows carry **no top-level `id`**, so they previously stored **zero rows** (`all_items_failed_id_extraction`). The overrides can therefore only add rows or stay neutral — never collapse. `entityId` is unique only *within* a `scope`, so the `scope` discriminator keeps a device `#5` and an organization `#5` from collapsing onto one row.

\*`NodeAttributesDetailed.deviceId` is marked `writeOnly` in the spec; if the live response omits it the override is a clean no-op (stays at today's zero rows), proven by a dedicated test.

## Why this is safe

- **Class A (bug-fix-only):** no new command/flag/output/permission. Completes the `/v2/queries/*` storage fix begun in 0.1.3.
- **Scoped to one connector**, one issue — 4 files under `skills/ninjaone/`, no `go.mod`/`go.sum`/CI/auth changes.
- **Security gate (Layer 3): 0 P1.** Deterministic gate `[pass]`, codex adversarial `CLEAN`, fresh-context Claude security agent `CLEAN` (96/100).

## Tests

`internal/store/queries_custom_fields_key_test.go` (new) asserts per-device keying, **cross-scope non-collision** (NODE `#5` vs ORG `#5` stay distinct), no cross-device collapse, and the `writeOnly` clean fallthrough. Full module `go test ./...` + `go vet` green; `check_handfixes.py` PASS.

The durable fix still belongs in cli-printing-press (the id-profiler should detect id-less device-scoped reports) — existing `printing-press-retro` item; the hand-fix (`queries-composite-key-extraction`) is updated to cover these variants so a reprint won't clobber them.

Thanks to @DamienStevens for filing the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)