### PR TITLE
fix(hudu): relations page_size=25 + sync --exclude (#167, #168, #169)

### DIFF
--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4] - unreleased
+
+### Fixed
+- `sync` now pages the `relations` resource at `page_size=25` instead of the
+  global 100. Hudu's `/relations` endpoint returns HTTP 500 when walked at
+  page_size 100 beyond the first page, so every `sync` failed on `relations`
+  and exhausted its retries. (A direct `relations list` at page_size 100/25/1
+  all succeed; only sync's page-2 request at size 100 500s, so `relations` is
+  not non-paginated like the IPAM family - it just needs the smaller page.) 25
+  is Hudu's documented default page size, and the size the mature
+  n8n-nodes-hudu client uses to retrieve every relation, so the `?page=N` walk
+  now fetches the full collection with no truncation. `relations list` also
+  defaults to `--page-size 25` so manual paging does not hit the same 500.
+  Thanks @Xenith-B (#167).
+
+### Added
+- `sync --exclude <a,b,c>` skips the named resources, applied after
+  `--resources` (or the default set). Ideal for a scheduled daily sync that
+  skips slow or rarely-changing resources without having to enumerate every
+  resource to keep, e.g.
+  `sync --exclude public-photos,procedures,procedure-tasks`. Unknown resource
+  names fail loudly. Thanks @Xenith-B (#169).
+
+### Documented
+- `procedures`/`procedure-tasks` are not broken (#168): the multi-minute sync
+  time is the cost of fetching the full collection now that pagination works
+  in v0.1.3 (v0.1.2 silently truncated to the first 100 rows). The
+  `pagination_cursor_missing` warning on `procedure-tasks` is a false alarm on
+  Hudu's `?page=N` endpoints - verify completeness with the local cache row
+  count, which exceeds one page when the data is complete. The SKILL and guide
+  now cover keeping a daily sync fast (`--exclude` / `--since` / `--latest-only`
+  / `--resources`) and the integration-ID discovery method for `matchers`.
+  Thanks @Xenith-B (#168).
+
 ## [0.1.3] - unreleased
 
 ### Fixed

--- a/skills/hudu/SKILL.md
+++ b/skills/hudu/SKILL.md
@@ -409,6 +409,45 @@ hudu-cli reconcile --integrator cw_manage --agent
 
 Reports which ConnectWise integrator records no longer resolve to a live Hudu asset, both directions.
 
+### Keep a scheduled daily sync fast
+
+A full `sync` fetches every resource's complete collection. A few resources (`public-photos`, `procedures`, `procedure-tasks`) hold the bulk of the data and dominate the runtime. For a scheduled daily job, skip them or sync incrementally:
+
+```bash
+# Skip the heavy resources; everything else still syncs
+hudu-cli sync --exclude public-photos,procedures,procedure-tasks
+
+# Or sync only the resources you name
+hudu-cli sync --resources companies,assets,asset-passwords
+
+# Or refresh incrementally instead of a full re-pull
+hudu-cli sync --since 7d
+hudu-cli sync --latest-only
+```
+
+Run a full `hudu-cli sync` on a slower cadence (e.g. weekly) to backfill the excluded resources. Note: `procedure-tasks` may emit a `pagination_cursor_missing` warning ("data may be truncated"). On Hudu's `?page=N` endpoints this is expected and does not mean data was lost  -  the sync still walks every page. Confirm completeness by checking that the local cache row count exceeds one page.
+
+### Sync matchers for an integration
+
+Hudu's `/matchers` endpoint requires an `integration_id` and returns HTTP 500 without one, so a flat `sync` skips it. There is no integrations-list endpoint; integration IDs live in synced asset `cards` data. After a full sync, list the IDs from the local cache:
+
+```sql
+SELECT DISTINCT
+  json_extract(card.value, '$.integrator_id')   AS integration_id,
+  json_extract(card.value, '$.integrator_name') AS integration_name
+FROM resources, json_each(json_extract(data, '$.cards')) AS card
+WHERE resource_type = 'assets'
+  AND json_extract(card.value, '$.integrator_id') IS NOT NULL
+ORDER BY integration_id;
+```
+
+Then fetch matchers per integration:
+
+```bash
+hudu-cli matchers list --integration-id 2
+hudu-cli sync --resource-param matchers:integration_id=6
+```
+
 ## Auth Setup
 
 Hudu is per-tenant. Set HUDU_BASE_URL to your instance's /api/v1 URL (self-hosted, *.huducloud.com, or a custom domain) and HUDU_API_KEY to a key created under Admin -> API Keys. The key is sent as the x-api-key header. Keys are global or company-scoped; a company-scoped key cannot call the global `assets list` (use `assets list-by-company`). Run `doctor` to confirm the key, base URL, and reachability; use `api-info get` for the Hudu version. Save the key with `auth set-token` (or env vars) and check it with `auth status`.

--- a/skills/hudu/cli/internal/cli/relations_list.go
+++ b/skills/hudu/cli/internal/cli/relations_list.go
@@ -83,7 +83,11 @@ func newRelationsListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagPage, "page", "1", "1-based page number")
-	cmd.Flags().IntVar(&flagPageSize, "page-size", 100, "Results per page")
+	// #167: Hudu's /relations endpoint 500s when paged at size 100 beyond the
+	// first page; it paginates cleanly at 25 (Hudu's documented default, and the
+	// size sync uses via resourcePageSize). Default this command to 25 too so
+	// manual paging (`relations list --page 2`) doesn't hit the same 500.
+	cmd.Flags().IntVar(&flagPageSize, "page-size", 25, "Results per page")
 
 	return cmd
 }

--- a/skills/hudu/cli/internal/cli/sync.go
+++ b/skills/hudu/cli/internal/cli/sync.go
@@ -43,6 +43,7 @@ type syncResult struct {
 
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
+	var exclude []string
 	var full bool
 	var since string
 	var concurrency int
@@ -128,6 +129,22 @@ Resource scoping:
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
 				resources = defaultSyncResources()
+			}
+
+			// #169: --exclude drops named resources from the effective set
+			// (whether that set came from --resources or the default), so a
+			// scheduled daily sync can skip slow or rarely-changing resources
+			// without having to enumerate every resource to keep. Validate
+			// names against the known set so a typo fails loudly instead of
+			// silently excluding nothing (same contract as --resource-param).
+			if len(exclude) > 0 {
+				if err := validateExcludeNames(exclude, knownSyncResourceNames()); err != nil {
+					return usageErr(err)
+				}
+				resources = filterExcludedResources(resources, exclude)
+				if len(resources) == 0 {
+					return usageErr(fmt.Errorf("--exclude removed every selected resource; nothing to sync"))
+				}
 			}
 
 			// Reject --resource-param keys that don't match a known resource.
@@ -325,6 +342,7 @@ Resource scoping:
 	}
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
+	cmd.Flags().StringSliceVar(&exclude, "exclude", nil, "Comma-separated resource types to skip. Applied after --resources (or the default set), so `sync --exclude a,b` runs everything except a and b — ideal for scheduled daily syncs that skip slow or rarely-changing resources (e.g. --exclude public-photos,procedures,procedure-tasks).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
@@ -456,6 +474,11 @@ func syncResource(ctx context.Context, c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
+	// #167: apply any per-resource page-size override (relations must page at 25,
+	// not the global 100 — see resourcePageSize).
+	if lim := resourcePageSize(resource); lim > 0 {
+		pageSize.limit = lim
+	}
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -906,6 +929,25 @@ func resourceRejectsPageSize(resource string) bool {
 		return true
 	}
 	return false
+}
+
+// resourcePageSize returns a per-resource page-size override, or 0 to use the
+// global default (determinePaginationDefaults, page_size=100). Hudu's
+// /relations endpoint returns HTTP 500 when sync walks it at page_size=100, but
+// paginates cleanly at 25 — Hudu's documented default page size and the size
+// the mature n8n-nodes-hudu client uses to retrieve every relation ("lots of 25
+// until all records retrieved"). Keeping the ?page=N walk (rather than
+// profiling it non-paginated like the IPAM family in resourceRejectsPageSize,
+// which *rejects* page_size with HTTP 400 — relations *accepts* it) fetches the
+// whole collection without truncation. See issue #167. A live `relations list`
+// at page_size 100/25/1 all succeed; only sync's page-2 request at size 100
+// 500s, so this override, not the single-request IPAM profile, is the fix.
+func resourcePageSize(resource string) int {
+	switch resource {
+	case "relations":
+		return 25
+	}
+	return 0
 }
 
 // syncResourceSinceParam returns the query parameter name this resource's
@@ -1654,6 +1696,42 @@ func defaultSyncResources() []string {
 		"vlans",
 		"websites",
 	}
+}
+
+// validateExcludeNames rejects --exclude entries that don't name a known
+// resource, so a misspelling fails loudly instead of silently excluding
+// nothing (the same contract as --resource-param name validation). #169.
+func validateExcludeNames(exclude, known []string) error {
+	knownSet := make(map[string]bool, len(known))
+	for _, k := range known {
+		knownSet[k] = true
+	}
+	var unknown []string
+	for _, e := range exclude {
+		if !knownSet[e] {
+			unknown = append(unknown, e)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("--exclude names unknown resource(s): %s", strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
+// filterExcludedResources returns resources with every name in exclude
+// removed, preserving order. #169.
+func filterExcludedResources(resources, exclude []string) []string {
+	excludeSet := make(map[string]bool, len(exclude))
+	for _, e := range exclude {
+		excludeSet[e] = true
+	}
+	kept := make([]string, 0, len(resources))
+	for _, r := range resources {
+		if !excludeSet[r] {
+			kept = append(kept, r)
+		}
+	}
+	return kept
 }
 
 // knownSyncResourceNames returns every resource name sync will accept —

--- a/skills/hudu/cli/internal/cli/sync_page_size_test.go
+++ b/skills/hudu/cli/internal/cli/sync_page_size_test.go
@@ -7,6 +7,9 @@
 //     of truncating at the first page.
 //   - #159: /matchers requires an integration_id, so flat sync must skip it
 //     unless the caller supplies one.
+//   - #167: /relations 500s when walked at the global page_size=100, so sync
+//     must page it at 25 (resourcePageSize override), not the global default.
+//   - #169: sync --exclude drops named resources from the effective set.
 // A reprint that drops this file is caught by skills/hudu/handfixes.json — do
 // not remove without porting the fixes.
 
@@ -218,6 +221,77 @@ func TestSyncResource_Matchers_SyncedWithIntegrationID(t *testing.T) {
 	}
 	if n := countRows(t, db, "matchers"); n != 1 {
 		t.Errorf("stored %d matcher rows, want 1", n)
+	}
+}
+
+// TestResourcePageSize_RelationsOverridesGlobalTo25 pins the #167 fix: relations
+// pages at 25 (Hudu's default; the size n8n-nodes-hudu uses to retrieve every
+// relation), while every other resource keeps the global default (0 => 100).
+func TestResourcePageSize_RelationsOverridesGlobalTo25(t *testing.T) {
+	if got := resourcePageSize("relations"); got != 25 {
+		t.Errorf("resourcePageSize(relations) = %d, want 25 (#167: /relations 500s at the global 100)", got)
+	}
+	for _, r := range []string{"companies", "assets", "procedure-tasks", "articles", "users"} {
+		if got := resourcePageSize(r); got != 0 {
+			t.Errorf("resourcePageSize(%q) = %d, want 0 (use the global default)", r, got)
+		}
+	}
+}
+
+// TestSyncResource_Relations_PagesAt25NotGlobal100 pins the #167 behavioral fix:
+// sync must send page_size=25 on every /relations request (never the 100 that
+// 500s beyond page 1) and still walk the full collection via ?page=N.
+func TestSyncResource_Relations_PagesAt25NotGlobal100(t *testing.T) {
+	db := openSyncTestDB(t)
+	defer db.Close()
+
+	rel := resourcePageSize("relations") // 25
+	c := &recordingClient{pages: [][]byte{
+		makePage(1, rel),     // page 1: full at 25
+		makePage(rel+1, rel), // page 2: full at 25
+		makePage(2*rel+1, 4), // page 3: short -> stop
+	}}
+
+	res := syncResource(context.Background(), c, db, "relations", "", true, 0, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource returned error: %v", res.Err)
+	}
+	// Every request must carry page_size=25 — the global 100 is what 500s.
+	for i, p := range c.seen {
+		if p["page_size"] != strconv.Itoa(rel) {
+			t.Errorf("request %d sent page_size=%q, want %q (#167)", i, p["page_size"], strconv.Itoa(rel))
+		}
+	}
+	// The walk advances at the 25-row threshold and fetches the whole collection.
+	if got := len(c.seen); got != 3 {
+		t.Fatalf("made %d requests, want 3 (page-int walk at size 25)", got)
+	}
+	if c.seen[1]["page"] != "2" || c.seen[2]["page"] != "3" {
+		t.Errorf("page sequence = %q,%q, want 2,3", c.seen[1]["page"], c.seen[2]["page"])
+	}
+	if n := countRows(t, db, "relations"); n != 2*rel+4 {
+		t.Errorf("stored %d rows, want %d (full collection, no truncation)", n, 2*rel+4)
+	}
+}
+
+// TestExcludeResources pins the #169 --exclude flag: valid names are removed
+// (order preserved) and an unknown name fails loudly instead of silently
+// excluding nothing.
+func TestExcludeResources(t *testing.T) {
+	got := filterExcludedResources(
+		[]string{"companies", "public-photos", "procedures", "procedure-tasks", "assets"},
+		[]string{"public-photos", "procedures", "procedure-tasks"},
+	)
+	if want := "companies,assets"; strings.Join(got, ",") != want {
+		t.Errorf("filterExcludedResources = %v, want %q", got, want)
+	}
+
+	known := knownSyncResourceNames()
+	if err := validateExcludeNames([]string{"companies", "notathing"}, known); err == nil {
+		t.Error("validateExcludeNames accepted an unknown resource; want an error")
+	}
+	if err := validateExcludeNames([]string{"public-photos", "procedures"}, known); err != nil {
+		t.Errorf("validateExcludeNames rejected known resources: %v", err)
 	}
 }
 

--- a/skills/hudu/guide.md
+++ b/skills/hudu/guide.md
@@ -273,6 +273,45 @@ hudu-cli reconcile --integrator cw_manage --agent
 
 Reports which ConnectWise integrator records no longer resolve to a live Hudu asset, both directions.
 
+### Keep a scheduled daily sync fast
+
+A full `sync` fetches every resource's complete collection. A few resources (`public-photos`, `procedures`, `procedure-tasks`) hold the bulk of the data and dominate the runtime. For a scheduled daily job, skip them or sync incrementally:
+
+```bash
+# Skip the heavy resources; everything else still syncs
+hudu-cli sync --exclude public-photos,procedures,procedure-tasks
+
+# Or sync only the resources you name
+hudu-cli sync --resources companies,assets,asset-passwords
+
+# Or refresh incrementally instead of a full re-pull
+hudu-cli sync --since 7d
+hudu-cli sync --latest-only
+```
+
+Run a full `hudu-cli sync` on a slower cadence (e.g. weekly) to backfill the excluded resources. Note: `procedure-tasks` may emit a `pagination_cursor_missing` warning ("data may be truncated"). On Hudu's `?page=N` endpoints this is expected and does not mean data was lost  -  the sync still walks every page. Confirm completeness by checking that the local cache row count exceeds one page.
+
+### Sync matchers for an integration
+
+Hudu's `/matchers` endpoint requires an `integration_id` and returns HTTP 500 without one, so a flat `sync` skips it. There is no integrations-list endpoint; integration IDs live in synced asset `cards` data. After a full sync, list the IDs from the local cache:
+
+```sql
+SELECT DISTINCT
+  json_extract(card.value, '$.integrator_id')   AS integration_id,
+  json_extract(card.value, '$.integrator_name') AS integration_name
+FROM resources, json_each(json_extract(data, '$.cards')) AS card
+WHERE resource_type = 'assets'
+  AND json_extract(card.value, '$.integrator_id') IS NOT NULL
+ORDER BY integration_id;
+```
+
+Then fetch matchers per integration:
+
+```bash
+hudu-cli matchers list --integration-id 2
+hudu-cli sync --resource-param matchers:integration_id=6
+```
+
 ## Usage
 
 Run `hudu-cli --help` for the full command reference and flag list.

--- a/skills/hudu/handfixes.json
+++ b/skills/hudu/handfixes.json
@@ -79,6 +79,32 @@
         {"file": "cli/internal/cli/helpers.go", "contains": "func (p *syncUserParams) hasParam", "min_count": 1},
         {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_Matchers_SkippedWithoutIntegrationID", "min_count": 1}
       ]
+    },
+    {
+      "id": "relations-page-size-25",
+      "summary": "sync pages the relations resource at page_size=25 (per-resource resourcePageSize override), not the global 100; relations list also defaults --page-size to 25",
+      "why": "issue #167: Hudu's /relations endpoint returns HTTP 500 when sync walks it at the global page_size=100 (page-2 request onward), so every sync failed on relations and exhausted retries. A live relations list at page_size 100/25/1 all succeed, so relations is NOT non-paginated like the IPAM family (resourceRejectsPageSize) - it accepts page_size and pages by ?page=N, it just 500s at size 100. Fix: resourcePageSize() returns 25 for relations (Hudu's documented default, and the size n8n-nodes-hudu uses to retrieve all relations), applied to pageSize.limit in syncResource; relations_list.go defaults --page-size to 25 so manual paging does not hit the same 500. A reprint re-emits the global 100 for relations and re-breaks sync.",
+      "status": "active",
+      "spec_encode_followup": "Press gap: PER-ENDPOINT page_size (some endpoints 500 at the API max page size and need a smaller one). Filed in the same printing-press-retro as the per-endpoint pagination shape. Sibling of ipam-endpoints-reject-page-size.",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "func resourcePageSize", "min_count": 1},
+        {"file": "cli/internal/cli/sync.go", "contains": "if lim := resourcePageSize(resource); lim > 0", "min_count": 1},
+        {"file": "cli/internal/cli/relations_list.go", "contains": "\"page-size\", 25", "min_count": 1},
+        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestSyncResource_Relations_PagesAt25NotGlobal100", "min_count": 1}
+      ]
+    },
+    {
+      "id": "sync-exclude-flag",
+      "summary": "sync has an --exclude flag that drops named resources from the effective set (after --resources or the default), with loud validation of unknown names",
+      "why": "issue #169: sync ran every resource on every run with no way to skip the slow ones (public-photos/procedures/procedure-tasks), making a scheduled daily sync impractical; the only workaround was to enumerate all 20+ resources to keep via --resources. Added --exclude (StringSliceVar) plus validateExcludeNames (rejects unknown names, same contract as --resource-param) and filterExcludedResources (order-preserving set difference). A reprint drops the flag and both helpers.",
+      "status": "active",
+      "spec_encode_followup": "Press gap: sync should offer a native --exclude complement to --resources. Filed in the printing-press-retro.",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "func filterExcludedResources", "min_count": 1},
+        {"file": "cli/internal/cli/sync.go", "contains": "func validateExcludeNames", "min_count": 1},
+        {"file": "cli/internal/cli/sync.go", "contains": "StringSliceVar(&exclude, \"exclude\"", "min_count": 1},
+        {"file": "cli/internal/cli/sync_page_size_test.go", "contains": "TestExcludeResources", "min_count": 1}
+      ]
     }
   ]
 }


