### PR TITLE
chore: gitignore connector cli/-root binaries fleet-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,17 +66,14 @@ skills/*/*-mcp
 skills/*/*-cli-*
 skills/*/*-mcp-*
 # Locally-built binaries at a vendored Go module root (skills/<skill>/cli/).
-# The Go source under cli/ (including cmd/<name>-pp-cli/ dirs) IS tracked; only
-# build OUTPUTS are ignored. Paths are anchored to the module root so they never
-# match the cmd/ source directories. The Makefile emits to bin/ (already ignored).
-skills/halopsa/cli/halopsa-pp-cli
-skills/halopsa/cli/halopsa-pp-mcp
-skills/halopsa/cli/halopsa-cli
-skills/halopsa/cli/halopsa-mcp
-skills/servosity/cli/servosity-pp-cli
-skills/servosity/cli/servosity-pp-mcp
-skills/servosity/cli/servosity-cli
-skills/servosity/cli/servosity-mcp
+# A stray `go build -o <slug>-mcp` at the module root drops a 60+ MB binary one
+# level under cli/, which the skills/*/*-mcp rule above does NOT reach. These
+# globs catch every connector (incl. the -pp- internal variants) by convention,
+# so a new skill can't reintroduce the gap. The `*` cannot cross `/`, so they
+# match only cli/<name> and never the tracked cli/cmd/<name>/ source dirs.
+# (The Makefile emits to bin/, already ignored; this covers manual builds.)
+skills/*/cli/*-cli
+skills/*/cli/*-mcp
 *.mcpb
 # Go workspace
 go.work


### PR DESCRIPTION
## Why
A stray `go build -o axcient-mcp` (run at the module root rather than the Makefile's `bin/` target) left a **68 MB Mach-O binary** at `skills/axcient/cli/axcient-mcp` — and it was **not gitignored**, so a careless `git add -A` could have swept it into a commit/release. Root cause: the `cli/`-root binary ignores were **hardcoded per-connector** (only `halopsa` + `servosity`); the generic `skills/*/*-mcp` rule stops one level above `cli/`, so every other connector (axcient included) had the gap.

## Change
Replace the 8 hardcoded lines with two convention globs:

```
skills/*/cli/*-cli
skills/*/cli/*-mcp
```

- Covers **every** connector and the `-pp-` internal variants — a new skill can't reintroduce the gap.
- `*` can't cross `/`, so they match only `cli/<name>` (the build output) and **never** the tracked `cli/cmd/<name>/` source dirs. Verified with `git check-ignore`: stray → ignored; `cmd/axcient-mcp`, `cmd/axcient-cli` → not ignored; no tracked file is newly-ignored.

The stray binary itself was deleted; a fleet sweep found no others.

No code or connector files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved `.gitignore` configuration to better manage build artifact exclusions using flexible glob patterns instead of hardcoded paths, reducing repository clutter from development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->