### PR TITLE
fix(axcient): MCP search returns concise projection by default (Refs #101)

### DIFF
--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.8] - unreleased
+
+### Fixed
+- MCP `search` now returns the concise `id/name/type/match` projection by default
+  instead of dumping whole raw records, matching the CLI `search` command and the
+  connector guide. The v0.2.4 projection fix only covered the CLI path; the MCP
+  `search` tool is a separate hand-wired handler that kept marshalling the full
+  records via `db.Search`, so MCP/agent users still saw a wall of nested JSON
+  (e.g. complete client objects with all `devices_counters` blocks) through
+  v0.2.7. A new `full` boolean parameter restores the whole records, mirroring the
+  CLI's `--full`. (reported via #101)
+
 ## [0.2.7] - unreleased
 
 ### Fixed

--- a/skills/axcient/cli/internal/mcp/search_project.go
+++ b/skills/axcient/cli/internal/mcp/search_project.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// Hand-authored (NOT generated). Concise-projection for the MCP `search` tool.
+// Issue #101 residual item #2: the v0.2.4 fix gave the CLI `search` command a
+// concise id/name/type/match projection, but the MCP `search` tool (a separate
+// hand-wired handler) kept dumping whole raw records — a token sink for the very
+// agents the projection exists to protect. This mirrors the CLI projection on the
+// MCP surface; `full=true` restores raw records (parity with the CLI's --full).
+//
+// ponytail: this is a small deliberate mirror of internal/cli/search_projection.go
+// (projectSearchHit/matchIndicator). The two live in different packages and the CLI
+// copy is pinned by its own unit tests; the durable single-source home is the press
+// (see handfixes.json: search-concise-projection spec_encode_followup + the
+// /printing-press-retro filed for issue #101). Consolidate there, not here.
+
+package mcp
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"axcient-pp-cli/internal/store"
+)
+
+type searchRow struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Match string `json:"match"`
+}
+
+// searchIDFields mirrors the live x360Recover key shapes (Python-style id_
+// included); searchNameFields lists common human-label fields, best first.
+// Kept in sync with internal/cli/search_projection.go.
+var searchIDFields = []string{"id_", "id", "uid", "uuid", "guid", "gid", "sid", "key", "code"}
+var searchNameFields = []string{"name", "title", "identifier", "alias", "hostname", "label", "display_name", "client_name", "device_name", "email", "subject"}
+
+// projectSearchHit reduces a raw record to {id, name, type, match}.
+func projectSearchHit(hit store.SearchHit, query string) searchRow {
+	row := searchRow{Type: hit.ResourceType}
+	var obj map[string]any
+	if err := json.Unmarshal(hit.Data, &obj); err != nil {
+		return row
+	}
+	for _, f := range searchIDFields {
+		if v := store.LookupFieldValue(obj, f); v != nil {
+			if s := store.ResourceIDString(v); s != "" && s != "<nil>" {
+				row.ID = s
+				break
+			}
+		}
+	}
+	for _, f := range searchNameFields {
+		if v := store.LookupFieldValue(obj, f); v != nil {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				row.Name = strings.TrimSpace(s)
+				break
+			}
+		}
+	}
+	row.Match = searchMatchIndicator(obj, query)
+	return row
+}
+
+// searchMatchIndicator finds the first top-level string field (deterministic
+// order) whose value contains the query term case-insensitively, as "field~term".
+func searchMatchIndicator(obj map[string]any, query string) string {
+	term := strings.TrimSpace(query)
+	if term == "" {
+		return ""
+	}
+	needle := strings.ToLower(term)
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if s, ok := obj[k].(string); ok && strings.Contains(strings.ToLower(s), needle) {
+			return k + "~" + term
+		}
+	}
+	return ""
+}

--- a/skills/axcient/cli/internal/mcp/search_project_test.go
+++ b/skills/axcient/cli/internal/mcp/search_project_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// Hand-authored tests for the MCP `search` concise projection (issue #101
+// residual item #2): the MCP search tool, like the CLI, must default to the
+// id/name/type/match projection rather than dumping whole raw records.
+
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"axcient-pp-cli/internal/store"
+)
+
+func TestProjectSearchHit_DeviceShape(t *testing.T) {
+	hit := store.SearchHit{
+		ResourceType: "device",
+		Data:         json.RawMessage(`{"id_":7654321,"name":"Acme-FS01","devices_counters":{"nested":"WALL_OF_JSON"}}`),
+	}
+	row := projectSearchHit(hit, "Acme")
+	// Numeric id_ must render as an integer, not scientific notation (1.234e+06).
+	if row.ID != "7654321" {
+		t.Fatalf("ID = %q, want 7654321", row.ID)
+	}
+	if row.Name != "Acme-FS01" {
+		t.Fatalf("Name = %q, want Acme-FS01", row.Name)
+	}
+	if row.Type != "device" {
+		t.Fatalf("Type = %q, want device", row.Type)
+	}
+	if row.Match != "name~Acme" {
+		t.Fatalf("Match = %q, want name~Acme", row.Match)
+	}
+
+	// The projected row must NOT carry the raw nested blocks the tester reported
+	// (devices_counters) — that's the whole point of the projection.
+	out, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(out); strings.Contains(got, "devices_counters") || strings.Contains(got, "WALL_OF_JSON") {
+		t.Fatalf("projection leaked raw record fields: %s", got)
+	}
+}
+
+func TestSearchMatchIndicator(t *testing.T) {
+	obj := map[string]any{"name": "Acme-FS01", "note": "hello world"}
+	if got := searchMatchIndicator(obj, "Acme"); got != "name~Acme" {
+		t.Fatalf("searchMatchIndicator(Acme) = %q, want name~Acme", got)
+	}
+	if got := searchMatchIndicator(obj, "world"); got != "note~world" {
+		t.Fatalf("searchMatchIndicator(world) = %q, want note~world", got)
+	}
+	if got := searchMatchIndicator(obj, "zzz"); got != "" {
+		t.Fatalf("searchMatchIndicator(no-substring) = %q, want empty", got)
+	}
+}

