### PR TITLE
chore(fleet): bump Go toolchain to go1.26.5 across 54 connectors (GO-2026-5856)

### DIFF
--- a/skills/abnormal/cli/go.mod
+++ b/skills/abnormal/cli/go.mod
@@ -2,7 +2,7 @@ module abnormal-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/acronis/cli/go.mod
+++ b/skills/acronis/cli/go.mod
@@ -2,7 +2,7 @@ module acronis-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/action1/cli/go.mod
+++ b/skills/action1/cli/go.mod
@@ -2,7 +2,7 @@ module action1-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/afi/cli/go.mod
+++ b/skills/afi/cli/go.mod
@@ -2,7 +2,7 @@ module afi-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/appdirect/cli/go.mod
+++ b/skills/appdirect/cli/go.mod
@@ -2,7 +2,7 @@ module appdirect-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/atera/cli/go.mod
+++ b/skills/atera/cli/go.mod
@@ -2,7 +2,7 @@ module atera-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/autotask/cli/go.mod
+++ b/skills/autotask/cli/go.mod
@@ -2,7 +2,7 @@ module autotask-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/axcient/cli/go.mod
+++ b/skills/axcient/cli/go.mod
@@ -2,7 +2,7 @@ module axcient-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/enetx/surf v1.0.199

--- a/skills/betterstack/cli/go.mod
+++ b/skills/betterstack/cli/go.mod
@@ -2,7 +2,7 @@ module betterstack-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/blumira/cli/go.mod
+++ b/skills/blumira/cli/go.mod
@@ -2,7 +2,7 @@ module blumira-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/cipp/cli/go.mod
+++ b/skills/cipp/cli/go.mod
@@ -2,7 +2,7 @@ module cipp-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/connectwise-automate/cli/go.mod
+++ b/skills/connectwise-automate/cli/go.mod
@@ -2,7 +2,7 @@ module connectwise-automate-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/connectwise-control/cli/go.mod
+++ b/skills/connectwise-control/cli/go.mod
@@ -2,7 +2,7 @@ module connectwise-control-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/enetx/http v1.0.28

--- a/skills/cove/cli/go.mod
+++ b/skills/cove/cli/go.mod
@@ -2,7 +2,7 @@ module cove-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/crowdstrike/cli/go.mod
+++ b/skills/crowdstrike/cli/go.mod
@@ -2,7 +2,7 @@ module crowdstrike-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/datto-bcdr/cli/go.mod
+++ b/skills/datto-bcdr/cli/go.mod
@@ -2,7 +2,7 @@ module datto-bcdr-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/datto-rmm/cli/go.mod
+++ b/skills/datto-rmm/cli/go.mod
@@ -2,7 +2,7 @@ module datto-rmm-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/domotz/cli/go.mod
+++ b/skills/domotz/cli/go.mod
@@ -2,7 +2,7 @@ module domotz-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/gradient/cli/go.mod
+++ b/skills/gradient/cli/go.mod
@@ -2,7 +2,7 @@ module gradient-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/halopsa/cli/go.mod
+++ b/skills/halopsa/cli/go.mod
@@ -2,7 +2,7 @@ module halopsa-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/hubspot/cli/go.mod
+++ b/skills/hubspot/cli/go.mod
@@ -2,7 +2,7 @@ module hubspot-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/hudu/cli/go.mod
+++ b/skills/hudu/cli/go.mod
@@ -2,7 +2,7 @@ module hudu-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/huntress/cli/go.mod
+++ b/skills/huntress/cli/go.mod
@@ -2,7 +2,7 @@ module huntress-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/itglue/cli/go.mod
+++ b/skills/itglue/cli/go.mod
@@ -2,7 +2,7 @@ module itglue-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/kaseya-bms/cli/go.mod
+++ b/skills/kaseya-bms/cli/go.mod
@@ -2,7 +2,7 @@ module kaseya-bms-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/knowbe4/cli/go.mod
+++ b/skills/knowbe4/cli/go.mod
@@ -2,7 +2,7 @@ module knowbe4-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/levelio/cli/go.mod
+++ b/skills/levelio/cli/go.mod
@@ -2,7 +2,7 @@ module levelio-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/liongard/cli/go.mod
+++ b/skills/liongard/cli/go.mod
@@ -2,7 +2,7 @@ module liongard-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/maxio/cli/go.mod
+++ b/skills/maxio/cli/go.mod
@@ -2,7 +2,7 @@ module maxio-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/microsoft-graph/cli/go.mod
+++ b/skills/microsoft-graph/cli/go.mod
@@ -2,7 +2,7 @@ module microsoft-graph-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/mspbots/cli/go.mod
+++ b/skills/mspbots/cli/go.mod
@@ -2,7 +2,7 @@ module mspbots-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/n-central/cli/go.mod
+++ b/skills/n-central/cli/go.mod
@@ -2,7 +2,7 @@ module n-central-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/nerdio/cli/go.mod
+++ b/skills/nerdio/cli/go.mod
@@ -2,7 +2,7 @@ module nerdio-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/pagerduty/cli/go.mod
+++ b/skills/pagerduty/cli/go.mod
@@ -2,7 +2,7 @@ module pagerduty-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/pandadoc/cli/go.mod
+++ b/skills/pandadoc/cli/go.mod
@@ -2,7 +2,7 @@ module pandadoc-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/pax8/cli/go.mod
+++ b/skills/pax8/cli/go.mod
@@ -2,7 +2,7 @@ module pax8-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/pipedrive/cli/go.mod
+++ b/skills/pipedrive/cli/go.mod
@@ -2,7 +2,7 @@ module pipedrive-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/proofpoint/cli/go.mod
+++ b/skills/proofpoint/cli/go.mod
@@ -2,7 +2,7 @@ module proofpoint-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/quickbooks/cli/go.mod
+++ b/skills/quickbooks/cli/go.mod
@@ -2,7 +2,7 @@ module quickbooks-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/rewst/cli/go.mod
+++ b/skills/rewst/cli/go.mod
@@ -2,7 +2,7 @@ module rewst-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/skills/rocketcyber/cli/go.mod
+++ b/skills/rocketcyber/cli/go.mod
@@ -2,7 +2,7 @@ module rocketcyber-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/rootly/cli/go.mod
+++ b/skills/rootly/cli/go.mod
@@ -2,7 +2,7 @@ module rootly-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/runzero/cli/go.mod
+++ b/skills/runzero/cli/go.mod
@@ -2,7 +2,7 @@ module runzero-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/salesbuildr/cli/go.mod
+++ b/skills/salesbuildr/cli/go.mod
@@ -2,7 +2,7 @@ module salesbuildr-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/sentinelone/cli/go.mod
+++ b/skills/sentinelone/cli/go.mod
@@ -2,7 +2,7 @@ module sentinelone-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/servosity/cli/go.mod
+++ b/skills/servosity/cli/go.mod
@@ -2,7 +2,7 @@ module servosity-msp-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/sherweb/cli/go.mod
+++ b/skills/sherweb/cli/go.mod
@@ -2,7 +2,7 @@ module sherweb-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/skykick/cli/go.mod
+++ b/skills/skykick/cli/go.mod
@@ -2,7 +2,7 @@ module skykick-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require github.com/spf13/cobra v1.9.1
 

