### PR TITLE
docs(statusline): sync line-2 description (in/out tokens, active time)

### DIFF
--- a/tools/statusline/README.md
+++ b/tools/statusline/README.md
@@ -4,7 +4,7 @@
 > RMM, or backup workflows - it just makes Claude Code nicer to work in. It lives
 > under `tools/` (outside `skills/`) for that reason.
 
-Two-line status line for Claude Code that shows model, cwd, git branch, date/time, accurate context-window usage as a window-scaled gradient bar (200k or 1M auto-detected), and session cost / tokens / duration.
+Two-line status line for Claude Code that shows model, cwd, git branch, date/time, accurate context-window usage as a window-scaled gradient bar (200k or 1M auto-detected), and session cost, input/output token counts, and active time (wall-clock minus the time spent waiting on you — so it counts API, tool, agent, and CI/CD-watch time but not idle prompts).
 
 The canonical source for this statusline is its own repository:
 

--- a/tools/statusline/README.md
+++ b/tools/statusline/README.md
@@ -4,7 +4,7 @@
 > RMM, or backup workflows - it just makes Claude Code nicer to work in. It lives
 > under `tools/` (outside `skills/`) for that reason.
 
-Two-line status line for Claude Code that shows model, cwd, git branch, date/time, accurate context-window usage as a window-scaled gradient bar (200k or 1M auto-detected), and session cost, input/output token counts, and active time (wall-clock minus the time spent waiting on you — so it counts API, tool, agent, and CI/CD-watch time but not idle prompts).
+Two-line status line for Claude Code that shows model, cwd, git branch, date/time, accurate context-window usage as a window-scaled gradient bar (200k or 1M auto-detected), and session cost, input/output token counts, and active time (wall-clock minus the time spent waiting on you - so it counts API, tool, agent, and CI/CD-watch time but not idle prompts).
 
 The canonical source for this statusline is its own repository:
 


### PR DESCRIPTION
One-line README sync. The canonical `statusline.py` (Servosity/claude-code-statusline@6f07a81) now renders the second line as `$cost | ↑input ↓output | active-time`:

- **time → active time**: wall-clock minus the gaps spent waiting on the user. Counts API generation, tool execution, background agents, and CI/CD watches (all happen inside a turn); excludes idle while Claude waits for your next message (no more overnight "1d 4h").
- **tokens → ↑in / ↓out**, deduped by API message id (the old undeduped cumulative over-counted streamed partials ~3-4x).
- **cost** unchanged (`total_cost_usd` is already model/cache/in-out accurate).

No vendored copy in msp-skills — `install.sh` fetches from canonical `main`, so users already get the new version. This PR only fixes the stale description line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the statusline README description to clarify the two-line display now includes input/output token counts and “active time” (wall-clock minus waiting/idle), alongside session cost.
  * Clarified the context-window indicator as a window-scaled gradient bar with automatic sizing for 200k or 1M configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->