--- a/skills/axcient/cli/internal/mcp/tools.go
+++ b/skills/axcient/cli/internal/mcp/tools.go
@@ -298,6 +298,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
 			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithBoolean("full", mcplib.Description("Return whole raw records instead of the concise id/name/type/match projection (default false)")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 		),
@@ -688,6 +689,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if v, ok := args["limit"].(float64); ok && v > 0 {
 		limit = int(v)
 	}
+	full, _ := args["full"].(bool)
 
 	// Hand-fix (issue #148): search reads the LOCAL synced DB. When it has not
 	// been populated, OpenReadOnly (mode=ro) surfaces a cryptic SQLite
@@ -702,18 +704,39 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	}
 	defer db.Close()
 
-	results, err := db.Search(query, limit)
+	// Hand-fix (issue #101 residual #2): default to the concise id/name/type/match
+	// projection so agents aren't handed a wall of nested JSON; full=true restores
+	// whole raw records (parity with the CLI's --full). The MCP path was missed by
+	// the v0.2.4 CLI-only projection fix. See internal/mcp/search_project.go.
+	if full {
+		results, err := db.Search(query, limit)
+		if err != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+		}
+		if len(results) == 0 {
+			return noSearchMatches(query), nil
+		}
+		return toolResultJSON(results)
+	}
+
+	hits, err := db.SearchHits(query, limit)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
-
-	// Hand-fix (issue #148): a bare `null` on no matches reads as "search is
-	// broken"; return an actionable hint (stale/unsynced data is the common cause).
-	if len(results) == 0 {
-		return mcplib.NewToolResultText(fmt.Sprintf("No matches for %q. If your local data is stale or unsynced, run the 'sync' tool first, then search again.", query)), nil
+	if len(hits) == 0 {
+		return noSearchMatches(query), nil
 	}
+	rows := make([]searchRow, 0, len(hits))
+	for _, h := range hits {
+		rows = append(rows, projectSearchHit(h, query))
+	}
+	return toolResultJSON(rows)
+}
 