--- a/skills/superops/cli/go.mod
+++ b/skills/superops/cli/go.mod
@@ -2,7 +2,7 @@ module superops-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/syncro/cli/go.mod
+++ b/skills/syncro/cli/go.mod
@@ -2,7 +2,7 @@ module syncro-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/tactical-rmm/cli/go.mod
+++ b/skills/tactical-rmm/cli/go.mod
@@ -2,7 +2,7 @@ module tactical-rmm-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/threatlocker/cli/go.mod
+++ b/skills/threatlocker/cli/go.mod
@@ -2,7 +2,7 @@ module threatlocker-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/veeam/cli/go.mod
+++ b/skills/veeam/cli/go.mod
@@ -2,7 +2,7 @@ module veeam-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/skills/xero/cli/go.mod
+++ b/skills/xero/cli/go.mod
@@ -2,7 +2,7 @@ module xero-pp-cli
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4


### PR DESCRIPTION
Bumps the Go toolchain directive `go1.26.4` → `go1.26.5` in **54 connectors'** `cli/go.mod` — a pure one-line edit per file, no regeneration.

## Why
CI's `security-gate` pins govulncheck to each module's toolchain directive. Every connector minted before the go1.26.5 press stamped `toolchain go1.26.4`, which govulncheck flags as **GO-2026-5856** (crypto/tls Encrypted Client Hello privacy leak, Go stdlib, fixed in **go1.26.5**). Result: *any* PR touching those connectors was blocked at the gate on a pre-existing, unrelated finding. This clears it fleet-wide.

## Durability
`cli-printing-press` 4.28.0 now stamps `toolchain go1.26.5` (verified: golden connectors), so a future **reprint** of any connector keeps 1.26.5 — this sweep won't regress. ninjaone + connectwise-manage were already bumped in #187 / #188 (not in this diff).

## Verification
- 54 files changed, each **only** the toolchain line (`-toolchain go1.26.4` / `+toolchain go1.26.5`); 0 remaining on 1.26.4.
- Locally reproduced the fix on ninjaone + connectwise-manage: `security-gate` went `1 P1 → 0 P1`.
- Note: CI's diff-scoped gate will run govulncheck across all 54 modules (slow but a clean bulk check).

Opened by `gh-loop`. Not merged — presented for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26.5 across the CLI components.
  * Preserved existing module settings and dependency requirements.
  * No user-facing functionality or behavior changes are included.
  * Builds and development workflows now use the newer toolchain patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->