### PR TITLE
fix(ci): green the guards check on main

### DIFF
--- a/skills/connectwise-manage/CHANGELOG.md
+++ b/skills/connectwise-manage/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this skill are documented here. Format follows
 ## [0.1.4] - 2026-07-10
 
 ### Fixed
-- The `.mcpb` extension now installs via Claude Desktop → Settings → Extensions. The published manifest previously failed to install for three reasons, all corrected: (1) non-spec top-level keys (`printing_press_version`, `press_provenance`) made Claude Desktop's validator reject the whole manifest — provenance now lives under the spec's `_meta` slot; (2) only one of the required credentials was declared — all five (`CW_COMPANY_ID`, `CW_PUBLIC_KEY`, `CW_PRIVATE_KEY`, `CW_CLIENT_ID`, `CW_SITE`) are now in `user_config` and wired into the MCP server env; (3) the server command pointed at a binary name the release never ships (`ENOENT`) — `platform_overrides` now select the correct per-OS binary. Reported by @jborello (#185).
+- The `.mcpb` extension now installs via Claude Desktop → Settings → Extensions. The published manifest previously failed to install for three reasons, all corrected: (1) non-spec top-level keys (`printing_press_version`, `press_provenance`) made Claude Desktop's validator reject the whole manifest - provenance now lives under the spec's `_meta` slot; (2) only one of the required credentials was declared - all five (`CW_COMPANY_ID`, `CW_PUBLIC_KEY`, `CW_PRIVATE_KEY`, `CW_CLIENT_ID`, `CW_SITE`) are now in `user_config` and wired into the MCP server env; (3) the server command pointed at a binary name the release never ships (`ENOENT`) - `platform_overrides` now select the correct per-OS binary. Reported by @jborello (#185).
 
 ### Changed
 - Bumped the Go toolchain to go1.26.5 (clears the `crypto/tls` standard-library advisory GO-2026-5856).

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this skill are documented here. Format follows
 ## [0.1.6] - 2026-07-10
 
 ### Fixed
-- Device tagging now works through the MCP server. The code-orchestration executor substituted only numeric path parameters, leaving string-typed ones (e.g. `{assetType}`, `{entityType}`) as literal template tokens in the request URL — which broke `tag.set-for-asset`, `tag.batch-update`, and the `custom-fields` endpoints that carry a string path segment. String path parameters are now resolved and URL-escaped like numeric ones. Reported by @livewire-it (#186).
+- Device tagging now works through the MCP server. The code-orchestration executor substituted only numeric path parameters, leaving string-typed ones (e.g. `{assetType}`, `{entityType}`) as literal template tokens in the request URL - which broke `tag.set-for-asset`, `tag.batch-update`, and the `custom-fields` endpoints that carry a string path segment. String path parameters are now resolved and URL-escaped like numeric ones. Reported by @livewire-it (#186).
 
 ### Changed
 - Bumped the Go toolchain to go1.26.5 (clears the `crypto/tls` standard-library advisory GO-2026-5856).

--- a/tools/maintainer/ci_guards.sh
+++ b/tools/maintainer/ci_guards.sh
@@ -60,7 +60,11 @@ echo "==> 5. No real production-tenant transaction counts in human-authored file
 # comma so this guard never contains the strings it bans (same trick as guards
 # 1-2). Use a generic phrasing ("the full book") instead of real totals.
 cma=$(printf ',')
-counts="44${cma}?211|17${cma}?940|16${cma}?863"
+# Word-boundary anchored so the counts only match as standalone numbers in
+# prose, not as an incidental digit run inside a longer token (e.g. one of
+# the banned counts surfacing by chance inside the hex of a sha256 hash in a
+# generated data file).
+counts="\\b(44${cma}?211|17${cma}?940|16${cma}?863)\\b"
 if human_files | xargs grep -nIE "$counts" 2>/dev/null; then
   note "real production-tenant transaction count found; replace with generic phrasing (e.g. 'the full book')"
   fail=1


### PR DESCRIPTION
## main is red on `guards` — this greens it

`ci_guards.sh` scans the whole post-merge tree, so main's failure blocks the `guards` check on **every** open PR (incl. #190/#191). Two pre-existing issues:

1. **Rule 5 false positive.** The real-tenant-count rule matched `17940` inside a **sha256 hash** in `docs/_data/pending.json` (a machine-generated file). Fixed by anchoring the banned count literals with word boundaries (`\b(...)\b`) so they only match standalone numbers in prose, never an incidental digit run inside a longer token. Verified the hash line no longer matches while real prose counts (with or without commas) still do, on both GNU and BSD grep.

2. **Rule 2 (em-dash).** Genuine em-dashes in two recently-merged CHANGELOGs (`connectwise-manage` #185, `ninjaone` #186) slipped in. Replaced ` — ` with ` - ` per the CONTRIBUTING style rule.

`bash tools/maintainer/ci_guards.sh` now passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `.mcpb` extension installation by correcting manifest validation, credential configuration, and platform-specific release setup.
  * Fixed device tagging and custom-field operations involving string-based path parameters, including asset and entity types.
* **Chores**
  * Strengthened automated safeguards for more accurate detection of transaction-count references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->