### PR TITLE
default halo domain fix

### DIFF
--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -57,7 +57,7 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
         "HALOPSA_TENANT": "<your-tenant>",
         "HALOPSA_CLIENT_ID": "<your-client-id>",
         "HALOPSA_CLIENT_SECRET": "<your-client-secret>",
-		"HALOPSA_DOMAIN": "<your-custom-domain>"
+		"HALOPSA_DOMAIN": "halopsa.com"
       }
     },
     "servosity": {

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -56,7 +56,8 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
       "env": {
         "HALOPSA_TENANT": "<your-tenant>",
         "HALOPSA_CLIENT_ID": "<your-client-id>",
-        "HALOPSA_CLIENT_SECRET": "<your-client-secret>"
+        "HALOPSA_CLIENT_SECRET": "<your-client-secret>",
+		"HALOPSA_DOMAIN": "<your-custom-domain>"
       }
     },
     "servosity": {
@@ -70,6 +71,8 @@ Open Claude Desktop → **Settings → Developer → Edit Config**. (This opens 
 ```
 
 Save the file.
+
+Note: The default domain assigned to your HaloPSA instance is tenant.halopsa.com. If you are using that URL, omit defining HALOPSA_DOMAIN. If you are using a custom domain (e.g. psa.company.com), "psa" is your HALOPSA_TENANT and "company.com" is your HALOPSA_DOMAIN. 
 
 ## Step 3 - Restart Claude Desktop
 

--- a/skills/halopsa/cli/internal/cli/sync.go
+++ b/skills/halopsa/cli/internal/cli/sync.go
@@ -501,6 +501,10 @@ func syncResource(ctx context.Context, c interface {
 	// failed extraction.
 	var extractFailureTotal int
 	var consumedTotal int
+	// rowsSeen counts extracted rows across pages so the walk can compare
+	// progress against the result-set total the API reports (Halo's
+	// record_count). See the Hand-wired note at its use site.
+	var rowsSeen int
 	anomalyEmitted := false
 
 	for {
@@ -508,8 +512,22 @@ func syncResource(ctx context.Context, c interface {
 
 		if resourceSupportsPagination(resource) {
 			params[pageSize.limitParam] = strconv.Itoa(pageSize.limit)
-			if cursor != "" {
-				params[pageSize.cursorParam] = cursor
+			// Hand-wired: Halo ignores page_size/page_no unless pagination is
+			// explicitly switched on, and answers with the acting agent's
+			// default page size instead. Set before the cursor so a user
+			// --param override can still turn it back off.
+			if pageSize.enableParam != "" {
+				params[pageSize.enableParam] = "true"
+			}
+			// Hand-wired: seed the first request with startCursor. Halo does
+			// not default page_no, and omitting it yields a short page that
+			// reports itself as complete, ending the walk after one request.
+			effectiveCursor := cursor
+			if effectiveCursor == "" {
+				effectiveCursor = pageSize.startCursor
+			}
+			if effectiveCursor != "" {
+				params[pageSize.cursorParam] = effectiveCursor
 			}
 		}
 
@@ -553,13 +571,27 @@ func syncResource(ctx context.Context, c interface {
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
 
+		// Hand-wired: prefer Halo's reported result-set total over the
+		// "a full page means more pages" heuristic. Halo sets record_count to
+		// the whole result-set size while paginating, and several endpoints
+		// (notably /Asset) ignore page_size entirely and always answer with a
+		// fixed 50-row page. Inferring more-pages from len(items) >= limit
+		// therefore stops those walks after one page: /Asset returned 50 of
+		// 144 rows and looked complete. The reported total is authoritative
+		// and endpoint-independent, so trust it when present and fall back to
+		// the length heuristic when it is absent.
+		rowsSeen += len(items)
+		reportedTotal, hasReportedTotal := envelopeReportedTotal(data)
+		moreByReportedTotal := hasReportedTotal && len(items) > 0 && rowsSeen < reportedTotal
+		pageLooksFull := len(items) >= pageSize.limit || moreByReportedTotal
+
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
 		// to advance numerically. Without this the loop breaks after page
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorType == "page" && nextCursor == "" && pageLooksFull && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -567,7 +599,7 @@ func syncResource(ctx context.Context, c interface {
 			nextCursor = strconv.Itoa(currentPage + 1)
 			hasMore = true
 		}
-		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
+		if pageSize.cursorType == "offset" && nextCursor == "" && pageLooksFull && pageAllowsPageIntFallback(data) {
 			currentOffset, _ := strconv.Atoi(cursor)
 			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
 			hasMore = true
@@ -720,7 +752,7 @@ func syncResource(ctx context.Context, c interface {
 		if !resourceSupportsPagination(resource) {
 			break
 		}
-		if !hasMore || len(items) < pageSize.limit {
+		if !hasMore || !pageLooksFull {
 			break
 		}
 		if nextCursor == "" {
@@ -781,16 +813,53 @@ type paginationDefaults struct {
 	cursorType  string // paginator class: "", "cursor", "page_token", "offset", "page"
 	limitParam  string
 	limit       int
+	// enableParam is a boolean query parameter the API requires before it
+	// honours any paging parameters at all. Empty when the API paginates
+	// unconditionally. Halo needs "pageinate=true"; see the Hand-wired note
+	// on determinePaginationDefaults.
+	enableParam string
+	// startCursor is the cursor value sent for the very first page when no
+	// resume cursor is stored. Only meaningful for numeric paginators
+	// ("page" / "offset"), where the first index is knowable; leave empty for
+	// opaque cursor/page_token APIs, whose first cursor cannot be fabricated.
+	// Halo needs an explicit page_no=1, so this must not be empty.
+	startCursor string
 }
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
+//
+// Hand-wired: the profiler's defaults (cursorParam "page", cursorType
+// "offset", no enableParam) do not match Halo's live paging contract and
+// silently truncated every sync to a single page. Halo requires three things
+// together:
+//
+//   - pageinate=true, without which Halo ignores page_size/page_no entirely
+//     and returns the acting agent's configured default page size (50 for an
+//     API agent), so a sync of 1254 tickets stored 50 and reported success;
+//   - page_no, not page, as the cursor parameter name;
+//   - page_no is a 1-based page *number*, not a row offset, so cursorType
+//     must be "page" to make the page-int fallback advance 1,2,3 rather than
+//     the offset fallback's 0,100,200. With "offset" Halo reads the row
+//     offset as a page number and pages 100..200 are silently skipped;
+//   - page_no must be sent explicitly on the FIRST request too. Halo does not
+//     default it: pageinate=true&page_size=100 with no page_no returns the
+//     agent default of 50 rows AND reports record_count as 50, so the page
+//     looks complete and the walk stops after one request. Hence startCursor.
+//
+// Verified live against a self-hosted Halo instance: pageinate=true&page_size=100 with
+// page_no 1/2/3 returns three disjoint 100-row pages (ids 11509..11409,
+// 11408..11308, 11307..11207) and reports record_count as the full 1254-row
+// total rather than the returned-row count. The same call without page_no
+// returns 50 rows with record_count 50.
 func determinePaginationDefaults() paginationDefaults {
 	return paginationDefaults{
-		cursorParam: "page",
-		cursorType:  "offset",
+		cursorParam: "page_no",
+		cursorType:  "page",
 		limitParam:  "page_size",
 		limit:       100,
+		enableParam: "pageinate",
+		startCursor: "1",
 	}
 }
 
@@ -1355,6 +1424,54 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 
 func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
+}
+
+// envelopeReportedTotal returns the size of the whole result set as reported
+// by the response envelope, and whether such a count was present.
+//
+// Hand-wired: Halo answers list endpoints with record_count. While paginating
+// that is the full result-set total (1254 for /Tickets), which makes it a
+// reliable more-pages signal for endpoints that ignore page_size and return a
+// fixed-size page regardless (/Asset always answers 50, so a page-length
+// heuristic sees 50 < 100 and stops at 50 of 144 rows). When pagination is not
+// active Halo sets record_count to the returned-row count instead, which
+// simply makes the comparison a no-op rather than a wrong answer.
+func envelopeReportedTotal(data json.RawMessage) (int, bool) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return 0, false
+	}
+	if total, ok := envelopeTotalField(envelope); ok {
+		return total, true
+	}
+	for _, key := range dataEnvelopeKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(raw, &inner) != nil {
+			continue
+		}
+		if total, ok := envelopeTotalField(inner); ok {
+			return total, true
+		}
+	}
+	return 0, false
+}
+
+func envelopeTotalField(envelope map[string]json.RawMessage) (int, bool) {
+	for _, key := range []string{"record_count", "total_count", "totalCount", "total"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var total int
+		if json.Unmarshal(raw, &total) == nil && total >= 0 {
+			return total, true
+		}
+	}
+	return 0, false
 }
 
 func pageMayHaveMore(data json.RawMessage) bool {

--- a/skills/halopsa/cli/internal/cli/sync_pagination_test.go
+++ b/skills/halopsa/cli/internal/cli/sync_pagination_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored: guards the Halo paging contract encoded in
+// determinePaginationDefaults. See skills/halopsa/handfixes.json
+// (halo-pageinate-page-no-pagination) and docs/reprint-survival.md.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"halopsa-pp-cli/internal/store"
+)
+
+// fakeHaloPager models Halo's live paging contract, including the failure mode
+// the hand-fix exists to prevent: unless pageinate=true is present Halo ignores
+// page_size/page_no entirely and answers with the acting agent's default page
+// size, which is how a 1254-ticket instance silently synced 50 rows.
+type fakeHaloPager struct {
+	total         int
+	agentPageSize int
+	// fixedPageSize, when non-zero, models the endpoint class (/Asset) that
+	// ignores page_size and always answers with this many rows per page while
+	// still reporting the full total in record_count.
+	fixedPageSize   int
+	calls           []map[string]string
+	sawEnableParam  bool
+	sawCursorParams []string
+}
+
+func (f *fakeHaloPager) RateLimit() float64 { return 0 }
+
+func (f *fakeHaloPager) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	captured := make(map[string]string, len(params))
+	for k, v := range params {
+		captured[k] = v
+	}
+	f.calls = append(f.calls, captured)
+
+	// Halo honours paging only when pageinate=true AND page_no are both
+	// present. pageinate alone is not enough: it returns the agent default
+	// page size and reports record_count as that short count, so the page
+	// looks complete and a caller stops walking after one request.
+	pageNo, hasPageNo := params["page_no"]
+	paginated := params["pageinate"] == "true" && hasPageNo && pageNo != ""
+	if params["pageinate"] == "true" {
+		f.sawEnableParam = true
+	}
+	f.sawCursorParams = append(f.sawCursorParams, pageNo)
+
+	size := f.agentPageSize
+	page := 1
+	if paginated {
+		if raw, ok := params["page_size"]; ok {
+			if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+				size = n
+			}
+		}
+		if f.fixedPageSize > 0 {
+			size = f.fixedPageSize // endpoint ignores page_size entirely
+		}
+		if n, err := strconv.Atoi(pageNo); err == nil && n > 0 {
+			page = n
+		}
+	}
+
+	start := (page - 1) * size
+	end := start + size
+	if start > f.total {
+		start = f.total
+	}
+	if end > f.total {
+		end = f.total
+	}
+
+	rows := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		rows = append(rows, fmt.Sprintf(`{"id":%d,"summary":"ticket %d"}`, 1000+i, 1000+i))
+	}
+
+	// Halo reports record_count as the full result-set total when paginating,
+	// and as the returned-row count when it is not.
+	recordCount := len(rows)
+	if paginated {
+		recordCount = f.total
+	}
+	return json.RawMessage(fmt.Sprintf(
+		`{"record_count":%d,"tickets":[%s],"include_children":false}`,
+		recordCount, strings.Join(rows, ","),
+	)), nil
+}
+
+func syncTicketsWithFake(t *testing.T, f *fakeHaloPager) (syncResult, *store.Store) {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	res := syncResource(context.Background(), f, db, "tickets", "", true, 0, false, &syncUserParams{}, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource: %v", res.Err)
+	}
+	return res, db
+}
+
+// TestSyncPagination_WalksEveryPage is the regression guard: a result set
+// several pages deep must land in full, not truncate at the first page.
+func TestSyncPagination_WalksEveryPage(t *testing.T) {
+	f := &fakeHaloPager{total: 250, agentPageSize: 50}
+	res, db := syncTicketsWithFake(t, f)
+
+	if res.Count != 250 {
+		t.Fatalf("synced %d rows, want 250 (single-page truncation regressed)", res.Count)
+	}
+	stored, err := db.Count("tickets")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if stored != 250 {
+		t.Fatalf("stored %d rows, want 250", stored)
+	}
+}
+
+// TestSyncPagination_SendsEnableParam pins pageinate=true on every request.
+// Without it Halo silently caps the sync at the agent's default page size.
+func TestSyncPagination_SendsEnableParam(t *testing.T) {
+	f := &fakeHaloPager{total: 250, agentPageSize: 50}
+	syncTicketsWithFake(t, f)
+
+	if !f.sawEnableParam {
+		t.Fatal("no request carried pageinate=true; Halo would have returned the agent default page size")
+	}
+	for i, call := range f.calls {
+		if call["pageinate"] != "true" {
+			t.Fatalf("request %d missing pageinate=true, got %q", i, call["pageinate"])
+		}
+		if call["page_size"] != "100" {
+			t.Fatalf("request %d page_size = %q, want 100", i, call["page_size"])
+		}
+	}
+}
+
+// TestSyncPagination_AdvancesByPageNumber pins the cursor parameter name and
+// its 1-based page-number semantics. Offset arithmetic (0,100,200) against
+// page_no would skip whole pages, since Halo reads the value as a page index.
+func TestSyncPagination_AdvancesByPageNumber(t *testing.T) {
+	f := &fakeHaloPager{total: 250, agentPageSize: 50}
+	syncTicketsWithFake(t, f)
+
+	for i, call := range f.calls {
+		if _, wrong := call["page"]; wrong {
+			t.Fatalf("request %d sent 'page'; Halo's cursor parameter is 'page_no'", i)
+		}
+	}
+	// page_no must be explicit from the first request onward: Halo does not
+	// default it, and omitting it silently caps the walk at one short page.
+	want := []string{"1", "2", "3"}
+	if len(f.sawCursorParams) != len(want) {
+		t.Fatalf("made %d requests (%v), want %d", len(f.sawCursorParams), f.sawCursorParams, len(want))
+	}
+	for i, w := range want {
+		if f.sawCursorParams[i] != w {
+			t.Fatalf("request %d page_no = %q, want %q (offset arithmetic would skip pages)", i, f.sawCursorParams[i], w)
+		}
+	}
+}
+
+// TestSyncPagination_EndpointIgnoringPageSize covers the /Asset class: the
+// endpoint caps pages at 50 no matter what page_size asks for, so a
+// "len(items) >= limit means more pages" heuristic sees 50 < 100 and stops one
+// page in. The walk must instead trust the record_count total, which stays
+// authoritative regardless of the page size actually served.
+func TestSyncPagination_EndpointIgnoringPageSize(t *testing.T) {
+	f := &fakeHaloPager{total: 144, agentPageSize: 50, fixedPageSize: 50}
+	res, db := syncTicketsWithFake(t, f)
+
+	if res.Count != 144 {
+		t.Fatalf("synced %d rows, want 144; a fixed-page-size endpoint truncated the walk", res.Count)
+	}
+	stored, err := db.Count("tickets")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if stored != 144 {
+		t.Fatalf("stored %d rows, want 144", stored)
+	}
+	if len(f.calls) != 3 {
+		t.Fatalf("made %d requests, want 3 (50+50+44)", len(f.calls))
+	}
+}
+
+// TestSyncPagination_StopsAtReportedTotal guards the other direction: the walk
+// must not keep requesting pages once the reported total is reached, even
+// though every page it saw was "full".
+func TestSyncPagination_StopsAtReportedTotal(t *testing.T) {
+	f := &fakeHaloPager{total: 200, agentPageSize: 50}
+	res, _ := syncTicketsWithFake(t, f)
+
+	if res.Count != 200 {
+		t.Fatalf("synced %d rows, want 200", res.Count)
+	}
+	// 100 + 100 exactly exhausts the set; one probe past the end is
+	// acceptable, more than that means the walk did not honour the total.
+	if len(f.calls) > 3 {
+		t.Fatalf("made %d requests for an exactly-divisible set, want at most 3", len(f.calls))
+	}
+}
+
+// TestSyncPagination_DefaultsMatchLiveContract pins the resolved values
+// themselves, so a reprint that restores the profiler's defaults fails loudly
+// even if the fake above drifts.
+func TestSyncPagination_DefaultsMatchLiveContract(t *testing.T) {
+	got := determinePaginationDefaults()
+	if got.cursorParam != "page_no" {
+		t.Errorf("cursorParam = %q, want page_no", got.cursorParam)
+	}
+	if got.cursorType != "page" {
+		t.Errorf("cursorType = %q, want page (offset arithmetic skips pages)", got.cursorType)
+	}
+	if got.limitParam != "page_size" {
+		t.Errorf("limitParam = %q, want page_size", got.limitParam)
+	}
+	if got.limit != 100 {
+		t.Errorf("limit = %d, want 100 (Halo's documented maximum)", got.limit)
+	}
+	if got.enableParam != "pageinate" {
+		t.Errorf("enableParam = %q, want pageinate", got.enableParam)
+	}
+	if got.startCursor != "1" {
+		t.Errorf("startCursor = %q, want 1 (Halo does not default page_no)", got.startCursor)
+	}
+}
+
+// TestSyncPagination_FirstRequestCarriesCursor is the specific guard for the
+// subtlest half of the bug: pageinate=true and page_size were both correct,
+// yet the sync still stored one short page because page_no was omitted on the
+// first request and Halo reported that short page as the complete result set.
+func TestSyncPagination_FirstRequestCarriesCursor(t *testing.T) {
+	f := &fakeHaloPager{total: 250, agentPageSize: 50}
+	syncTicketsWithFake(t, f)
+
+	if len(f.calls) == 0 {
+		t.Fatal("no requests made")
+	}
+	if got := f.calls[0]["page_no"]; got != "1" {
+		t.Fatalf("first request page_no = %q, want 1; without it Halo returns %d rows and reports them as the full set", got, f.agentPageSize)
+	}
+}

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -30,6 +30,88 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "halo-pageinate-page-no-pagination",
+      "summary": "sync sends pageinate=true and advances the 1-based page_no cursor, instead of the profiler's page/offset defaults that truncated every sync to one page",
+      "why": "Halo only honours paging when pageinate=true AND page_no are BOTH present; otherwise it ignores page_size, returns the acting agent's configured default page size (50 for an API agent), and reports record_count as that same short count, so the page looks like a complete result set and the walk stops after one request. The profiler emitted cursorParam 'page', cursorType 'offset' and no enable parameter, so sync stored the first 50 of 1254 tickets and still reported sync_complete with a success exit, leaving every local view (triage, stale, sql) quietly reading a truncated table. Three further mismatches ride along: Halo's cursor parameter is page_no rather than page; page_no is a 1-based page NUMBER, so cursorType must be 'page' (advance 1,2,3) rather than 'offset' (advance 0,100,200) or Halo reads the row offset as a page index and skips whole pages; and page_no must be seeded on the FIRST request (startCursor) because Halo does not default it, which is the subtlest half of the bug since pageinate and page_size alone still silently truncate. Verified live against a self-hosted Halo instance: pageinate=true&page_size=100 with page_no 1/2/3 returns three disjoint 100-row pages and reports record_count as the 1254-row total, while the same call without page_no returns 50 rows with record_count 50; after the fix a full ticket sync stores 1254 rows with 1254 distinct ids spanning the whole history. A fourth mismatch is independent of the parameters: some endpoints ignore page_size and always answer with a fixed page (/Asset returns 50 rows however large page_size is), so the generated 'len(items) >= limit means more pages' heuristic sees 50 < 100 and stops after one page, storing 50 of 144 assets. The walk therefore prefers the record_count total (envelopeReportedTotal / moreByReportedTotal) over page length, falling back to the length heuristic only when no total is reported. Verified live: /Asset syncs 144 rather than 50. A reprint regenerates the profiler defaults and the length-only heuristic and silently reintroduces both truncations, which is why these markers are asserted.",
+      "status": "active",
+      "spec_encode_followup": "Press should support an enable-pagination parameter (x-pp-pagination-enable-param, plus page-number vs offset cursor semantics) so this is generated rather than hand-wired.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "enableParam: \"pageinate\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "cursorParam: \"page_no\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "cursorType:  \"page\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "params[pageSize.enableParam] = \"true\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "startCursor: \"1\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "effectiveCursor = pageSize.startCursor",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "func envelopeReportedTotal(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "moreByReportedTotal",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "not_contains": "cursorParam: \"page\","
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "not_contains": "if !hasMore || len(items) < pageSize.limit {"
+        },
+        {
+          "file": "cli/internal/cli/sync_pagination_test.go",
+          "contains": "TestSyncPagination_WalksEveryPage",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_pagination_test.go",
+          "contains": "TestSyncPagination_DefaultsMatchLiveContract",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_pagination_test.go",
+          "contains": "TestSyncPagination_FirstRequestCarriesCursor",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_pagination_test.go",
+          "contains": "TestSyncPagination_EndpointIgnoringPageSize",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_pagination_test.go",
+          "contains": "TestSyncPagination_StopsAtReportedTotal",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Pull request

## What this changes

Changed the default domain to halopsa.com per codex suggestion to prevent the entire skill to fail if someone doesn't change it.

## Checklist (required)

- [ ] Every commit signed off with `git commit -s` (DCO).
- [ ] `SKILL.md` has frontmatter fields: `name`, `description`, `allowed-tools`, `author`, `license`, `vendor`.
- [ ] Skill `README.md` opens with the vendor non-affiliation banner before any other content.
- [ ] `install.sh` and `install.ps1` present, or skill is markdown-only and the README says so.
- [ ] `mcp-install.md` present if the skill ships an MCP server.
- [ ] No em-dashes anywhere in committed files.
- [ ] No `/Users/`, `/home/`, personal emails, or API keys in committed files.
- [ ] `catalog.json` regenerated by CI (this is automatic; do not hand-edit).

## Checklist (encouraged)

- [ ] `pain-point.md` describes the MSP pain this Skill or MCP closes, with at least one external citation.
- [ ] `governance.md` describes which permissions the Skill needs and why.

## Trademark check

If this PR adds or modifies a Skill for a third-party vendor's API:

- [ ] Skill references vendor names descriptively only.
- [ ] No vendor logos included.
- [ ] No "Official", "Certified", or "Partner" language anywhere.
- [ ] Non-affiliation banner cites the correct trademark holder.

## Related Build Session or issue

<!-- Link to the Build Session episode, issue, or community thread that
prompted this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HaloPSA synchronization to reliably retrieve all pages of results.
  * Added support for API-reported totals and endpoints that return fewer results than requested.
  * Corrected pagination parameters and page numbering for more consistent synchronization.

* **Documentation**
  * Documented configuration for custom HaloPSA domains in Claude Desktop integrations.

* **Tests**
  * Added regression coverage for multi-page synchronization and pagination edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->