-	return toolResultJSON(results)
+// noSearchMatches is the shared "no matches" hint (issue #148): a bare `null`
+// reads as "search is broken", so point at stale/unsynced data instead.
+func noSearchMatches(query string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(fmt.Sprintf("No matches for %q. If your local data is stale or unsynced, run the 'sync' tool first, then search again.", query))
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised

--- a/skills/axcient/handfixes.json
+++ b/skills/axcient/handfixes.json
@@ -105,15 +105,18 @@
     },
     {
       "id": "search-concise-projection",
-      "summary": "`search` defaults to a concise id/name/type/match projection (not whole raw records); --full restores raw. Logic lives in hand-authored files so a reprint can't clobber it.",
-      "why": "Issue #84/#101 residual item: `search` dumped entire raw JSON records, a token sink for agents. The fix adds store.SearchHits (returns resource_type alongside data) and a renderSearchResults projection, both in HAND-AUTHORED files (internal/store/search_hits.go, internal/cli/search_projection.go) that a cli-printing-press reprint of store.go/search.go won't touch. The generated search.go carries only a minimal hook (--full flag + SearchHits calls + renderSearchResults). A reprint must re-apply that hook; the asserts below fail CI if it regressed. Default-dumping-raw is systemic press behavior (a printing-press retro tracks the upstream fix).",
+      "summary": "`search` defaults to a concise id/name/type/match projection (not whole raw records) on BOTH the CLI and MCP surfaces; --full (CLI) / full=true (MCP) restores raw. Logic lives in hand-authored files so a reprint can't clobber it.",
+      "why": "Issue #84/#101 residual item: `search` dumped entire raw JSON records, a token sink for agents. The fix adds store.SearchHits (returns resource_type alongside data) and a renderSearchResults projection, both in HAND-AUTHORED files (internal/store/search_hits.go, internal/cli/search_projection.go) that a cli-printing-press reprint of store.go/search.go won't touch. The generated search.go carries only a minimal hook (--full flag + SearchHits calls + renderSearchResults). A reprint must re-apply that hook; the asserts below fail CI if it regressed. Default-dumping-raw is systemic press behavior (a printing-press retro tracks the upstream fix). Issue #101 follow-up (v0.2.8): the v0.2.4 fix only covered the CLI; the MCP `search` tool (internal/mcp/tools.go handleSearch) is a SEPARATE hand-wired handler that kept dumping raw via db.Search+toolResultJSON, so MCP/agent users still saw whole records through v0.2.7. handleSearch now defaults to db.SearchHits+projectSearchHit (hand-authored internal/mcp/search_project.go) and only db.Search-dumps when the new full=true param is set. A reprint of tools.go must re-apply that hook.",
       "status": "active",
-      "spec_encode_followup": "Belongs in the press: the generated search command should offer a concise projection by default with a --full opt-in. Until a reprint absorbs it, the hand-authored files + this hook guard it.",
+      "spec_encode_followup": "Belongs in the press: the generated search command AND the generated MCP search tool should both offer a concise projection by default with a --full / full opt-in. Until a reprint absorbs it, the hand-authored files + these hooks guard it.",
       "asserts": [
         {"file": "cli/internal/store/search_hits.go", "contains": "func (s *Store) SearchHits", "min_count": 1},
         {"file": "cli/internal/cli/search_projection.go", "contains": "func renderSearchResults", "min_count": 1},
         {"file": "cli/internal/cli/search.go", "contains": "renderSearchResults", "min_count": 1},
-        {"file": "cli/internal/cli/search.go", "contains": "db.SearchHits", "min_count": 2}
+        {"file": "cli/internal/cli/search.go", "contains": "db.SearchHits", "min_count": 2},
+        {"file": "cli/internal/mcp/search_project.go", "contains": "func projectSearchHit", "min_count": 1},
+        {"file": "cli/internal/mcp/tools.go", "contains": "projectSearchHit", "min_count": 1},
+        {"file": "cli/internal/mcp/tools.go", "contains": "db.SearchHits", "min_count": 1}
       ]
     },
     {


### PR DESCRIPTION
## What

The MCP `search` tool returned **whole raw records** by default — a token sink for the agents this connector serves. The v0.2.4 concise-projection fix (`internal/cli/search_projection.go`) only touched the **CLI** `search` command; that command is `mcp:hidden`, so the MCP `search` tool is a **separate hand-wired handler** (`internal/mcp/tools.go` `handleSearch`) that kept marshalling the full `[]json.RawMessage` via `db.Search` + `toolResultJSON`. MCP/agent users therefore still saw complete client objects (all nested `devices_counters` blocks) through **v0.2.7** — exactly what the reporter retested and reported.

## Fix

- `handleSearch` now defaults to `db.SearchHits` + a concise `id/name/type/match` projection (new hand-authored `internal/mcp/search_project.go`, mirroring the CLI's `search_projection.go`).
- New `full` boolean MCP param restores whole raw records — parity with the CLI's `--full` (that branch is byte-identical to the prior path).
- The #148 not-synced / no-match guidance hints are preserved (shared `noSearchMatches`).
- Adds an MCP projection unit test (the gap) and extends the `search-concise-projection` handfix ledger to the MCP path (3 new asserts) so a reprint can't silently clobber it.

The connector guide already documents "concise id/name/type/match view by default; add --full for whole records" — this makes the **MCP surface conform to the already-documented behavior**, so no docs/prose regeneration is needed.

## Scope — Refs #101 (multi-item tracker, intentionally NOT auto-closed)

- **Item 2 (search verbosity)** — resolved here.
- **Items 1 (dup vault identities) & 3 (AutoVerify portal screenshots)** — remain open, blocked on the live tenant (cannot diagnose offline; the issue itself scopes these to a live-tenant pass).
- **Item 4 (doctor/MCP auth hint)** — already resolved in v0.2.4.

## Verification

- `go build ./...`, `go vet ./...`, full `go test ./...` — all green (incl. new MCP projection test + existing #148 guidance test).
- `check_handfixes.py --slug axcient` — PASS (all markers incl. 3 new MCP asserts).
- Local security review (Layer 3): deterministic gate `0 P1` (11 pre-existing G104 P2s, none in this diff) + fresh-context adversarial agent `PASS, zero P1/P2`. No `go.mod`/`go.sum` changes; `validateReadOnlyQuery` untouched; read-only annotations preserved; default now returns *less* data.

## Follow-up (not in this PR)

`/printing-press-retro`: the press emits an **unprojected MCP search handler** beside a projected CLI path fleet-wide — the durable home for this projection is the generator (tracked in the handfix `spec_encode_followup`).

Release: patch → `axcient-v0.2.8` after merge (CHANGELOG section staged as `## [0.2.8] - unreleased`).

Reported via #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search tool now returns concise results (id/name/type/match) by default for improved readability
  * New `full` parameter available to retrieve complete records when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->