### PR TITLE
security(base-policy): suppress 7 fleet FPs in printing-press v4.28 self-learning-loop

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -215,6 +215,36 @@
       "file": "skills/aws-billing/cli/internal/client/client.go",
       "rule": "G306",
       "reason": "aws-billing (generated). os.WriteFile 0o644 for a local HTTP response-cache file (non-secret cost data) under the user's own cache dir. Local, user-owned; same class as the client.go G304 fleet suppression."
+    },
+    {
+      "file": "cli/internal/store/learnings.go",
+      "rule": "G202",
+      "reason": "FLEET (generated, printing-press v4.28 self-learning loop). DELETE query is built from HARDCODED constant clause strings (\"query_pattern = ?\", \"resource_id = ?\", \"action = ?\") joined with AND; every value is bound via a `?` placeholder in args. No user input reaches the SQL text. gosec G202 flags the strings.Join concat pattern; parameterization makes it safe."
+    },
+    {
+      "file": "cli/internal/learn/teach_log.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). os.OpenFile on an app-determined path from teachErrLogPath()/learningsAuditPath() under the user's own config/cache dir; not user-controlled. Same class as the accepted cli/internal/client/client.go G304 entry."
+    },
+    {
+      "file": "cli/internal/learn/playbooks.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Reads/writes the local learning playbooks file at an app-determined path under the user's own config dir; no untrusted path input."
+    },
+    {
+      "file": "cli/internal/cli/teach_playbook.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Opens the local playbook JSON at an app-determined config-dir path; no untrusted path input."
+    },
+    {
+      "file": "cli/internal/cli/teach.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Appends to the local teach.log / learnings audit JSONL at app-determined config-dir paths (teachErrLogPath / learningsAuditPath); not user-controlled."
+    },
+    {
+      "file": "cli/internal/learn/journal.go",
+      "rule": "G117",
+      "reason": "FLEET (generated). The marshaled struct field SessionKey is a local journal SESSION IDENTIFIER (JournalSessionKey()), not a credential; gosec G117 name-matches the field name against a secret pattern. No secret is serialized."
     }
   ]
 }


### PR DESCRIPTION
## Base-policy suppression — merge BEFORE skill PR #190

zammad (#190) is the **first connector to ship the printing-press v4.28 self-learning-loop** (`cli/internal/learn/`, `cli/internal/cli/teach*.go`, `learnings.go`). gosec flags **7 P1 false-positives** on this generated framework. Per `AGENTS.md` §7.1, base-policy suppressions live on `main` (CI reads policy from base), never inline in a skill PR — so this PR must merge first, then #190 goes green on rebase.

All entries are **FLEET-scoped** (slug-relative `cli/...`) because the code is byte-identical in every connector reprinted with v4.28+.

### The 7 findings (all verified false-positives)
| Rule | File | Why it's a false-positive |
|---|---|---|
| G202 | `cli/internal/store/learnings.go` | DELETE built from **hardcoded constant** clause strings; every value bound via `?` placeholder. No user input in SQL text. |
| G304 | `cli/internal/learn/teach_log.go` | `os.OpenFile` on an **app-determined** config/cache path; not user-controlled. Same class as the accepted `client.go` G304. |
| G304 | `cli/internal/learn/playbooks.go` | Local playbooks file at an app-determined config-dir path. |
| G304 | `cli/internal/cli/teach_playbook.go` | Local playbook JSON at an app-determined config-dir path. |
| G304 | `cli/internal/cli/teach.go` | Appends to local teach.log / audit JSONL at app-determined paths. |
| G117 | `cli/internal/learn/journal.go` | `SessionKey` is a journal **session identifier**, not a credential; name-match heuristic. |

No real finding is muted — these are the generated learning-loop's own local-state file access and parameterized SQL. Verified with `check_security_gate.py --slug zammad --policy-base <this-branch>` → **0 P1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated security scanning rules to account for safe, internally controlled learning and teaching workflows.
  * Clarified handling of local configuration, cache, journal, and generated data paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->