### PR TITLE
fix(connectwise-manage): correct .mcpb manifest for Claude Desktop install (#185)

### DIFF
--- a/skills/connectwise-manage/cli/go.mod
+++ b/skills/connectwise-manage/cli/go.mod
@@ -2,7 +2,7 @@ module connectwise-manage-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/connectwise-manage/handfixes.json
+++ b/skills/connectwise-manage/handfixes.json
@@ -43,6 +43,23 @@
         {"file": "cli/internal/mcp/tools.go", "contains": "Large/historical tenant: sync is a FULL re-fetch today", "min_count": 1},
         {"file": "cli/internal/mcp/tools.go", "contains": "resource_not_incremental", "min_count": 1}
       ]
+    },
+    {
+      "id": "mcpb-manifest-packaging-v013",
+      "summary": "MCPB manifest stays Claude Desktop-valid and points at packaged suffixed binaries with all ConnectWise auth env vars",
+      "why": "connectwise-manage v0.1.3 shipped a press-generated MCPB manifest with invalid top-level press provenance keys, only CW_CLIENT_ID in user_config/env, and a generic bin/connectwise-manage-mcp command even though the bundle contains only architecture-suffixed binaries. A reprint from the unfixed press can restore all three packaging regressions.",
+      "status": "active",
+      "asserts": [
+        {"file": "manifest.json", "not_contains": "\"press_provenance\""},
+        {"file": "manifest.json", "contains": "\"_meta\"", "min_count": 1},
+        {"file": "manifest.json", "contains": "\"CW_COMPANY_ID\"", "min_count": 2},
+        {"file": "manifest.json", "contains": "\"CW_PRIVATE_KEY\"", "min_count": 2},
+        {"file": "manifest.json", "contains": "\"CW_SITE\"", "min_count": 2},
+        {"file": "manifest.json", "contains": "\"platform_overrides\"", "min_count": 1},
+        {"file": "manifest.json", "contains": "connectwise-manage-mcp-darwin-arm64", "min_count": 2},
+        {"file": "manifest.json", "contains": "connectwise-manage-mcp-linux-amd64", "min_count": 1},
+        {"file": "manifest.json", "contains": "connectwise-manage-mcp-windows-amd64.exe", "min_count": 1}
+      ]
     }
   ]
 }

--- a/skills/connectwise-manage/manifest.json
+++ b/skills/connectwise-manage/manifest.json
@@ -10,16 +10,57 @@
   "license": "Apache-2.0",
   "server": {
     "type": "binary",
-    "entry_point": "bin/connectwise-manage-mcp",
+    "entry_point": "bin/connectwise-manage-mcp-darwin-arm64",
     "mcp_config": {
-      "command": "${__dirname}/bin/connectwise-manage-mcp",
+      "command": "${__dirname}/bin/connectwise-manage-mcp-darwin-arm64",
       "args": [],
       "env": {
+        "CW_COMPANY_ID": "${user_config.cw_company_id}",
+        "CW_PUBLIC_KEY": "${user_config.cw_public_key}",
+        "CW_PRIVATE_KEY": "${user_config.cw_private_key}",
+        "CW_SITE": "${user_config.cw_site}",
         "CW_CLIENT_ID": "${user_config.cw_client_id}"
+      },
+      "platform_overrides": {
+        "darwin": {
+          "command": "${__dirname}/bin/connectwise-manage-mcp-darwin-arm64"
+        },
+        "linux": {
+          "command": "${__dirname}/bin/connectwise-manage-mcp-linux-amd64"
+        },
+        "win32": {
+          "command": "${__dirname}/bin/connectwise-manage-mcp-windows-amd64.exe"
+        }
       }
     }
   },
   "user_config": {
+    "cw_company_id": {
+      "type": "string",
+      "title": "CW_COMPANY_ID",
+      "description": "ConnectWise Manage company ID/codebase used in the composite Basic auth username.",
+      "required": true
+    },
+    "cw_public_key": {
+      "type": "string",
+      "title": "CW_PUBLIC_KEY",
+      "description": "API Member public key used with the company ID in the composite Basic auth username.",
+      "sensitive": true,
+      "required": true
+    },
+    "cw_private_key": {
+      "type": "string",
+      "title": "CW_PRIVATE_KEY",
+      "description": "API Member private key used as the composite Basic auth password.",
+      "sensitive": true,
+      "required": true
+    },
+    "cw_site": {
+      "type": "string",
+      "title": "CW_SITE",
+      "description": "ConnectWise Manage region host such as api-na.myconnectwise.net, api-eu.myconnectwise.net, api-au.myconnectwise.net, or your on-prem host.",
+      "required": true
+    },
     "cw_client_id": {
       "type": "string",
       "title": "CW_CLIENT_ID",
@@ -36,11 +77,12 @@
       "win32"
     ]
   },