### PR DESCRIPTION
One `hudu-v0.1.4` closing three field-test reports from @Xenith-B against v0.1.3.

## #167 — `relations` HTTP 500 in `sync` (the real bug)
Sync walked `/relations` at the global `page_size=100`; Hudu's `/relations` returns **HTTP 500** on the page-2 request at that size, so every sync failed on `relations` and exhausted retries.

Diagnosed against trusted oracles (not the reporter's guess): a live `relations list` at `page_size` 100/25/1 **all succeed**, so `/relations` is *not* non-paginated like the IPAM family — it accepts `page_size` but 500s at 100. Hudu's API docs cap `page_size` at 100 (default 25), and the mature `n8n-nodes-hudu` client pages relations *"in lots of 25 until all records retrieved"* — proving `page≥2` works at 25.

**Fix:** a per-resource `resourcePageSize()` override sets `relations` to `page_size=25`, keeping the `?page=N` walk so the full collection is fetched with **no truncation**. `relations list` also defaults `--page-size` to 25 so manual paging avoids the same 500.

## #169 — resource-exclusion flag (new capability)
Added `sync --exclude a,b,c` (validated, order-preserving) so a scheduled daily sync can skip the heavy resources without enumerating every resource to keep:
```
hudu-cli sync --exclude public-photos,procedures,procedure-tasks
```

## #168 — `procedures`/`procedure-tasks` "perf regression" (not a bug)
Confirmed **not broken**: the multi-minute runtime is correct full pagination now that v0.1.3 walks every page (v0.1.2 silently truncated at 100). The reporter's cache held 679 procedure-tasks (>1 page), so the `pagination_cursor_missing` warning is a **false alarm**, not truncation. Documented the daily-sync-fast flags, the false-alarm warning, and the `matchers` integration-ID discovery method in SKILL.md + guide.md.

## Receipts
- `verify_all.sh`: PASS (all hard gates; catalog/llms idempotent)
- `check_security_gate.py --slug hudu --base origin/main`: **0 P1** (12 P2, all pre-existing)
- codex adversarial review (security + pagination correctness): **CLEAN — no P1/P2**
- New behavioral regression tests: relations pages at 25 (not 100), `--exclude` filtering; `go test ./...` + `go vet` green
- `handfixes.json` markers added so a reprint cannot silently clobber the fix

Closure = @Xenith-B's re-test on the v0.1.4 build.

Fixes #167
Fixes #168
Fixes #169

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)