### PR TITLE
fix(hudu): IPAM endpoints non-paginated, enable page walk, skip matchers (#158, #159)

### DIFF
--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3] - unreleased
+
+### Fixed
+- `sync` and the `list` commands no longer send `page` to Hudu's IPAM-family
+  endpoints (`ip-addresses`, `networks`, `vlans`, `vlan-zones`,
+  `rack-storage-items`). The v0.1.2 fix correctly dropped `page_size` but then
+  assumed these endpoints page by `page` - they don't: they are non-paginated
+  and reject `page` with the same HTTP 400, so every sync after the first page
+  failed and stored zero rows. They now fetch the full collection in a single
+  request. The non-functional `--page`/`page` MCP arg is removed for them.
+  Thanks @Xenith-B (#158).
+- `sync` now advances through every page of the paginated resources instead of
+  stopping after the first 100 rows. The pagination profile declared
+  `cursorType ""`, which disabled the `?page=N` page-int fallback, so any
+  resource with more than one page was silently truncated (v0.1.2's new
+  "data may be truncated" warning is what surfaced it on `expirations`,
+  `folders`, `public-photos`, `relations`, and `procedure-tasks`). Set to
+  `cursorType "page"` so the walk runs until a short/empty page. Thanks
+  @Xenith-B (#158).
+- `sync` now skips `matchers` (with a warning) instead of failing on it every
+  run. Hudu's `/matchers` requires an `integration_id` and returns HTTP 500
+  without one; a flat sync cannot supply it, and the connector exposes no
+  endpoint to enumerate integration IDs. Fetch matchers per integration with
+  `hudu-cli matchers list --integration-id <id>`, or
+  `hudu-cli sync --resource-param matchers:integration_id=<id>`. Thanks
+  @Xenith-B (#159).
+
 ## [0.1.2] - unreleased
 
 ### Fixed

--- a/skills/hudu/cli/internal/cli/helpers.go
+++ b/skills/hudu/cli/internal/cli/helpers.go
@@ -408,6 +408,26 @@ func (p *syncUserParams) applyTo(resource string, params map[string]string, isDe
 	}
 }
 
+// hasParam reports whether the user supplied a value for key that would apply
+// to resource — via --resource-param (perResource), --global-param (trueGlobal),
+// or --param (flatGlobal). #159: lets an explicit integration_id satisfy the
+// /matchers sync instead of the loop skipping it unconditionally. Nil-safe.
+func (p *syncUserParams) hasParam(resource, key string) bool {
+	if p == nil {
+		return false
+	}
+	if _, ok := p.perResource[resource][key]; ok {
+		return true
+	}
+	if _, ok := p.trueGlobal[key]; ok {
+		return true
+	}
+	if _, ok := p.flatGlobal[key]; ok {
+		return true
+	}
+	return false
+}
+
 // validateResourceNames returns a usage-shaped error when any --resource-param
 // key targets a resource not in known. Without this check a typo
 // (e.g. --resource-param chanels:mine=true) is a silent no-op: the param

--- a/skills/hudu/cli/internal/cli/ip-addresses_list.go
+++ b/skills/hudu/cli/internal/cli/ip-addresses_list.go
@@ -13,7 +13,6 @@ import (
 
 func newIpAddressesListCmd(flags *rootFlags) *cobra.Command {
 	var flagCompanyId string
-	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -30,9 +29,6 @@ func newIpAddressesListCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			if flagCompanyId != "" {
 				params["company_id"] = formatCLIParamValue(flagCompanyId)
-			}
-			if flagPage != "" {
-				params["page"] = formatCLIParamValue(flagPage)
 			}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "ip-addresses", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
@@ -83,7 +79,6 @@ func newIpAddressesListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagCompanyId, "company-id", "", "Filter by company id")
-	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/cli/networks_list.go
+++ b/skills/hudu/cli/internal/cli/networks_list.go
@@ -13,7 +13,6 @@ import (
 
 func newNetworksListCmd(flags *rootFlags) *cobra.Command {
 	var flagCompanyId string
-	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -30,9 +29,6 @@ func newNetworksListCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			if flagCompanyId != "" {
 				params["company_id"] = formatCLIParamValue(flagCompanyId)
-			}
-			if flagPage != "" {
-				params["page"] = formatCLIParamValue(flagPage)
 			}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "networks", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
@@ -83,7 +79,6 @@ func newNetworksListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagCompanyId, "company-id", "", "Filter by company id")
-	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/cli/rack-storage-items_list.go
+++ b/skills/hudu/cli/internal/cli/rack-storage-items_list.go
@@ -13,7 +13,6 @@ import (
 
 func newRackStorageItemsListCmd(flags *rootFlags) *cobra.Command {
 	var flagRackStorageId string
-	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -30,9 +29,6 @@ func newRackStorageItemsListCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			if flagRackStorageId != "" {
 				params["rack_storage_id"] = formatCLIParamValue(flagRackStorageId)
-			}
-			if flagPage != "" {
-				params["page"] = formatCLIParamValue(flagPage)
 			}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "rack-storage-items", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
@@ -83,7 +79,6 @@ func newRackStorageItemsListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagRackStorageId, "rack-id", "", "Filter by rack storage id")
-	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/cli/sync.go
+++ b/skills/hudu/cli/internal/cli/sync.go
@@ -397,6 +397,27 @@ func syncResource(ctx context.Context, c interface {
 		}
 	}
 
+	// #159: Hudu's /matchers endpoint requires an integration_id query param
+	// (it returns HTTP 500 — not 400 — without one), and the connector exposes
+	// no integrations-list endpoint to enumerate IDs, so a flat `sync` 500s on
+	// matchers every run and exhausts retries. Skip it unless the user supplied
+	// an integration_id (via `--resource-param matchers:integration_id=<id>` or
+	// `--global-param integration_id=<id>`). Fetch matchers per integration with
+	// `hudu-cli matchers list --integration-id <id>`.
+	if resource == "matchers" && !userParams.hasParam("matchers", "integration_id") {
+		const msg = "matchers requires integration_id, which flat sync cannot supply (Hudu returns HTTP 500 without it); skipped. Fetch per integration with `hudu-cli matchers list --integration-id <id>`, or `sync --resource-param matchers:integration_id=<id>`."
+		if !humanFriendly {
+			fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"matchers","reason":"requires_unsuppliable_param","message":%q}`+"\n", msg)
+		} else {
+			fmt.Fprintf(os.Stderr, "  matchers skipped (requires integration_id; use `hudu-cli matchers list --integration-id <id>`)\n")
+		}
+		return syncResult{
+			Resource: resource,
+			Warn:     fmt.Errorf("skipped matchers: requires integration_id"),
+			Duration: time.Since(started),
+		}
+	}
+
 	var totalCount int
 
 	// Resume cursor from sync_state (unless --full cleared it)
@@ -438,7 +459,7 @@ func syncResource(ctx context.Context, c interface {
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
-	lastPageFingerprint := "" // #153: page-until-empty dup guard for page_size-less endpoints
+	lastPageFingerprint := "" // #158: page-int walk dup guard (page-ignoring endpoint)
 	capExitHit := false
 	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
@@ -456,20 +477,19 @@ func syncResource(ctx context.Context, c interface {
 	for {
 		params := map[string]string{}
 
-		if resourceSupportsPagination(resource) {
-			// #153: some Hudu IPAM-family endpoints (ip-addresses, networks,
-			// vlans, vlan-zones, rack-storage-items) reject the page_size
-			// filter with HTTP 400 "page_size is not a valid filter
-			// parameter." Page those by `page` alone and advance until an
-			// empty page (see the more-pages block below) so we neither 400
-			// nor silently truncate.
-			if !resourceRejectsPageSize(resource) {
-				params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
-			}
+		if resourceSupportsPagination(resource) && !resourceRejectsPageSize(resource) {
+			// #158: the IPAM-family endpoints (ip-addresses, networks, vlans,
+			// vlan-zones, rack-storage-items) are non-paginated — they reject
+			// BOTH page_size AND `page` with HTTP 400 ("page is not a valid
+			// filter parameter."; rack-storage-items: "...not a valid
+			// parameter.") and return the whole collection in one response. We
+			// send them no pagination params at all (see the more-pages block,
+			// which stops after that single response). Every other resource
+			// pages by ?page=N (see determinePaginationDefaults, cursorType
+			// "page").
+			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
 			if cursor != "" {
 				params[pageSize.cursorParam] = cursor
-			} else if resourceRejectsPageSize(resource) {
-				params[pageSize.cursorParam] = "1"
 			}
 		}
 
@@ -519,13 +539,26 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if !resourceRejectsPageSize(resource) && pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+			// #158: this fallback advances ?page=N until a short/empty page.
+			// Guard the page-ignoring endpoint (one that re-returns the same
+			// full collection for every page) and a runaway: stop advancing
+			// when this page is byte-identical to the last (fingerprint match)
+			// or we hit the ceiling. The sticky-cursor detector below can't
+			// catch this because the synthetic page number always changes, and
+			// --max-pages defaults to 0 (unlimited), so without this guard a
+			// page-ignoring endpoint loops forever. Leaving nextCursor "" ends
+			// the walk naturally and emits the missing-cursor truncation warning.
+			fp := pageFingerprint(items)
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
 			}
-			nextCursor = strconv.Itoa(currentPage + 1)
-			hasMore = true
+			if fp != lastPageFingerprint && currentPage < pageIntWalkCeiling {
+				lastPageFingerprint = fp
+				nextCursor = strconv.Itoa(currentPage + 1)
+				hasMore = true
+			}
 		}
 		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
@@ -606,7 +639,11 @@ func syncResource(ctx context.Context, c interface {
 
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+		if resourceSupportsPagination(resource) && !resourceRejectsPageSize(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+			// #158: skip non-paginated (resourceRejectsPageSize) endpoints —
+			// their single full response IS the whole collection, so the
+			// "data may be truncated" warning would be a false alarm (and it
+			// is the very warning #158 reported).
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 
@@ -681,40 +718,15 @@ func syncResource(ctx context.Context, c interface {
 			break
 		}
 		if resourceRejectsPageSize(resource) {
-			// #153 page-until-empty: these endpoints don't accept page_size
-			// and don't report has_more, so advance `page` until a page comes
-			// back empty. The fingerprint guard stops the rare endpoint that
-			// ignores `page` and re-returns the full collection every request
-			// (otherwise we'd loop to the --max-pages cap on duplicate data).
-			if len(items) == 0 {
-				break
-			}
-			fp := pageFingerprint(items)
-			if fp == lastPageFingerprint {
-				break
-			}
-			lastPageFingerprint = fp
-			cur, _ := strconv.Atoi(cursor)
-			if cur < 1 {
-				cur = 1
-			}
-			if cur >= rejectsPageSizePageCeiling {
-				// Backstop for a page-ignoring endpoint whose collection churns
-				// between requests (fingerprint never matches, empty page never
-				// arrives). Bound the walk and warn rather than loop forever.
-				if humanFriendly {
-					fmt.Fprintf(os.Stderr, "\n  %s: reached the %d-page safety ceiling for a page_size-less endpoint; data may be truncated.\n", resource, rejectsPageSizePageCeiling)
-				} else {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"page_ceiling_hit","message":"reached the %d-page safety ceiling for a page_size-less endpoint; data may be truncated (the endpoint may ignore the page parameter)."}`+"\n", resource, rejectsPageSizePageCeiling)
-				}
-				break
-			}
-			nextCursor = strconv.Itoa(cur + 1)
-			if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
-				fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
-			}
-			cursor = nextCursor
-			continue
+			// #158: these IPAM-family endpoints are non-paginated — they reject
+			// `page` (and page_size) and return the full collection in a single
+			// response (confirmed on a live huducloud tenant and by the
+			// n8n-nodes-hudu project, which likewise removed pagination here).
+			// #156 wrongly assumed they page by `page` and walked page=1,2,...,
+			// which 400s on every request after the first. We sent no
+			// pagination params above, so this one response is the whole
+			// collection: stop.
+			break
 		}
 		if !hasMore || len(items) < pageSize.limit {
 			break
@@ -784,9 +796,16 @@ type paginationDefaults struct {
 func determinePaginationDefaults() paginationDefaults {
 	return paginationDefaults{
 		cursorParam: "page",
-		cursorType:  "",
-		limitParam:  "page_size",
-		limit:       100,
+		// #158: Hudu paginates list endpoints by ?page=N and returns no body
+		// cursor. cursorType "page" (not "") activates the page-int fallback so
+		// sync advances page=1,2,... until a short/empty page; cursorType ""
+		// disabled that fallback and silently truncated every resource at the
+		// first 100 rows (the new 4.24 "data may be truncated" warning is what
+		// surfaced it). The non-paginated IPAM endpoints opt out via
+		// resourceRejectsPageSize at every page-advance site.
+		cursorType: "page",
+		limitParam: "page_size",
+		limit:      100,
 	}
 }
 
@@ -852,39 +871,41 @@ func resourceSupportsPagination(resource string) bool {
 	return false
 }
 
-// rejectsPageSizePageCeiling hard-caps the page-until-empty walk (#153) for a
-// page_size-less endpoint, independent of --max-pages (which defaults to 0 =
-// unlimited). The fingerprint guard already terminates a page-ignoring endpoint
-// that returns a STABLE collection; this ceiling is the backstop for the
-// pathological page-ignoring-AND-churning case so the walk degrades to a loud
-// truncation warning instead of a non-terminating loop. 10000 pages is far
-// beyond any real IPAM collection, so it never caps legitimate pagination.
-const rejectsPageSizePageCeiling = 10000
+// pageIntWalkCeiling hard-caps the ?page=N page-int fallback walk (#158),
+// independent of --max-pages (which defaults to 0 = unlimited). The fingerprint
+// dup-guard already terminates a page-ignoring endpoint that returns a STABLE
+// collection; this ceiling is the backstop for the pathological
+// page-ignoring-AND-churning case (fingerprint never matches, short page never
+// arrives) so the walk degrades to a loud truncation warning instead of a
+// non-terminating loop. 10000 pages × 100/page is far beyond any real Hudu
+// collection, so it never caps legitimate pagination.
+const pageIntWalkCeiling = 10000
 
-// resourceRejectsPageSize lists the Hudu IPAM-family list endpoints that reject
-// the `page_size` query param with HTTP 400 ("page_size is not a valid filter
-// parameter." — rack-storage-items returns "...not a valid parameter."). They are
-// paged by `page` alone (or return the full collection in one response); the sync
-// loop pages them until an empty page so we neither 400 nor silently truncate.
-// Keep this set in sync with the per-command list files, which omit --page-size
-// for these resources, and with code_orch.go, which drops the page-size MCP arg.
-// See issue #153 and handfixes.json.
+// pageFingerprint returns a cheap byte-identity for a page of items so the
+// page-int fallback (#158) can detect an endpoint that ignores the `page` param
+// and re-returns the same collection on every request.
+func pageFingerprint(items []json.RawMessage) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return strconv.Itoa(len(items)) + "|" + string(items[0]) + "|" + string(items[len(items)-1])
+}
+
+// resourceRejectsPageSize lists the Hudu IPAM-family list endpoints that are
+// non-paginated: they reject BOTH `page_size` AND `page` with HTTP 400
+// ("page_size/page is not a valid filter parameter." — rack-storage-items
+// returns "...not a valid parameter.") and return the whole collection in one
+// response. sync sends them no pagination params and stops after that single
+// response (see the param-build and more-pages blocks). Keep this set in sync
+// with the per-command list files, which omit --page-size and --page for these
+// resources, and with code_orch.go, which drops the page-size MCP arg. See
+// issues #153 and #158, and handfixes.json.
 func resourceRejectsPageSize(resource string) bool {
 	switch resource {
 	case "ip-addresses", "networks", "vlans", "vlan-zones", "rack-storage-items":
 		return true
 	}
 	return false
-}
-
-// pageFingerprint returns a cheap identity for a page of items so the
-// page-until-empty paginator (#153) can detect an endpoint that ignores the
-// `page` param and re-returns the same collection on every request.
-func pageFingerprint(items []json.RawMessage) string {
-	if len(items) == 0 {
-		return ""
-	}
-	return strconv.Itoa(len(items)) + "|" + string(items[0]) + "|" + string(items[len(items)-1])
 }
 
 // syncResourceSinceParam returns the query parameter name this resource's

--- a/skills/hudu/cli/internal/cli/sync_page_size_test.go
+++ b/skills/hudu/cli/internal/cli/sync_page_size_test.go
@@ -1,18 +1,24 @@
 // Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
-// Hand-authored regression test for issue #153: several Hudu IPAM-family list
-// endpoints reject the `page_size` filter with HTTP 400 ("page_size is not a
-// valid filter parameter."). The connector must page them by `page` alone and
-// drain every page. Guards resourceRejectsPageSize, pageFingerprint, and the
-// page-until-empty sync path. A reprint that drops this file is caught by
-// skills/hudu/handfixes.json — do not remove without porting the fix.
+// Hand-authored regression tests for the Hudu pagination defects:
+//   - #153: the IPAM-family list endpoints reject the `page_size` filter.
+//   - #158: those same endpoints are in fact NON-paginated — they reject
+//     `page` too — so sync must send neither param and fetch them once; and
+//     every other resource must advance by ?page=N (cursorType "page") instead
+//     of truncating at the first page.
+//   - #159: /matchers requires an integration_id, so flat sync must skip it
+//     unless the caller supplies one.
+// A reprint that drops this file is caught by skills/hudu/handfixes.json — do
+// not remove without porting the fixes.
 
 package cli
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"hudu-pp-cli/internal/store"
@@ -22,36 +28,22 @@ func TestResourceRejectsPageSize(t *testing.T) {
 	rejects := []string{"ip-addresses", "networks", "vlans", "vlan-zones", "rack-storage-items"}
 	for _, r := range rejects {
 		if !resourceRejectsPageSize(r) {
-			t.Errorf("resourceRejectsPageSize(%q) = false, want true (endpoint 400s on page_size)", r)
+			t.Errorf("resourceRejectsPageSize(%q) = false, want true (non-paginated; 400s on page and page_size)", r)
 		}
 	}
 	for _, r := range []string{"companies", "articles", "assets", "websites", "users"} {
 		if resourceRejectsPageSize(r) {
-			t.Errorf("resourceRejectsPageSize(%q) = true, want false (endpoint accepts page_size)", r)
+			t.Errorf("resourceRejectsPageSize(%q) = true, want false (endpoint paginates normally)", r)
 		}
 	}
 }
 
-func TestPageFingerprint(t *testing.T) {
-	empty := []json.RawMessage{}
-	if got := pageFingerprint(empty); got != "" {
-		t.Errorf("pageFingerprint(empty) = %q, want \"\"", got)
-	}
-	a := []json.RawMessage{json.RawMessage(`{"id":1}`), json.RawMessage(`{"id":2}`)}
-	b := []json.RawMessage{json.RawMessage(`{"id":3}`), json.RawMessage(`{"id":4}`)}
-	if pageFingerprint(a) == pageFingerprint(b) {
-		t.Error("pageFingerprint: distinct pages must not collide")
-	}
-	if pageFingerprint(a) != pageFingerprint(a) {
-		t.Error("pageFingerprint: identical pages must match (the page-ignoring dup guard)")
-	}
-}
-
 // recordingClient implements the syncResource client interface, records every
-// params map it is handed, and serves canned array pages indexed by `page`.
+// params map it is handed, and serves canned array pages indexed by `page`
+// (absent `page` => page 1; index past the end => empty page).
 type recordingClient struct {
 	seen  []map[string]string
-	pages [][]byte // pages[i] is the body for page i+1; absent index => empty page
+	pages [][]byte
 }
 
 func (r *recordingClient) RateLimit() float64 { return 0 }
@@ -74,92 +66,192 @@ func (r *recordingClient) Get(_ context.Context, _ string, params map[string]str
 	return json.RawMessage(`[]`), nil
 }
 
-func TestSyncResource_PageSizeRejectingEndpoint_PagesByPageOnly(t *testing.T) {
-	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
-	if err != nil {
-		t.Fatalf("open store: %v", err)
-	}
+// TestSyncResource_NonPaginatedEndpoint_FetchesOnceNoPageParam pins the #158
+// fix: the IPAM-family endpoints are non-paginated, so sync sends neither
+// page_size nor page and makes exactly one request even at the unlimited
+// (--max-pages 0) production default. The pre-#158 code sent page=1,2,... and
+// 400'd on every request after the first.
+func TestSyncResource_NonPaginatedEndpoint_FetchesOnceNoPageParam(t *testing.T) {
+	db := openSyncTestDB(t)
 	defer db.Close()
 
 	c := &recordingClient{pages: [][]byte{
-		[]byte(`[{"id":"a1"},{"id":"a2"}]`),
-		[]byte(`[{"id":"a3"},{"id":"a4"}]`),
-		// page 3+ => empty (recordingClient default) => end of data
+		[]byte(`[{"id":"a1"},{"id":"a2"},{"id":"a3"}]`),
 	}}
 
-	res := syncResource(context.Background(), c, db, "ip-addresses", "", true, 10, false, nil, nil)
+	res := syncResource(context.Background(), c, db, "ip-addresses", "", true, 0, false, nil, nil)
 	if res.Err != nil {
 		t.Fatalf("syncResource returned error: %v", res.Err)
 	}
-
-	// (1) page_size must NEVER be sent to a rejecting endpoint — that is the bug.
-	for i, p := range c.seen {
-		if _, bad := p["page_size"]; bad {
-			t.Errorf("request %d carried page_size=%q to a page_size-rejecting endpoint", i, p["page_size"])
-		}
+	// Exactly one request — no page walk (would loop/400 against a real tenant).
+	if len(c.seen) != 1 {
+		t.Fatalf("made %d requests, want exactly 1 (non-paginated endpoint)", len(c.seen))
 	}
-	// (2) the first request must page by `page=1` (not an empty/absent page).
-	if len(c.seen) == 0 || c.seen[0]["page"] != "1" {
-		t.Errorf("first request page = %q, want \"1\"", firstPage(c.seen))
+	// Neither pagination param may be sent — both 400 on these endpoints.
+	if v, bad := c.seen[0]["page"]; bad {
+		t.Errorf("request carried page=%q to a non-paginated endpoint", v)
 	}
-	// (3) every page must be drained — all 4 rows land, no silent truncation.
-	var n int
-	if err := db.DB().QueryRow(
-		`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "ip-addresses",
-	).Scan(&n); err != nil {
-		t.Fatalf("count rows: %v", err)
+	if v, bad := c.seen[0]["page_size"]; bad {
+		t.Errorf("request carried page_size=%q to a non-paginated endpoint", v)
 	}
-	if n != 4 {
-		t.Errorf("stored %d rows, want 4 (pages 1+2 fully drained)", n)
+	// The single response is the whole collection — all rows must land.
+	if n := countRows(t, db, "ip-addresses"); n != 3 {
+		t.Errorf("stored %d rows, want 3 (single response is the full collection)", n)
 	}
 }
 
-// staticClient ignores the `page` param and returns the same body every call —
-// the pathological "endpoint ignores page" shape the fingerprint guard defends.
+// TestSyncResource_PageType_AdvancesUntilShortPage pins the #158 cursorType
+// fix: cursorType "page" drives the page-int fallback so full pages advance
+// page=2,3,... until a short page ends the walk. Pre-#158 (cursorType "") the
+// fallback was dead and every resource truncated at the first 100 rows.
+func TestSyncResource_PageType_AdvancesUntilShortPage(t *testing.T) {
+	db := openSyncTestDB(t)
+	defer db.Close()
+
+	limit := determinePaginationDefaults().limit // 100
+	c := &recordingClient{pages: [][]byte{
+		makePage(1, limit),       // page 1: full
+		makePage(limit+1, limit), // page 2: full
+		makePage(2*limit+1, 5),   // page 3: short -> stop
+	}}
+
+	res := syncResource(context.Background(), c, db, "companies", "", true, 0, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource returned error: %v", res.Err)
+	}
+	if got := len(c.seen); got != 3 {
+		t.Fatalf("made %d requests, want 3 (page-int walk across two full pages)", got)
+	}
+	// First request omits page (cursor == ""); then page=2, page=3.
+	if v, sent := c.seen[0]["page"]; sent {
+		t.Errorf("first request sent page=%q, want no page param", v)
+	}
+	if c.seen[1]["page"] != "2" || c.seen[2]["page"] != "3" {
+		t.Errorf("page sequence = %q,%q, want 2,3", c.seen[1]["page"], c.seen[2]["page"])
+	}
+	if n := countRows(t, db, "companies"); n != 2*limit+5 {
+		t.Errorf("stored %d rows, want %d (no truncation at page 1)", n, 2*limit+5)
+	}
+}
+
+// staticClient ignores `page` and returns the same full page on every call —
+// the page-ignoring shape the fingerprint guard must terminate.
 type staticClient struct {
 	calls int
 	body  []byte
 }
 
 func (s *staticClient) RateLimit() float64 { return 0 }
+
 func (s *staticClient) Get(_ context.Context, _ string, _ map[string]string) (json.RawMessage, error) {
 	s.calls++
 	return json.RawMessage(s.body), nil
 }
 
-func TestSyncResource_PageIgnoringEndpoint_FingerprintTerminatesAtUnlimitedBudget(t *testing.T) {
+// TestSyncResource_PageIgnoringEndpoint_FingerprintTerminates pins the loop
+// backstop for the now-active page-int walk (#158): an endpoint that returns a
+// full page (>= limit) and ignores `page` must NOT loop forever at the
+// unlimited (--max-pages 0) production default — the fingerprint dup-guard
+// stops it on the first repeated page.
+func TestSyncResource_PageIgnoringEndpoint_FingerprintTerminates(t *testing.T) {
+	db := openSyncTestDB(t)
+	defer db.Close()
+
+	limit := determinePaginationDefaults().limit // 100
+	c := &staticClient{body: makePage(1, limit)} // full page, same every call
+	res := syncResource(context.Background(), c, db, "companies", "", true, 0, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource returned error: %v", res.Err)
+	}
+	// Page 1 advances; page 2 is byte-identical -> fingerprint match -> stop.
+	// If the guard were missing this would loop to the page ceiling (or forever).
+	if c.calls != 2 {
+		t.Errorf("made %d requests, want 2 (fingerprint guard must break on the duplicate page)", c.calls)
+	}
+	if n := countRows(t, db, "companies"); n != limit {
+		t.Errorf("stored %d distinct rows, want %d", n, limit)
+	}
+}
+
+// TestSyncResource_Matchers_SkippedWithoutIntegrationID pins the #159 fix: a
+// flat sync must not call /matchers without an integration_id (Hudu 500s), so
+// the resource is skipped with a warning and zero API requests.
+func TestSyncResource_Matchers_SkippedWithoutIntegrationID(t *testing.T) {
+	db := openSyncTestDB(t)
+	defer db.Close()
+
+	c := &recordingClient{pages: [][]byte{[]byte(`[{"id":"m1"}]`)}}
+	res := syncResource(context.Background(), c, db, "matchers", "", true, 0, false, nil, nil)
+
+	if len(c.seen) != 0 {
+		t.Errorf("matchers made %d API requests, want 0 (must skip without integration_id)", len(c.seen))
+	}
+	if res.Warn == nil {
+		t.Error("expected a skip warning for matchers without integration_id")
+	}
+	if res.Err != nil {
+		t.Errorf("skip must not surface an error: %v", res.Err)
+	}
+}
+
+// TestSyncResource_Matchers_SyncedWithIntegrationID pins the escape hatch: an
+// explicit integration_id (via --resource-param) lets matchers sync, and the
+// param is forwarded to the request.
+func TestSyncResource_Matchers_SyncedWithIntegrationID(t *testing.T) {
+	db := openSyncTestDB(t)
+	defer db.Close()
+
+	up, err := parseSyncUserParams(nil, []string{"matchers:integration_id=42"}, nil)
+	if err != nil {
+		t.Fatalf("parseSyncUserParams: %v", err)
+	}
+	c := &recordingClient{pages: [][]byte{[]byte(`[{"id":"m1"}]`)}}
+	res := syncResource(context.Background(), c, db, "matchers", "", true, 0, false, up, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource returned error: %v", res.Err)
+	}
+	if len(c.seen) == 0 {
+		t.Fatal("matchers must be fetched when integration_id is supplied")
+	}
+	if got := c.seen[0]["integration_id"]; got != "42" {
+		t.Errorf("integration_id forwarded = %q, want 42 (params: %v)", got, c.seen[0])
+	}
+	if n := countRows(t, db, "matchers"); n != 1 {
+		t.Errorf("stored %d matcher rows, want 1", n)
+	}
+}
+
+func openSyncTestDB(t *testing.T) *store.Store {
+	t.Helper()
 	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
-	defer db.Close()
+	return db
+}
 
-	c := &staticClient{body: []byte(`[{"id":"n1"},{"id":"n2"},{"id":"n3"}]`)}
-	// maxPages=0 is the PRODUCTION default (unlimited): the fingerprint guard,
-	// not the page cap, must stop the walk. If it doesn't, this test hangs.
-	res := syncResource(context.Background(), c, db, "networks", "", true, 0, false, nil, nil)
-	if res.Err != nil {
-		t.Fatalf("syncResource returned error: %v", res.Err)
-	}
-	// Page 1 stores the set; page 2 returns the identical set → fingerprint
-	// match → break. So exactly 2 requests, and only 3 distinct rows persist.
-	if c.calls != 2 {
-		t.Errorf("made %d requests, want 2 (fingerprint guard must break on the duplicate page)", c.calls)
-	}
+func countRows(t *testing.T, db *store.Store, resource string) int {
+	t.Helper()
 	var n int
 	if err := db.DB().QueryRow(
-		`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "networks",
+		`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, resource,
 	).Scan(&n); err != nil {
 		t.Fatalf("count rows: %v", err)
 	}
-	if n != 3 {
-		t.Errorf("stored %d distinct rows, want 3", n)
-	}
+	return n
 }
 
-func firstPage(seen []map[string]string) string {
-	if len(seen) == 0 {
-		return "<no requests>"
+// makePage builds a JSON array of n objects with sequential integer ids
+// starting at start — used to synthesize full/short pages for the page walk.
+func makePage(start, n int) []byte {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%d}`, start+i)
 	}
-	return seen[0]["page"]
+	b.WriteByte(']')
+	return []byte(b.String())
 }

--- a/skills/hudu/cli/internal/cli/vlan-zones_list.go
+++ b/skills/hudu/cli/internal/cli/vlan-zones_list.go
@@ -13,7 +13,6 @@ import (
 
 func newVlanZonesListCmd(flags *rootFlags) *cobra.Command {
 	var flagCompanyId string
-	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -30,9 +29,6 @@ func newVlanZonesListCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 			if flagCompanyId != "" {
 				params["company_id"] = formatCLIParamValue(flagCompanyId)
-			}
-			if flagPage != "" {
-				params["page"] = formatCLIParamValue(flagPage)
 			}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "vlan-zones", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
@@ -83,7 +79,6 @@ func newVlanZonesListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagCompanyId, "company-id", "", "Filter by company id")
-	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/cli/vlans_list.go
+++ b/skills/hudu/cli/internal/cli/vlans_list.go
@@ -14,7 +14,6 @@ import (
 func newVlansListCmd(flags *rootFlags) *cobra.Command {
 	var flagCompanyId string
 	var flagVlanZoneId string
-	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "list",
@@ -34,9 +33,6 @@ func newVlansListCmd(flags *rootFlags) *cobra.Command {
 			}
 			if flagVlanZoneId != "" {
 				params["vlan_zone_id"] = formatCLIParamValue(flagVlanZoneId)
-			}
-			if flagPage != "" {
-				params["page"] = formatCLIParamValue(flagPage)
 			}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "vlans", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
@@ -88,7 +84,6 @@ func newVlansListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&flagCompanyId, "company-id", "", "Filter by company id")
 	cmd.Flags().StringVar(&flagVlanZoneId, "zone-id", "", "Filter by VLAN zone id")
-	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/mcp/code_orch.go
+++ b/skills/hudu/cli/internal/mcp/code_orch.go
@@ -689,7 +689,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary:        "List IP address records (paginated)",
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
-		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}, {PublicName: "page", WireName: "page"}},
+		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}},
 		keywords:       codeOrchKeywords("ip-addresses", "list", "List IP address records (paginated)", "/ip_addresses"),
 	},
 	{
@@ -839,7 +839,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary:        "List networks (paginated)",
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
-		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}, {PublicName: "page", WireName: "page"}},
+		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}},
 		keywords:       codeOrchKeywords("networks", "list", "List networks (paginated)", "/networks"),
 	},
 	{
@@ -1029,7 +1029,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary:        "List rack storage items (paginated)",
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
-		QueryParams:    []codeOrchParamBinding{{PublicName: "rack-id", WireName: "rack_storage_id"}, {PublicName: "page", WireName: "page"}},
+		QueryParams:    []codeOrchParamBinding{{PublicName: "rack-id", WireName: "rack_storage_id"}},
 		keywords:       codeOrchKeywords("rack-storage-items", "list", "List rack storage items (paginated)", "/rack_storage_items"),
 	},
 	{
@@ -1209,7 +1209,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary:        "List VLAN zones (paginated)",
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
-		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}, {PublicName: "page", WireName: "page"}},
+		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}},
 		keywords:       codeOrchKeywords("vlan-zones", "list", "List VLAN zones (paginated)", "/vlan_zones"),
 	},
 	{
@@ -1259,7 +1259,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Summary:        "List VLANs (paginated)",
 		Positional:     []string{},
 		TemplateParams: []codeOrchParamBinding{},
-		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}, {PublicName: "zone-id", WireName: "vlan_zone_id"}, {PublicName: "page", WireName: "page"}},
+		QueryParams:    []codeOrchParamBinding{{PublicName: "company-id", WireName: "company_id"}, {PublicName: "zone-id", WireName: "vlan_zone_id"}},
 		keywords:       codeOrchKeywords("vlans", "list", "List VLANs (paginated)", "/vlans"),
 	},
 	{

--- a/skills/hudu/handfixes.json
+++ b/skills/hudu/handfixes.json
@@ -37,19 +37,47 @@
     },
     {
       "id": "ipam-endpoints-reject-page-size",
-      "summary": "Five Hudu IPAM-family list endpoints (ip-addresses, networks, vlans, vlan-zones, rack-storage-items) are paged by `page` alone; the `page_size` param + `--page-size` flag + page-size MCP arg are removed for them, and sync pages them until an empty page",
-      "why": "issue #153: the press emits a single global pagination profile (limitParam=page_size) and registers every list endpoint as page_size-capable. Hudu rejects page_size on these five with HTTP 400 ('page_size is not a valid filter parameter.'; rack-storage-items: '...not a valid parameter.'), so `sync` and each `list` failed on the first request and stored 0 rows. Fix: resourceRejectsPageSize() carves these out of the page_size send (both sync.go and the 5 list cmds), drops the page-size MCP binding in code_orch.go, and the sync loop pages them by `page` until an empty page (pageFingerprint guards the page-ignoring case) so there is neither a 400 nor SILENT truncation. A reprint re-adds page_size everywhere and re-breaks all five. Cross-ref: the n8n-nodes-hudu project independently removed pagination from these same endpoints.",
+      "summary": "Five Hudu IPAM-family list endpoints (ip-addresses, networks, vlans, vlan-zones, rack-storage-items) are NON-paginated: sync/list send them neither page_size NOR page (both 400), the --page-size + --page flags and the page-size + page MCP args are removed for them, and sync fetches the full collection in one request",
+      "why": "issues #153 + #158: the press emits a single global pagination profile and registers every list endpoint as paginated. Hudu rejects page_size on these five with HTTP 400 ('page_size is not a valid filter parameter.'; rack-storage-items: '...not a valid parameter.'). #153 carved out page_size but ASSUMED they page by `page` and walked page=1,2,...; #158 proved that assumption wrong - they reject `page` with the same 400 (they are non-paginated and return the whole collection in one response, confirmed on a live huducloud tenant + the n8n-nodes-hudu project, which likewise removed pagination here). Fix: resourceRejectsPageSize() now means 'non-paginated' - sync sends no pagination params and stops after the single response (the page-int fallback and more-pages walk both opt these out), the 5 list cmds drop both --page-size and --page, and code_orch.go drops both the page-size and page MCP args. A reprint re-adds page_size+page everywhere and re-breaks all five.",
       "status": "active",
-      "spec_encode_followup": "Press gap: the profiler must support PER-ENDPOINT pagination params, not one global limitParam for the whole API. Some endpoints accept page+page_size, some accept page only, some are non-paginated. Filed as a printing-press-retro. Sibling of project_ninjaone_after_id_pagination_defect (per-endpoint pagination shape).",
+      "spec_encode_followup": "Press gap: the profiler must support PER-ENDPOINT pagination shape, not one global profile for the whole API. Some endpoints accept page+page_size, some are non-paginated. Filed as a printing-press-retro. Sibling of project_ninjaone_after_id_pagination_defect.",
       "asserts": [
         {"file": "cli/internal/cli/sync.go", "contains": "func resourceRejectsPageSize", "min_count": 1},
         {"file": "cli/internal/cli/sync.go", "contains": "\"ip-addresses\", \"networks\", \"vlans\", \"vlan-zones\", \"rack-storage-items\"", "min_count": 1},
-        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_PageSizeRejectingEndpoint_PagesByPageOnly", "min_count": 1},
+        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_NonPaginatedEndpoint_FetchesOnceNoPageParam", "min_count": 1},
         {"file": "cli/internal/cli/ip-addresses_list.go", "not_contains": "page_size"},
         {"file": "cli/internal/cli/networks_list.go", "not_contains": "page_size"},
         {"file": "cli/internal/cli/vlans_list.go", "not_contains": "page_size"},
         {"file": "cli/internal/cli/vlan-zones_list.go", "not_contains": "page_size"},
-        {"file": "cli/internal/cli/rack-storage-items_list.go", "not_contains": "page_size"}
+        {"file": "cli/internal/cli/rack-storage-items_list.go", "not_contains": "page_size"},
+        {"file": "cli/internal/cli/ip-addresses_list.go", "not_contains": "flagPage"},
+        {"file": "cli/internal/cli/networks_list.go", "not_contains": "flagPage"},
+        {"file": "cli/internal/cli/vlans_list.go", "not_contains": "flagPage"},
+        {"file": "cli/internal/cli/vlan-zones_list.go", "not_contains": "flagPage"},
+        {"file": "cli/internal/cli/rack-storage-items_list.go", "not_contains": "flagPage"}
+      ]
+    },
+    {
+      "id": "pagination-cursor-type-page",
+      "summary": "determinePaginationDefaults() sets cursorType \"page\" so the ?page=N page-int fallback is live; cursorType \"\" disabled it and silently truncated every multi-page resource at the first 100 rows",
+      "why": "issue #158 (Bug 2): the press emitted cursorType \"\" while cursorParam was \"page\". The page-int fallback in sync.go guards on cursorType==\"page\", so with \"\" it was dead code - and Hudu returns no body cursor, so sync could not advance past page 1 for ANY resource. v0.1.0 truncated silently; the 4.24 engine's new 'data may be truncated' warning surfaced it on the high-cardinality resources (expirations/folders/public-photos/relations/procedure-tasks). Fix: cursorType \"page\". Sibling connectors generated correctly (connectwise-manage has cursorType \"page\"); this was a Hudu-specific profiler miss. A reprint re-emits cursorType \"\".",
+      "status": "active",
+      "spec_encode_followup": "Press gap: when cursorParam resolves to a page-integer spelling (page/page_number/...), cursorType must be set to 'page', not left ''. Filed in the same printing-press-retro as the per-endpoint pagination shape.",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "cursorType: \"page\"", "min_count": 1},
+        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_PageType_AdvancesUntilShortPage", "min_count": 1}
+      ]
+    },
+    {
+      "id": "matchers-requires-integration-id",
+      "summary": "Flat `sync` skips the matchers resource (with a warning) unless integration_id is supplied, because Hudu's /matchers returns HTTP 500 without one and there is no integrations-list endpoint to enumerate IDs",
+      "why": "issue #159: /matchers requires an integration_id query param (Hudu 500s without it). The press registers matchers as a flat-syncable list, so every `sync` 500'd on it and exhausted retries. Fix: syncResource skips matchers when the user did not pass integration_id (via --resource-param matchers:integration_id=<id> / --global-param), via the new syncUserParams.hasParam() accessor; users fetch per-integration with `matchers list --integration-id <id>`. A reprint re-adds matchers to the flat sync set and re-breaks it.",
+      "status": "active",
+      "spec_encode_followup": "Press gap: an endpoint with a REQUIRED query param that flat-list sync cannot supply (and no enumerable parent) should be excluded from the default sync set, not registered as flat-syncable. Sibling of the unresolved-path-key skip already in sync.go.",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "skipped matchers: requires integration_id", "min_count": 1},
+        {"file": "cli/internal/cli/helpers.go", "contains": "func (p *syncUserParams) hasParam", "min_count": 1},
+        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_Matchers_SkippedWithoutIntegrationID", "min_count": 1}
       ]
     }
   ]


