### PR TITLE
fix(axcient): search finds 3-letter all-caps names + MCP search guidance (#148)

### DIFF
--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.7] - unreleased
+
+### Fixed
+- Search now finds records whose name is a 3-letter all-caps label (e.g. `WEB`,
+  `SQL`, `DNS`, `DMZ`, `APP`, `VPN`). The local full-text index dropped any
+  3-letter all-caps string (a rule meant for currency/country codes like `USD`),
+  but it was key-blind, so it also discarded a record's `name`/`alias` when the
+  name was a short host label. Those records were fully present (list/get
+  returned them) but `search` by name returned nothing, which is why it showed up
+  only through the MCP `search` tool. The index filter is now key-aware: it keeps
+  the value for display-name fields and still drops bare codes elsewhere. The
+  FTS-content schema version is bumped so existing local databases re-index
+  through the fixed filter on the next `sync`. (reported by Barret, #148)
+- MCP `search` now gives actionable guidance instead of failing opaquely: when the
+  local database has not been synced it returns "run the `sync` tool first" rather
+  than a cryptic SQLite error, and a no-match returns a clear hint instead of a
+  bare `null`. (reported by Barret, #148)
+
 ## [0.2.6] - unreleased
 
 ### Fixed

--- a/skills/axcient/cli/internal/mcp/search_guidance_test.go
+++ b/skills/axcient/cli/internal/mcp/search_guidance_test.go
@@ -1,0 +1,76 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"axcient-pp-cli/internal/store"
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestHandleSearch_Issue148_Guidance verifies the MCP search tool gives
+// actionable guidance instead of a cryptic SQLite error (no local DB) or a bare
+// `null` (no matches), while still returning the record on a real match.
+func TestHandleSearch_Issue148_Guidance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	mkReq := func(q string) mcplib.CallToolRequest {
+		var req mcplib.CallToolRequest
+		req.Params.Arguments = map[string]any{"query": q}
+		return req
+	}
+
+	// (1) No DB yet -> clear "run sync" error, never the cryptic SQLite text.
+	r1, err := handleSearch(context.Background(), mkReq("anything"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r1.IsError {
+		t.Fatalf("missing-DB search should be an error result")
+	}
+	txt1 := mcpTextContent(t, r1)
+	if !strings.Contains(txt1, "sync") {
+		t.Fatalf("missing-DB error should mention sync, got %q", txt1)
+	}
+	if strings.Contains(strings.ToLower(txt1), "out of memory") {
+		t.Fatalf("missing-DB error leaked the cryptic SQLite message: %q", txt1)
+	}
+
+	// Populate a synced DB at the resolved dbPath().
+	dbDir := filepath.Join(home, ".local", "share", "axcient-cli")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := store.Open(filepath.Join(dbDir, "data.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.UpsertBatch("device", []json.RawMessage{json.RawMessage(`{"id_":1,"name":"AcmeServer01"}`)}); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// (2) No match -> a hint, not a bare "null".
+	r2, err := handleSearch(context.Background(), mkReq("NoSuchNameXyz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt2 := mcpTextContent(t, r2)
+	if strings.TrimSpace(txt2) == "null" || !strings.Contains(txt2, "No matches") {
+		t.Fatalf("no-match search should return a 'No matches' hint, got %q", txt2)
+	}
+
+	// (3) Real match still returns the record as JSON.
+	r3, err := handleSearch(context.Background(), mkReq("AcmeServer01"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(mcpTextContent(t, r3), "AcmeServer01") {
+		t.Fatalf("matching search should return the record")
+	}
+}

--- a/skills/axcient/cli/internal/mcp/tools.go
+++ b/skills/axcient/cli/internal/mcp/tools.go
@@ -689,15 +689,28 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 		limit = int(v)
 	}
 
+	// Hand-fix (issue #148): search reads the LOCAL synced DB. When it has not
+	// been populated, OpenReadOnly (mode=ro) surfaces a cryptic SQLite
+	// "out of memory (14)"; give actionable guidance instead.
+	if _, statErr := os.Stat(dbPath()); os.IsNotExist(statErr) {
+		return mcplib.NewToolResultError("local search database not found; run the 'sync' tool first to populate it, then search again"), nil
+	}
+
 	db, err := store.OpenReadOnly(dbPath())
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+		return mcplib.NewToolResultError(fmt.Sprintf("opening search database: %v\nIf you have not synced yet, run the 'sync' tool first.", err)), nil
 	}
 	defer db.Close()
 
 	results, err := db.Search(query, limit)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	// Hand-fix (issue #148): a bare `null` on no matches reads as "search is
+	// broken"; return an actionable hint (stale/unsynced data is the common cause).
+	if len(results) == 0 {
+		return mcplib.NewToolResultText(fmt.Sprintf("No matches for %q. If your local data is stale or unsynced, run the 'sync' tool first, then search again.", query)), nil
 	}
 
 	return toolResultJSON(results)

--- a/skills/axcient/cli/internal/store/display_name_index_test.go
+++ b/skills/axcient/cli/internal/store/display_name_index_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestSearchByThreeLetterUpperName_Issue148 is the regression oracle for issue
+// #148: a record whose name is a 3-letter all-caps host label (WEB/SQL/DNS/DMZ)
+// must be searchable by name. Before the fix, shouldIndexSearchString's
+// key-blind 3-letter-all-caps branch dropped the name from the FTS index, so
+// MCP search returned 0 rows for it while list/get (live API) still found it.
+func TestSearchByThreeLetterUpperName_Issue148(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id_": 1, "name": "WEB", "client_name": "Acme Corp"}`),
+		json.RawMessage(`{"id_": 2, "name": "AcmeServer01"}`),
+	}
+	if _, _, err := s.UpsertBatch("device", items); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, q := range []string{"WEB", "web", "AcmeServer01"} {
+		hits, err := s.SearchHits(q, 10)
+		if err != nil {
+			t.Fatalf("SearchHits(%q): %v", q, err)
+		}
+		if len(hits) == 0 {
+			t.Errorf("search-by-name %q returned 0 results (issue #148: 3-letter all-caps name dropped from FTS)", q)
+		}
+	}
+
+	// The display-name exemption must NOT re-admit bare 3-letter codes under a
+	// non-name field: a currency code under "currency" stays out of the index.
+	if shouldIndexSearchString("currency", "USD") {
+		t.Errorf("3-letter all-caps code under a non-name key should still be dropped from the index")
+	}
+	// ...but a 3-letter all-caps value under a display-name key must be indexed.
+	for _, k := range []string{"name", "alias", "hostname", "device_name"} {
+		if !shouldIndexSearchString(k, "DMZ") {
+			t.Errorf("3-letter all-caps value under display-name key %q must be indexed", k)
+		}
+	}
+}

--- a/skills/axcient/cli/internal/store/store.go
+++ b/skills/axcient/cli/internal/store/store.go
@@ -49,14 +49,18 @@ func IsUUID(s string) bool {
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
 // checked on every open. Non-learn CLIs advance to v4 for the
-// resources_fts content extraction.
-const StoreSchemaVersion = 4
+// resources_fts content extraction; v5 (issue #148) re-indexes existing DBs
+// after the display-name FTS filter fix so already-synced records become
+// searchable by name on the next sync.
+const StoreSchemaVersion = 5
 
 // resourcesFTSContentSchemaVersion pins the schema bump that rewrote
 // resources_fts content from raw JSON to searchable leaf values. Keep this
 // separate from StoreSchemaVersion so future unrelated migrations do not
-// trigger an expensive full FTS rebuild.
-const resourcesFTSContentSchemaVersion = 4
+// trigger an expensive full FTS rebuild. Bumped to 5 (issue #148) to force a
+// one-time FTS rebuild through the display-name-aware index filter. Must stay
+// <= StoreSchemaVersion so the rebuild fires once and the version stamp settles.
+const resourcesFTSContentSchemaVersion = 5
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -928,7 +932,13 @@ func shouldIndexSearchString(key, value string) bool {
 		return false
 	case strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://"):
 		return false
-	case upper == s && len(s) == 3 && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
+	// Hand-fix (issue #148): gate the 3-letter ALL-CAPS drop on !isDisplayNameKey.
+	// The rule suppresses bare codes (USD/GBP/country codes) in non-name fields, but
+	// being value-based and key-blind it also discarded a record's NAME when it is a
+	// 3-letter all-caps host label (WEB/SQL/DNS/DMZ/APP/VPN/CRM/ERP); those never
+	// entered resources_fts, so MCP search missed the record by name. Keep the key
+	// guard on reprint.
+	case upper == s && len(s) == 3 && !isDisplayNameKey(key) && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
 		return false
 	}
 	tokens := ftsQueryTokenRE.FindAllString(s, -1)
@@ -946,6 +956,19 @@ func isIdentifierKey(key string) bool {
 		strings.HasSuffix(lower, "-id") ||
 		strings.HasSuffix(key, "Id") ||
 		strings.HasSuffix(key, "ID")
+}
+
+// isDisplayNameKey reports whether key holds a record's human-readable name.
+// Hand-fix (issue #148): such values must stay in the search index even when
+// they look like a bare 3-letter all-caps code (a NetBIOS/host label like WEB
+// or SQL), so search-by-name finds the record.
+func isDisplayNameKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "name", "alias", "full_name", "fullname", "username",
+		"display_name", "displayname", "hostname", "device_name", "client_code":
+		return true
+	}
+	return false
 }
 
 func ftsMatchQuery(query string) string {

--- a/skills/axcient/handfixes.json
+++ b/skills/axcient/handfixes.json
@@ -162,6 +162,31 @@
         {"file": "cli/internal/mcp/cobratree/shellout.go", "not_contains": "\"client\":   true"},
         {"file": "cli/internal/mcp/cobratree/shellout_test.go", "contains": "TestCliArgsFromMCP_ForwardsClientFilter", "min_count": 1}
       ]
+    },
+    {
+      "id": "fts-display-name-three-letter-caps",
+      "summary": "FTS index filter must not drop a record's display NAME when it is a 3-letter all-caps host label (WEB/SQL/DNS); search-by-name missed those records",
+      "why": "shouldIndexSearchString (cli/internal/store/store.go) had a value-based, KEY-BLIND branch dropping any 3-letter all-caps string (intended for currency/country codes like USD/GBP). Being key-blind it also discarded a record's name/alias when the name was a 3-letter all-caps NetBIOS/host label (WEB/SQL/DNS/DMZ/APP/VPN/CRM/ERP - ubiquitous in MSP fleets), so the name never entered resources_fts and MCP search returned 0 rows for it while list/get (live API) still found it (issue #148, reported by Barret). Fix: gate the drop on !isDisplayNameKey(key) + added isDisplayNameKey helper; bumped StoreSchemaVersion AND resourcesFTSContentSchemaVersion 4->5 (kept equal) so existing synced DBs rebuild FTS through the fixed filter once on the next sync. TestSearchByThreeLetterUpperName_Issue148 fails without the guard.",
+      "status": "active",
+      "spec_encode_followup": "Belongs in the press content-extraction template: the 3-letter all-caps suppression must be key-aware (exempt display-name keys), and a content-filter change must bump the FTS-content schema version (kept <= StoreSchemaVersion) to re-index existing DBs. Printing-press retro filed alongside #148.",
+      "asserts": [
+        {"file": "cli/internal/store/store.go", "contains": "isDisplayNameKey", "min_count": 2},
+        {"file": "cli/internal/store/store.go", "contains": "!isDisplayNameKey(key)", "min_count": 1},
+        {"file": "cli/internal/store/store.go", "contains": "const resourcesFTSContentSchemaVersion = 5", "min_count": 1},
+        {"file": "cli/internal/store/display_name_index_test.go", "contains": "TestSearchByThreeLetterUpperName_Issue148", "min_count": 1}
+      ]
+    },
+    {
+      "id": "mcp-search-unsynced-guidance",
+      "summary": "MCP search must give actionable 'run sync first' guidance instead of a cryptic SQLite error / bare null on an unsynced or empty local DB",
+      "why": "handleSearch (cli/internal/mcp/tools.go) opens the local DB read-only and queried it directly: on a missing/never-synced DB OpenReadOnly (mode=ro) surfaced SQLite 'out of memory (14)', and a no-match returned a bare 'null' from toolResultJSON(nil) - both read as 'search is broken' to an MCP user, while the CLI search path emits sync hints (issue #148, reported by Barret). Fix: stat dbPath() and return 'run the sync tool first' when absent; return a 'No matches ... run sync' hint on empty results; keep JSON results unchanged on a real match.",
+      "status": "active",
+      "spec_encode_followup": "Belongs in the press MCP local-DB tool template: search/sql handlers should stat the DB and surface a sync hint instead of leaking the raw SQLite open error, and return a structured empty/hint result rather than a bare null. Printing-press retro filed alongside #148.",
+      "asserts": [
+        {"file": "cli/internal/mcp/tools.go", "contains": "run the 'sync' tool first", "min_count": 1},
+        {"file": "cli/internal/mcp/tools.go", "contains": "Hand-fix (issue #148", "min_count": 1},
+        {"file": "cli/internal/mcp/search_guidance_test.go", "contains": "TestHandleSearch_Issue148_Guidance", "min_count": 1}
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #148 (reported by Barret). The MCP `search` tool missed records whose name is a 3-letter all-caps host label (WEB, SQL, DNS, DMZ, APP, VPN, CRM, ERP), common in MSP fleets. Other MCP tools (list/get/health) hit the live API and always returned the record, so it presented as "works except for the search via record name."

## Root cause
`shouldIndexSearchString` (`store.go`) had a value-based, **key-blind** branch that drops any 3-letter all-caps string (intended for currency/country codes like USD/GBP). Being key-blind it also discarded a record's `name`/`alias`, so the name never entered `resources_fts.content` and a MATCH on it returned 0 rows. `search` is the only MCP tool that reads the local FTS index, which is why only it failed.

Found via a parallel diagnosis workflow (4 reproductions -> synthesis -> adversarial verify); independently reproduced (device `WEB` -> search returns 0; control `AcmeServer01` -> 1) and the fix adversarially verified.

## Fix
- **`store.go`**: gate the 3-letter all-caps drop on `!isDisplayNameKey(key)` (+ helper) so display names stay indexed while bare codes in non-name fields are still dropped. Bump `StoreSchemaVersion` and `resourcesFTSContentSchemaVersion` 4->5 (kept equal) so existing local DBs rebuild the FTS index through the fixed filter once on the next `sync`.
- **`tools.go` (bundled)**: MCP `search` now returns "run the `sync` tool first" on a missing/unsynced DB instead of a cryptic SQLite `out of memory (14)`, and a clear hint instead of a bare `null` on no matches.
- Regression tests (3-letter name searchable, proven to fail pre-fix; the MCP guidance branches) + hand-fix ledger markers.

## Impact
Bug-fix-only. Existing users re-index by running `sync` once after upgrading. Patch -> `axcient-v0.2.7`.

## Verification
- `go test ./...` green; `go vet` clean; both binaries build.
- `check_handfixes.py --slug axcient` PASS.
- Security/correctness gate (0 P1): `check_security_gate.py`; fresh-context adversarial agent (empirically verified the 4->5 migration rebuilds FTS exactly once, no perpetual rebuild, no data loss); codex (gpt-5) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search now correctly finds devices with 3-letter all-uppercase names or aliases
  * Improved error guidance when the local search database requires synchronization
  * Search queries now provide clear feedback when no matches are found

* **Documentation**
  * Updated changelog for v0.2.7 with resolved search and database issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->