### PR TITLE
HaloPSA instructions

### DIFF
--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -57,7 +57,7 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
         "HALOPSA_TENANT": "<your-tenant>",
         "HALOPSA_CLIENT_ID": "<your-client-id>",
         "HALOPSA_CLIENT_SECRET": "<your-client-secret>",
-		"HALOPSA_DOMAIN": "<your-custom-domain>"
+		"HALOPSA_DOMAIN": "halopsa.com"
       }
     },
     "servosity": {

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -56,7 +56,8 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
       "env": {
         "HALOPSA_TENANT": "<your-tenant>",
         "HALOPSA_CLIENT_ID": "<your-client-id>",
-        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>",
+		"HALOPSA_DOMAIN": "<your-custom-domain>"
       }
     },
     "servosity": {
@@ -70,6 +71,8 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
 ```
 
 Save the file.
+
+Note: The default domain assigned to your HaloPSA instance is tenant.halopsa.com. If you are using that URL, omit defining HALOPSA_DOMAIN. If you are using a custom domain (e.g. psa.company.com), "psa" is your HALOPSA_TENANT and "company.com" is your HALOPSA_DOMAIN. 
 
 ## Step 3 - Restart Claude Desktop
 


### PR DESCRIPTION
Custom domains for HaloPSA require defining the HALOPSA_DOMAIN var.

# Pull request

## What this changes

Added the HALOPSA_DOMAIN var to the mcpservers block example for the Claude json config. Put a note under the code block to explain the difference between the TENANT and DOMAIN slugs.

## Checklist (required)

- [ ] Every commit signed off with `git commit -s` (DCO).
- [ ] `SKILL.md` has frontmatter fields: `name`, `description`, `allowed-tools`, `author`, `license`, `vendor`.
- [ ] Skill `README.md` opens with the vendor non-affiliation banner before any other content.
- [ ] `install.sh` and `install.ps1` present, or skill is markdown-only and the README says so.
- [ ] `mcp-install.md` present if the skill ships an MCP server.
- [ ] No em-dashes anywhere in committed files.
- [ ] No `/Users/`, `/home/`, personal emails, or API keys in committed files.
- [ ] `catalog.json` regenerated by CI (this is automatic; do not hand-edit).

## Checklist (encouraged)

- [ ] `pain-point.md` describes the MSP pain this Skill or MCP closes, with at least one external citation.
- [ ] `governance.md` describes which permissions the Skill needs and why.

## Trademark check

If this PR adds or modifies a Skill for a third-party vendor's API:

- [ ] Skill references vendor names descriptively only.
- [ ] No vendor logos included.
- [ ] No "Official", "Certified", or "Partner" language anywhere.
- [ ] Non-affiliation banner cites the correct trademark holder.

## Related Build Session or issue

<!-- Link to the Build Session episode, issue, or community thread that
prompted this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom HaloPSA domains in Claude Desktop.
  * Clarified when the optional domain setting can be omitted and how to determine the required values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->