-  "printing_press_version": "4.24.0",
-  "press_provenance": {
-    "printing_press_version": "4.24.0",
-    "generated_at": "2026-06-13T04:30:16.959816Z",
-    "spec_checksum": "sha256:1072495121d5e5db066142001ae76f745b41ec21ebdfc6d1f5919d794e6f3b40",
-    "spec_format": "openapi3"
+  "_meta": {
+    "io.github.mvanhorn.cli-printing-press": {
+      "printing_press_version": "4.24.0",
+      "generated_at": "2026-06-13T04:30:16.959816Z",
+      "spec_checksum": "sha256:1072495121d5e5db066142001ae76f745b41ec21ebdfc6d1f5919d794e6f3b40",
+      "spec_format": "openapi3"
+    }
   }
 }

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -99,7 +99,7 @@ def build_entry(skill_dir: Path) -> dict:
         # Which cli-printing-press version minted this skill (null for
         # markdown-only skills and any binary skill onboarded before the
         # press-provenance field was added to its manifest.json).
-        "printing_press_version": manifest.get("printing_press_version"),
+        "printing_press_version": printing_press_version(manifest),
         "license": manifest.get("license", "Apache-2.0"),
         "vendor": meta["vendor"],
         "vendor_trademark_owner": meta["vendor_trademark_owner"],
@@ -122,6 +122,19 @@ def build_entry(skill_dir: Path) -> dict:
     if markdown_only:
         entry["markdown_only"] = True
     return entry
+
+
+def printing_press_version(manifest: dict) -> str | None:
+    version = manifest.get("printing_press_version")
+    if version:
+        return version
+    meta = manifest.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    press = meta.get("io.github.mvanhorn.cli-printing-press")
+    if not isinstance(press, dict):
+        return None
+    return press.get("printing_press_version")
 
 
 def _verification_state(meta: dict, markdown_only: bool) -> str:


### PR DESCRIPTION
Fixes #185.

Corrects the `connectwise-manage` `.mcpb` manifest so it installs via Claude
Desktop **Settings → Extensions** (reported against the v0.1.3 release .mcpb).

## Three defects fixed (`skills/connectwise-manage/manifest.json`)
1. **Non-spec top-level keys** — `printing_press_version` + `press_provenance`
   are not MCPB manifest spec keys, so Claude Desktop's validator rejected the
   whole manifest (`Unrecognized key(s)`). Relocated under
   `_meta["io.github.mvanhorn.cli-printing-press"]` — verified against
   `anthropics/mcpb` MANIFEST.md as the spec's reverse-DNS namespaced metadata
   slot (a recognized key).
2. **Only 1 of 5 credentials wired** — `user_config` declared just `cw_client_id`.
   The CLI needs `CW_COMPANY_ID`, `CW_PUBLIC_KEY`, `CW_PRIVATE_KEY`, `CW_CLIENT_ID`
   **and a required `CW_SITE`** (reporter confirmed it does not default). Added all
   and mapped every one into `server.mcp_config.env`.
3. **Binary path ENOENT** — `command` pointed at `bin/connectwise-manage-mcp`,
   which no release ships (only arch-suffixed binaries). Added `platform_overrides`
   per OS.

`tools/maintainer/build-catalog.py` now reads `printing_press_version` from the
relocated `_meta` slot — verified regenerating catalog + llms yields **no diff**.

## Known limitation (partial fix, accepted)
MCPB `platform_overrides` has no CPU-arch axis, so this covers **Apple-Silicon
macOS + amd64 Linux/Windows**. **Intel macOS and arm64 Linux still ENOENT** — full
coverage needs a launcher shim or universal binaries. Filed as a press retro
(cli-printing-press) since the manifest is generated.

Note: this fixes the **source** manifest; users get it on the next
`connectwise-manage` release (which rebuilds the `.mcpb`).

---
Opened by `gh-loop`. Not merged — presented for maintainer review. Reported by @jborello.
