### PR TITLE
fix(halopsa): resolve {tenant}/{domain} in the OAuth token URL (#147)

### DIFF
--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.2.1] - unreleased
+## [0.2.2] - unreleased
+
+### Fixed
+- OAuth2 authentication now resolves the `{tenant}` and `{domain}` endpoint
+  placeholders in the token URL, so `auth login`, automatic token minting, and
+  refresh no longer fail with `invalid character "{" in host name`, on Windows
+  or any platform. The token-mint paths previously POSTed the literal
+  `https://{tenant}.{domain}/auth/token` because they bypassed the URL
+  substitution used for ordinary requests. Thanks to @Xenith-B for the report
+  (#147).
 
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.

--- a/skills/halopsa/cli/internal/cli/auth.go
+++ b/skills/halopsa/cli/internal/cli/auth.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"halopsa-pp-cli/internal/client"
 	"halopsa-pp-cli/internal/cliutil"
 	"halopsa-pp-cli/internal/config"
 )
@@ -85,6 +86,10 @@ Credentials default to HALOPSA_CLIENT_ID (Client ID) and HALOPSA_CLIENT_SECRET (
 			tokenURL := cfg.TokenURL
 			if tokenURL == "" {
 				tokenURL = "https://{tenant}.{domain}/auth/token"
+			}
+			tokenURL, err = client.ResolveTemplateURL(tokenURL, cfg.TemplateVars)
+			if err != nil {
+				return configErr(err)
 			}
 			tok, err := mintClientCredentialsToken(http.DefaultClient, tokenURL, clientID, clientSecret)
 			if err != nil {

--- a/skills/halopsa/cli/internal/client/client.go
+++ b/skills/halopsa/cli/internal/client/client.go
@@ -932,6 +932,16 @@ func resolveClientCredentialsScope() string {
 	return "all"
 }
 
+// templateVarsFrom returns the {placeholder} -> value map populated at config
+// Load() time, or nil when there is no config — so the token-URL substitution
+// in the mint/refresh paths is nil-safe.
+func templateVarsFrom(cfg *config.Config) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.TemplateVars
+}
+
 func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error {
 	tokenURL := ""
 	if c.Config != nil {
@@ -942,6 +952,10 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	}
 	if tokenURL == "" {
 		return nil
+	}
+	tokenURL, err := ResolveTemplateURL(tokenURL, templateVarsFrom(c.Config))
+	if err != nil {
+		return fmt.Errorf("building token request: %w", err)
 	}
 	form := url.Values{
 		"grant_type":    {"client_credentials"},
@@ -1003,6 +1017,10 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {
 		tokenURL = "https://{tenant}.{domain}/auth/token"
+	}
+	tokenURL, err := ResolveTemplateURL(tokenURL, templateVarsFrom(c.Config))
+	if err != nil {
+		return fmt.Errorf("building refresh request: %w", err)
 	}
 
 	params := url.Values{

--- a/skills/halopsa/cli/internal/client/url.go
+++ b/skills/halopsa/cli/internal/client/url.go
@@ -63,6 +63,17 @@ func buildURL(baseURL, path string, vars map[string]string) (string, error) {
 	return "", &TemplateVarError{Names: unresolved}
 }
 
+// ResolveTemplateURL substitutes {placeholder} markers in a standalone URL
+// (e.g. the OAuth2 token endpoint) against vars — the same substitution
+// buildURL applies to request URLs. The OAuth mint/refresh paths assemble
+// their token URL outside the normal request flow, so without this they would
+// POST a literal "https://{tenant}.{domain}/auth/token" and fail with
+// `invalid character "{" in host name`. Returns a TemplateVarError naming the
+// env var to export when a placeholder is genuinely unresolved.
+func ResolveTemplateURL(rawURL string, vars map[string]string) (string, error) {
+	return buildURL(rawURL, "", vars)
+}
+
 // TemplateVarError reports unresolved {var} placeholders detected at request
 // time. The message names the env var(s) the user needs to export — not just
 // the placeholder — because the placeholder ("shop") is implementation

--- a/skills/halopsa/cli/internal/client/url_token_resolution_test.go
+++ b/skills/halopsa/cli/internal/client/url_token_resolution_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestResolveTemplateURL_TokenEndpoint is the regression guard for issue #147:
+// the OAuth token-mint/refresh paths used to POST a literal
+// "https://{tenant}.{domain}/auth/token" because they never substituted the
+// {placeholder} markers, so http.NewRequest rejected it with
+// `invalid character "{" in host name`. ResolveTemplateURL now routes that URL
+// through the same substitution buildURL applies to request URLs.
+func TestResolveTemplateURL_TokenEndpoint(t *testing.T) {
+	const raw = "https://{tenant}.{domain}/auth/token"
+
+	// 1. With both vars set, placeholders resolve and the URL is requestable.
+	vars := map[string]string{"tenant": "acme", "domain": "halopsa.com"}
+	got, err := ResolveTemplateURL(raw, vars)
+	if err != nil {
+		t.Fatalf("ResolveTemplateURL returned error for resolvable URL: %v", err)
+	}
+	if want := "https://acme.halopsa.com/auth/token"; got != want {
+		t.Fatalf("substitution mismatch: got %q want %q", got, want)
+	}
+	if strings.ContainsAny(got, "{}") {
+		t.Fatalf("resolved URL still carries placeholder braces: %q", got)
+	}
+	if _, err := http.NewRequest(http.MethodPost, got, nil); err != nil {
+		t.Fatalf("resolved URL is not requestable (the #147 symptom): %v", err)
+	}
+
+	// 2. With an unresolved var, the error names the env var to export rather
+	//    than silently shipping a literal placeholder into the request.
+	if _, err := ResolveTemplateURL(raw, map[string]string{"domain": "halopsa.com"}); err == nil {
+		t.Fatal("expected a TemplateVarError when {tenant} is unresolved, got nil")
+	} else if !strings.Contains(err.Error(), "HALOPSA_TENANT") {
+		t.Fatalf("error should name the env var to export, got: %v", err)
+	}
+}

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -1,0 +1,35 @@
+{
+  "slug": "halopsa",
+  "doc": "CHANGELOG.md (#147)",
+  "_comment": "Connector-specific edits a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #147 (reporter @Xenith-B), fixed 2026-06-20. The OAuth2 token-mint/refresh paths assembled the token URL ('https://{tenant}.{domain}/auth/token') outside the normal request flow and POSTed it WITHOUT substituting the {tenant}/{domain} placeholders that buildURL resolves for ordinary requests -- so every `auth login`, auto-mint, and refresh failed with `invalid character \"{\" in host name`, even when HALOPSA_TENANT/HALOPSA_DOMAIN were set correctly. Fix routes the token URL through a new exported ResolveTemplateURL helper (wrapping the existing buildURL substitution). This is a GENERATOR-class defect (the press emits token-URL literals it never resolves) tracked for an upstream retro; until the press is fixed, a reprint regenerates the unresolved literals and these markers guard the connector. No new flag/command/output; bug-fix-only.",
+  "handfixes": [
+    {
+      "id": "token-url-template-substitution",
+      "summary": "OAuth2 token URL is run through ResolveTemplateURL so {tenant}/{domain} resolve before the POST (issue #147)",
+      "why": "The mint/refresh/auth-login paths build the token URL outside buildURL and would POST a literal 'https://{tenant}.{domain}/auth/token', which http.NewRequest rejects. A reprint regenerates these paths as unresolved literals; these markers ensure the substitution call survives.",
+      "status": "active",
+      "asserts": [
+        {
+          "file": "cli/internal/client/url.go",
+          "contains": "func ResolveTemplateURL(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/client/client.go",
+          "contains": "ResolveTemplateURL(tokenURL, templateVarsFrom(c.Config))",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/auth.go",
+          "contains": "client.ResolveTemplateURL(tokenURL, cfg.TemplateVars)",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/client/url_token_resolution_test.go",
+          "contains": "TestResolveTemplateURL_TokenEndpoint",
+          "min_count": 1
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What
The OAuth2 token-mint, auto-mint, and refresh paths assembled the token URL outside the normal request flow and POSTed the literal `https://{tenant}.{domain}/auth/token`, so `http.NewRequest` failed with `invalid character "{" in host name` on **every** authenticated attempt — even when `HALOPSA_TENANT`/`HALOPSA_DOMAIN` were set correctly (the Windows report was incidental; the bug is platform-independent).

The ordinary request path already substitutes `{tenant}`/`{domain}` via `buildURL`; the token paths bypassed it. This routes the token URL through a new exported `client.ResolveTemplateURL` (a thin wrapper over the same `buildURL` substitution) at all three sites before the request is built.

## Receipts
- New regression test `url_token_resolution_test.go` asserts the token URL resolves + is requestable, and errors actionably when a var is unresolved.
- Binary smoke: with env set, `auth login` now reaches `acme.halopsa.com` (real HTTP response) instead of the brace parse error.
- `handfixes.json` ledger records the markers (generator-class gap; a press retro follows — the press emits token-URL literals it never substitutes).
- Security: deterministic gate + codex + fresh-context review → **no P1 introduced**. (One pre-existing fleet G101 false-positive on `sync.go`'s endpoint-path map is cleared by a separate CODEOWNERS suppressions PR.)

## Impact
Bug-fix-only (Class A): no new command/flag/output/permission. Ships as `halopsa-v0.2.2` (absorbing the never-tagged phantom 0.2.1).

Fixes #147. Thanks to @Xenith-B for the report.