### PR DESCRIPTION
Fixes #158 and #159 (both reported by @Xenith-B against a live huducloud.com tenant). One coherent `sync`/pagination correctness PR; targets `hudu-v0.1.3`.

## #158 - two pagination bugs

**Bug 1 - IPAM endpoints reject `page` too (regression from #156).** `ip-addresses`, `networks`, `vlans`, `vlan-zones`, `rack-storage-items` are non-paginated: they reject BOTH `page_size` AND `page` with HTTP 400. #156 correctly dropped `page_size` but then assumed they page by `page` and walked `page=1,2,...`, which 400s on every request after the first (0 rows stored). They now send **no** pagination params and fetch the full collection in one request. Confirmed against the `n8n-nodes-hudu` project, which likewise removed pagination for these ("IP Addresses do not support pagination in the API. Always fetch all results."). The `page` flag is dropped from the 5 `list` commands and the `page` MCP arg from `code_orch.go` (twin-surface fix).

**Bug 2 - multi-page resources truncated at 100 rows.** The pagination profile declared `cursorType ""` while `cursorParam` was `"page"`, so the `?page=N` page-int fallback was dead code and `sync` could not advance past page 1 for any resource (Hudu returns no body cursor). v0.1.0 truncated silently; v0.1.2's new "data may be truncated" warning is what surfaced it on the high-cardinality resources (`expirations`, `folders`, `public-photos`, `relations`, `procedure-tasks`). Set `cursorType "page"`. A `pageFingerprint` dup-guard + a 10000-page ceiling stop a page-ignoring endpoint from looping at `--max-pages 0`. Scoped to Hudu (sibling `connectwise-manage` already has `cursorType "page"`).

## #159 - `matchers` HTTP 500 every sync

Hudu's `/matchers` requires an `integration_id` (HTTP 500 without it), and the connector exposes no integrations-list endpoint to enumerate IDs, so flat `sync` cannot satisfy it - it 500s and exhausts retries every run. `sync` now skips `matchers` with a warning unless the user supplies `integration_id` (`--resource-param matchers:integration_id=<id>`); fetch per integration with `hudu-cli matchers list --integration-id <id>`.

## Verification

- `go build` / `go vet` / full `go test ./...` green; 6 new/updated regression tests (non-paginated fetch-once, `cursorType "page"` advancement, page-ignoring termination, matchers skip + escape hatch).
- `check_handfixes.py` PASS (3 ledger entries: non-paginated IPAM, cursorType, matchers).
- `check_security_gate.py --require-scanners`: 0 P1 (gosec/govulncheck/osv/semgrep; the 12 P2s are pre-existing, in files this PR does not touch).
- Adversarial review (independent fresh-context agent + `codex` read-only): converged to **0 P1 / 0 P2** after a loop-safety P1 (page-int fallback could loop on a page-ignoring endpoint) was fixed by re-adding the fingerprint dup-guard + ceiling on the generic page walk.

Recorded in `handfixes.json` so a reprint cannot silently re-break any of the three; the durable fix is per-endpoint pagination shape + required-param awareness in `cli-printing-press` (retro to follow).

Thanks @Xenith-B for the detailed reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
