### PR TITLE
docs: resolve README badge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,7 @@ Free, open source, runs on your laptop. A local SQLite mirror lets your agent an
 > **New to the term?** What this repo calls an **MCP server** is what ChatGPT calls an *app* or *connector*, Claude on the web calls a *connector*, Microsoft Copilot calls a *connector*, and Claude Code calls a *Skill*. Same standard underneath: the [Model Context Protocol](https://modelcontextprotocol.io). Full plain-language answer: **[What is an MCP server?](https://msp-skills.compoundingteams.com/what-is-an-mcp-server/)**.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
-<<<<<<< HEAD
 [![Skills](https://img.shields.io/badge/skills-59-green.svg)](./catalog.json)
-=======
-<<<<<<< HEAD
-[![Skills](https://img.shields.io/badge/skills-59-green.svg)](./catalog.json)
-=======
-[![Skills](https://img.shields.io/badge/skills-59-green.svg)](./catalog.json)
->>>>>>> origin/main
->>>>>>> origin/main
 [![MCP](https://img.shields.io/badge/MCP-compatible-1f6feb.svg)](https://modelcontextprotocol.io)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-spec-2E7D32.svg)](https://agentskills.io)
 ![Status](https://img.shields.io/badge/status-beta-yellow.svg)


### PR DESCRIPTION
## Summary
- Remove accidental nested merge-conflict markers from the top-level README badge block.
- Keep the single generated 59-skill badge in place.

## Validation
- `python3 tools/maintainer/check_surface_coverage.py`
- `git diff --check origin/main...HEAD`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" --glob '!/.claude/**' .`\n- README-only local-link check\n\n## Release\nDocs-only README cleanup. No connector version bump, release batch, or tag is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up the README so the Skills badge displays correctly.
  * Removed stray merge-conflict markers and kept a single working badge link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->