### PR TITLE
fix(ninjaone): keep query object cursor paging advancing

### DIFF
--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5] - unreleased
+
+### Fixed
+- `sync` now continues through NinjaOne `/v2/queries/*` report pages when the API
+  keeps the same `cursor.name` token but advances the cursor object's `offset`.
+  The loop still sends the valid cursor token to the API, but uses the offset as
+  the internal progress key so large report resources no longer stop at 200 rows
+  with `stuck_pagination`. Thanks to @Xenith-B for the live-tenant report (#179).
+
 ## [0.1.4] - unreleased
 
 ### Fixed

--- a/skills/ninjaone/cli/internal/cli/queries_cursor_test.go
+++ b/skills/ninjaone/cli/internal/cli/queries_cursor_test.go
@@ -75,3 +75,87 @@ func TestCursorTokenFromObject(t *testing.T) {
 		}
 	}
 }
+
+func TestPaginationAdvanceKeyUsesObjectCursorOffset(t *testing.T) {
+	page1 := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":100,"count":"100"},
+		"results": [{"deviceId":1001}]
+	}`)
+	page2 := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":200,"count":"100"},
+		"results": [{"deviceId":1002}]
+	}`)
+
+	_, next1, hasMore1 := extractPageItems(page1, "cursor")
+	_, next2, hasMore2 := extractPageItems(page2, "cursor")
+	if next1 != "SESSION_TOKEN" || next2 != "SESSION_TOKEN" {
+		t.Fatalf("next cursors = (%q, %q), want same valid API cursor token", next1, next2)
+	}
+	if !hasMore1 || !hasMore2 {
+		t.Fatalf("hasMore = (%v, %v), want both true", hasMore1, hasMore2)
+	}
+
+	key1 := paginationAdvanceKey(page1, "cursor", next1)
+	key2 := paginationAdvanceKey(page2, "cursor", next2)
+	if key1 != "SESSION_TOKEN|offset=100" {
+		t.Fatalf("page1 advance key = %q, want offset-qualified key", key1)
+	}
+	if key2 != "SESSION_TOKEN|offset=200" {
+		t.Fatalf("page2 advance key = %q, want offset-qualified key", key2)
+	}
+	if key1 == key2 {
+		t.Fatalf("same cursor token with advancing offsets looked sticky: %q", key1)
+	}
+}
+
+func TestPaginationAdvanceKeyStableObjectOffsetRemainsSticky(t *testing.T) {
+	page := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":100,"count":"100"},
+		"results": [{"deviceId":1001}]
+	}`)
+	_, nextCursor, _ := extractPageItems(page, "cursor")
+
+	first := paginationAdvance(page, "cursor", nextCursor)
+	second := paginationAdvance(page, "cursor", nextCursor)
+	if first.key == "" || first.key != second.key {
+		t.Fatalf("stable object cursor keys = (%q, %q), want same non-empty key", first.key, second.key)
+	}
+	if !second.stuckAfter(first) {
+		t.Fatalf("stable object cursor offset was not treated as stuck")
+	}
+}
+
+func TestPaginationProgressRequiresMonotonicObjectOffset(t *testing.T) {
+	page100 := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":100,"count":"100"},
+		"results": [{"deviceId":1001}]
+	}`)
+	page200 := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":200,"count":"100"},
+		"results": [{"deviceId":1002}]
+	}`)
+	page50 := json.RawMessage(`{
+		"cursor": {"name":"SESSION_TOKEN","offset":50,"count":"100"},
+		"results": [{"deviceId":1003}]
+	}`)
+
+	_, nextCursor, _ := extractPageItems(page100, "cursor")
+	first := paginationAdvance(page100, "cursor", nextCursor)
+	second := paginationAdvance(page200, "cursor", nextCursor)
+	regressed := paginationAdvance(page50, "cursor", nextCursor)
+
+	if second.stuckAfter(first) {
+		t.Fatalf("advancing object cursor offset was treated as stuck: %q after %q", second.key, first.key)
+	}
+	if !regressed.stuckAfter(second) {
+		t.Fatalf("regressed object cursor offset was not treated as stuck: %q after %q", regressed.key, second.key)
+	}
+}
+
+func TestPaginationAdvanceKeyStringCursorFallsBackToToken(t *testing.T) {
+	data := json.RawMessage(`{"next_cursor":"STRING_TOKEN","results":[{"id":1}]}`)
+	key := paginationAdvanceKey(data, "cursor", "STRING_TOKEN")
+	if key != "STRING_TOKEN" {
+		t.Fatalf("string cursor advance key = %q, want token fallback", key)
+	}
+}

--- a/skills/ninjaone/cli/internal/cli/sync.go
+++ b/skills/ninjaone/cli/internal/cli/sync.go
@@ -470,7 +470,7 @@ func syncResource(ctx context.Context, c interface {
 	pageSize := determinePaginationDefaults()
 	var progressCount int64
 	pagesFetched := 0
-	lastNextCursor := ""
+	lastNextCursorProgress := paginationProgress{}
 	capExitHit := false
 	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
@@ -711,7 +711,8 @@ func syncResource(ctx context.Context, c interface {
 		// guard so cap-hit takes precedence; checked BEFORE the natural-end
 		// check below because the natural-end check would not catch a sticky
 		// non-empty cursor on its own.
-		if nextCursor != "" && nextCursor == lastNextCursor {
+		nextCursorProgress := paginationAdvance(data, pageSize.cursorParam, nextCursor)
+		if nextCursorProgress.stuckAfter(lastNextCursorProgress) {
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "\n  %s: API returned the same next cursor across two pages; aborting to prevent budget waste.\n", resource)
 			} else {
@@ -719,7 +720,7 @@ func syncResource(ctx context.Context, c interface {
 			}
 			break
 		}
-		lastNextCursor = nextCursor
+		lastNextCursorProgress = nextCursorProgress
 
 		// Determine if there are more pages.
 		if !resourceSupportsPagination(resource) {
@@ -1255,10 +1256,7 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	nextCursor := nextCursorFromLinks(envelope, cursorParam)
 
 	// Try common cursor field names
-	cursorKeys := []string{
-		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
-		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
-	}
+	cursorKeys := paginationCursorKeys()
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
 	}
@@ -1271,8 +1269,7 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	// runs when the top-level scan returned empty — and uses the same
 	// cursorKeys set so wrapper contents go through the same name match.
 	if nextCursor == "" {
-		paginationWrapperKeys := []string{"response_metadata", "additional_data", "pagination", "meta", "paging"}
-		for _, wrapperKey := range paginationWrapperKeys {
+		for _, wrapperKey := range paginationWrapperKeys() {
 			rawWrapper, ok := envelope[wrapperKey]
 			if !ok {
 				continue
@@ -1308,6 +1305,147 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	}
 
 	return nextCursor, hasMore
+}
+
+func paginationCursorKeys() []string {
+	return []string{
+		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+	}
+}
+
+func paginationWrapperKeys() []string {
+	return []string{"response_metadata", "additional_data", "pagination", "meta", "paging"}
+}
+
+type paginationProgress struct {
+	key       string
+	token     string
+	offset    int64
+	hasOffset bool
+}
+
+func (p paginationProgress) stuckAfter(prev paginationProgress) bool {
+	if p.key == "" {
+		return false
+	}
+	if p.key == prev.key {
+		return true
+	}
+	return p.hasOffset && prev.hasOffset && p.token == prev.token && p.offset <= prev.offset
+}
+
+func paginationAdvanceKey(data json.RawMessage, cursorParam, nextCursor string) string {
+	return paginationAdvance(data, cursorParam, nextCursor).key
+}
+
+func paginationAdvance(data json.RawMessage, cursorParam, nextCursor string) paginationProgress {
+	if nextCursor == "" {
+		return paginationProgress{}
+	}
+	if progress := objectCursorAdvance(data, cursorParam, nextCursor); progress.key != "" {
+		return progress
+	}
+	return paginationProgress{key: nextCursor}
+}
+
+func objectCursorAdvance(data json.RawMessage, cursorParam, nextCursor string) paginationProgress {
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(data, &envelope) != nil {
+		return paginationProgress{}
+	}
+	cursorKeys := paginationCursorKeys()
+	if cursorParam != "" {
+		cursorKeys = append([]string{cursorParam}, cursorKeys...)
+	}
+	if progress := objectCursorAdvanceFromMap(envelope, cursorKeys, nextCursor); progress.key != "" {
+		return progress
+	}
+	for _, wrapperKey := range paginationWrapperKeys() {
+		rawWrapper, ok := envelope[wrapperKey]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(rawWrapper, &inner) != nil {
+			continue
+		}
+		if progress := objectCursorAdvanceFromMap(inner, cursorKeys, nextCursor); progress.key != "" {
+			return progress
+		}
+	}
+	for _, dataKey := range dataEnvelopeKeys {
+		rawInner, ok := envelope[dataKey]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(rawInner, &inner) != nil {
+			continue
+		}
+		if progress := objectCursorAdvanceFromMap(inner, cursorKeys, nextCursor); progress.key != "" {
+			return progress
+		}
+	}
+	return paginationProgress{}
+}
+
+func objectCursorAdvanceFromMap(m map[string]json.RawMessage, cursorKeys []string, nextCursor string) paginationProgress {
+	for _, key := range cursorKeys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		if progress := cursorObjectOffsetAdvance(raw, nextCursor); progress.key != "" {
+			return progress
+		}
+	}
+	return paginationProgress{}
+}
+
+func cursorObjectOffsetAdvanceKey(raw json.RawMessage, nextCursor string) string {
+	return cursorObjectOffsetAdvance(raw, nextCursor).key
+}
+
+func cursorObjectOffsetAdvance(raw json.RawMessage, nextCursor string) paginationProgress {
+	var inner map[string]json.RawMessage
+	if json.Unmarshal(raw, &inner) != nil {
+		return paginationProgress{}
+	}
+	token := cursorTokenFromObject(raw)
+	if token == "" || token != nextCursor {
+		return paginationProgress{}
+	}
+	offsetText, ok := jsonScalarString(inner["offset"])
+	if !ok {
+		return paginationProgress{}
+	}
+	offset, err := strconv.ParseInt(offsetText, 10, 64)
+	if err != nil || offset < 0 {
+		return paginationProgress{}
+	}
+	return paginationProgress{
+		key:       nextCursor + "|offset=" + offsetText,
+		token:     nextCursor,
+		offset:    offset,
+		hasOffset: true,
+	}
+}
+
+func jsonScalarString(raw json.RawMessage) (string, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return "", false
+	}
+	var n json.Number
+	if json.Unmarshal(raw, &n) == nil {
+		return n.String(), true
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, true
+	}
+	return "", false
 }
 
 func pageAllowsPageIntFallback(data json.RawMessage) bool {
@@ -2004,7 +2142,7 @@ func syncDependentResource(ctx context.Context, c interface {
 
 		cursor := ""
 		pagesFetched := 0
-		lastNextCursor := ""
+		lastNextCursorProgress := paginationProgress{}
 		// Reset per parent: set once a bare-array response is seen, then used to
 		// request later pages with ?after=<lastId>. Mirrors syncResource (#88).
 		afterIDMode := false
@@ -2179,7 +2317,8 @@ func syncDependentResource(ctx context.Context, c interface {
 			// Sticky-cursor detector: see syncResource for rationale. Same shape
 			// here so dependent-resource page loops cannot burn the budget on a
 			// non-advancing next cursor.
-			if nextCursor != "" && nextCursor == lastNextCursor {
+			nextCursorProgress := paginationAdvance(data, pageSize.cursorParam, nextCursor)
+			if nextCursorProgress.stuckAfter(lastNextCursorProgress) {
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: API returned the same next cursor across two pages for parent %s; aborting to prevent budget waste.\n", dep.Name, parentID)
 				} else {
@@ -2187,7 +2326,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				}
 				break
 			}
-			lastNextCursor = nextCursor
+			lastNextCursorProgress = nextCursorProgress
 			if !resourceSupportsPagination(dep.Name) {
 				break
 			}

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -1,7 +1,7 @@
 {
   "slug": "ninjaone",
   "doc": "docs/reprint-survival.md",
-  "_comment": "Connector-specific edits to GENERATED (\"DO NOT EDIT\") files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #88 (reporter @AndrewITLive), fixed 2026-06-15 on press 4.24.0; issues #136 queries-* composite-key + object-cursor (reporter @Xenith-B), fixed 2026-06-17.",
+  "_comment": "Connector-specific edits to GENERATED (\"DO NOT EDIT\") files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #88 (reporter @AndrewITLive), fixed 2026-06-15 on press 4.24.0; issues #136 queries-* composite-key + object-cursor (reporter @Xenith-B), fixed 2026-06-17; issue #179 stable object-cursor offset (reporter @Xenith-B), fixed 2026-07-07.",
   "handfixes": [
     {
       "id": "after-id-pagination",
@@ -118,10 +118,10 @@
     },
     {
       "id": "queries-object-cursor-pagination",
-      "summary": "NinjaOne /v2/queries/* endpoints paginate via an OBJECT-valued cursor: \"cursor\":{\"name\":\"<token>\",\"offset\":0,\"count\":\"N\",\"expires\":...}. findCursorInMap only unmarshalled a string cursor, so the next-page token was never found; sync stopped after the first page and capped each queries resource at 100 rows (sync_warning pagination_cursor_missing). Fix adds cursorTokenFromObject, consulted by findCursorInMap only after the string unmarshal fails, which descends into the object and returns the first non-empty string token field (name/next_cursor/...).",
-      "why": "determinePaginationDefaults() emits cursorParam/cursorType \"cursor\" but the press models a string cursor only; it does not model an object cursor whose token is nested under a field. The natural-end (len<limit), sticky-cursor, and empty-page guards already in the loop make object-cursor advance terminate safely. String-cursor APIs are unaffected because the object descent runs only after the scalar unmarshal fails. A plain reprint regenerates the string-only findCursorInMap.",
+      "summary": "NinjaOne /v2/queries/* endpoints paginate via an OBJECT-valued cursor: \"cursor\":{\"name\":\"<token>\",\"offset\":0,\"count\":\"N\",\"expires\":...}. findCursorInMap only unmarshalled a string cursor, so the next-page token was never found; sync stopped after the first page and capped each queries resource at 100 rows (sync_warning pagination_cursor_missing). Fix adds cursorTokenFromObject, consulted by findCursorInMap only after the string unmarshal fails, which descends into the object and returns the first non-empty string token field (name/next_cursor/...). Issue #179 showed live tenants can keep cursor.name stable while cursor.offset advances; paginationProgress now compares an offset-qualified progress key and requires the same token's numeric offset to advance monotonically, so the sticky-cursor guard does not abort a progressing object cursor at 200 rows and still stops repeated or regressed offsets.",
+      "why": "determinePaginationDefaults() emits cursorParam/cursorType \"cursor\" but the press models a string cursor only; it does not model an object cursor whose token is nested under a field. The natural-end (len<limit), sticky-cursor, and empty-page guards already in the loop make object-cursor advance terminate safely. String-cursor APIs are unaffected because the object descent runs only after the scalar unmarshal fails. A plain reprint regenerates the string-only findCursorInMap. The #179 extension keeps sending the API's valid cursor.name token but compares cursor.name plus cursor.offset internally, so a repeated session token with advancing offset is treated as progress while repeated or regressed offsets still trip the loop-safety guard.",
       "status": "active",
-      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the pagination profiler to detect object-valued cursors (cursor field is an object; token nested under name/next/cursor) and emit the descent natively. File via printing-press-retro. Until then this hand-fix must survive every reprint. Verification residual: multi-page completeness assumes NinjaOne returns a FRESH cursor.name per page; if a live tenant ever shows truncation (~2 pages then the sticky-cursor guard fires) the cursor.name is a stable session token and the fix must ALSO thread the cursor object's `offset`. This is monotonic vs main regardless (worst case == the prior 100-row single-page cap; the sticky-cursor + max-pages guards prevent any hang).",
+      "spec_encode_followup": "DURABLE FIX belongs in cli-printing-press: teach the pagination profiler to detect object-valued cursors (cursor field is an object; token nested under name/next/cursor) and emit the descent natively, including object-cursor progress keys that can use offset when the API keeps the token stable. File via printing-press-retro. Until then this hand-fix must survive every reprint. Verification residual: multi-page completeness assumes NinjaOne advances server-side when the same cursor.name token is sent again; if a live tenant ever shows repeated rows with advancing offset, the fix must also send an offset query parameter, but the current OpenAPI surface only declares cursor plus pageSize for these report endpoints. This is monotonic vs main regardless (the sticky-cursor + max-pages guards still prevent any hang).",
       "asserts": [
         {
           "file": "cli/internal/cli/sync.go",
@@ -134,8 +134,33 @@
           "min_count": 1
         },
         {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "func paginationAdvanceKey",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "func (p paginationProgress) stuckAfter",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "func cursorObjectOffsetAdvanceKey",
+          "min_count": 1
+        },
+        {
           "file": "cli/internal/cli/queries_cursor_test.go",
           "contains": "func TestExtractPageItemsFollowsObjectCursor",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/queries_cursor_test.go",
+          "contains": "func TestPaginationAdvanceKeyUsesObjectCursorOffset",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/queries_cursor_test.go",
+          "contains": "func TestPaginationProgressRequiresMonotonicObjectOffset",
           "min_count": 1
         }
       ]


### PR DESCRIPTION
Fixes #179

Summary:
- Make NinjaOne object-cursor sync compare progress using cursor token plus numeric offset.
- Keep sending the valid cursor.name token to the API while allowing monotonically advancing offsets.
- Stop repeated or regressed offsets so unlimited sync cannot spin on a malformed cursor.
- Add regression tests and handfix ledger markers.

Verification:
- go test ./internal/cli ./internal/store
- python3 tools/maintainer/check_handfixes.py --slug ninjaone
- python3 tools/maintainer/check_security_gate.py --slug ninjaone --base origin/main
- python3 tools/maintainer/check_release_contract.py
- git diff --check
- codex exec read-only security review: No P1, no P2 in this diff

Note:
- A local full tools/maintainer/verify_all.sh ninjaone run previously passed the relevant connector gates and security gate, then failed only because the markdown link checker scanned gitignored .claude/worktrees files in this checkout.