### PR TITLE
servosity: drop private admin-repo URL from public docs

### DIFF
--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this skill are documented here. Format follows
   removal spans every surface: the two CLI subcommands, the MCP code-orchestration
   endpoint table (the `servosity-msp_search` / `servosity-msp_execute` tools),
   the `sync` resource map + store primary-key map, and the `guide.md` / `SKILL.md`
-  docs. Admin functionality lives in the dedicated admin CLI
-  (`github.com/Servosity/servosity-admin-cli`, admin `SERVOSITY_API_TOKEN`). The
+  docs. Admin functionality lives in Servosity's separate internal admin CLI
+  (admin-token-scoped), not this partner connector. The
   reprint-durability requirement is documented in `docs/reprint-survival.md` and
   machine-pinned in `handfixes.json`. `issues attention`,
   `archive`/`ignore`/`reactivate` and the `issues` table's `ignored_until` field

--- a/skills/servosity/docs/reprint-survival.md
+++ b/skills/servosity/docs/reprint-survival.md
@@ -12,8 +12,8 @@ so they are removed from the partner surface:
 - `issues archived`  → `GET /issues/archived/`  (admin only)
 - `issues ignored`   → `GET /issues/ignored/`   (admin only)
 
-These live in the admin CLI instead: `github.com/Servosity/servosity-admin-cli`
-(uses the admin `SERVOSITY_API_TOKEN`).
+These live in Servosity's separate internal admin CLI instead (admin-token-scoped;
+not part of this partner connector).
 
 **Reprint durability:** these endpoints are generated from the OpenAPI spec, so a naive
 reprint reintroduces them on **every** surface, not just the CLI. The de-msp ritual must

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -28,7 +28,7 @@
     {
       "id": "admin-only-issues-endpoints-removed",
       "summary": "issues archived (/issues/archived/) and issues ignored (/issues/ignored/) are stripped from EVERY surface (CLI, MCP code-orch, sync, store) because they are admin-scoped and 403 for the reseller-scoped partner token this connector ships (PR #178)",
-      "why": "These two GET endpoints are generated from the OpenAPI spec and admin-only; the partner SERVOSITY_MSP_TOKEN gets HTTP 403. A naive reprint regenerates them on every surface (the CLI command files, the MCP code-orch endpoint table agents drive via servosity-msp_search/_execute, the sync resource map + store PK map). The de-msp ritual must re-strip all of them; these not_contains asserts fail CI if any surface reintroduced them. Admin functionality lives in github.com/Servosity/servosity-admin-cli instead. See docs/reprint-survival.md.",
+      "why": "These two GET endpoints are generated from the OpenAPI spec and admin-only; the partner SERVOSITY_MSP_TOKEN gets HTTP 403. A naive reprint regenerates them on every surface (the CLI command files, the MCP code-orch endpoint table agents drive via servosity-msp_search/_execute, the sync resource map + store PK map). The de-msp ritual must re-strip all of them; these not_contains asserts fail CI if any surface reintroduced them. Admin functionality lives in Servosity's separate internal admin CLI (admin-token-scoped) instead. See docs/reprint-survival.md.",
       "status": "active",
       "pr": 178,
       "asserts": [


### PR DESCRIPTION
Follow-up to #178. The v0.4.0 removal docs referenced `github.com/Servosity/servosity-admin-cli`, which is a **private** repo — a 404 for any MSP reading the public partner-connector docs. Replaces the clickable private URL with a generic "Servosity's separate internal admin CLI (admin-token-scoped)" in `CHANGELOG.md`, `docs/reprint-survival.md`, and the `handfixes.json` note.

Docs-only, no version bump, no build. Handfix ledger + ci_guards pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where certain admin-only capabilities are handled, now pointing to Servosity’s separate internal admin CLI with token-scoped access.
  * Updated related notes and changelog text to remove outdated references and better reflect the current setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->