### PR TITLE
ci(live-verified): credit the reporter via --verified-by

### DIFF
--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -157,12 +157,15 @@ jobs:
         env:
           SLUG: ${{ steps.parse.outputs.slug }}
           EVIDENCE: ${{ github.event.issue.html_url }}
+          REPORTER: ${{ github.event.issue.user.login }}
         run: |
           set -euo pipefail
-          python3 tools/maintainer/verify_live.py \
-            --slug "$SLUG" \
-            --source github \
-            --evidence "$EVIDENCE"
+          # Credit the reporter (the MSP who confirmed it works) so the badge renders
+          # honest attribution + the receipt link, not the generic maintainer default.
+          # An array keeps the space in "@reporter (MSP)" correctly quoted.
+          args=(--slug "$SLUG" --source github --evidence "$EVIDENCE")
+          if [ -n "${REPORTER:-}" ]; then args+=(--verified-by "@${REPORTER} (MSP)"); fi
+          python3 tools/maintainer/verify_live.py "${args[@]}"
 
       - name: Regenerate catalog
         if: steps.parse.outputs.ok == 'true'
@@ -175,6 +178,7 @@ jobs:
           SLUG: ${{ steps.parse.outputs.slug }}
           ISSUE: ${{ github.event.issue.number }}
           EVIDENCE: ${{ github.event.issue.html_url }}
+          REPORTER: ${{ github.event.issue.user.login }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -204,10 +208,9 @@ jobs:
             # badge flip), and set -e would kill the loop before the staged-diff
             # check below can conclude there is nothing left to push. The diff
             # check is the real gate.
-            python3 tools/maintainer/verify_live.py \
-              --slug "$SLUG" \
-              --source github \
-              --evidence "$EVIDENCE" \
+            args=(--slug "$SLUG" --source github --evidence "$EVIDENCE")
+            if [ -n "${REPORTER:-}" ]; then args+=(--verified-by "@${REPORTER} (MSP)"); fi
+            python3 tools/maintainer/verify_live.py "${args[@]}" \
               || echo "verify_live returned non-zero (already verified?) - continuing to diff check"
             python3 tools/maintainer/build-catalog.py
             git add tools/maintainer/skills.json catalog.json README.md docs/_data/catalog.json docs/skills/ docs/_data/pending.json 2>/dev/null || true


### PR DESCRIPTION
The `live-verified.yml` auto-flip (for form-submitted "it works" reports) called
`verify_live.py --source github --evidence <url>` **without** `--verified-by`, so an
external report rendered the generic default *"Live-verified by Servosity (maintainer)"*
instead of the MSP who actually confirmed it — the same honesty gap the manual skill path
fixes with `--verified-by`.

This passes `--verified-by "@<issue author> (MSP)"` in both the flip step and the
push-retry loop (via a bash array so the space in the value stays correctly quoted).
`issue_url` continues to auto-derive from the github evidence URL, so the receipt link is
unaffected.

Docs-only path; no release fires. YAML parses; the array expansion was verified to produce
a single correctly-quoted `--verified-by @<login> (MSP)` argument.

Context: paired with an improvement to the local `issue-triage` skill that teaches it to
resolve "it works"/`[Works]` confirmations (and real-tenant bug fixes) by flipping the
live-verified badge with honest attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)