### PR TITLE
fix(cipp): unwrap the /ListTenants envelope and point sync at fanout

### DIFF
--- a/skills/cipp/CHANGELOG.md
+++ b/skills/cipp/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this skill are documented here. Format follows
 
 ## [0.1.1] - unreleased
 
+### Fixed
+- **Cross-tenant fan-out found zero tenants on current CIPP builds.** `/ListTenants`
+  now returns its array inside a `{"Results": [...]}` envelope; tenant enumeration
+  only understood a bare array, so it treated the whole envelope as a single
+  tenant, dropped it for having no domain, and reported an empty fleet against a
+  healthy CIPP. Envelope responses are now unwrapped, so `--all-tenants` fan-out
+  and `posture` see the whole fleet again.
+- **`sync` pointed at a remedy that cannot work.** CIPP's API is tenant-scoped end
+  to end and exposes no bulk-list endpoints, so `sync` is a structural no-op here.
+  Its warning suggested `--resources`, which always errors "unknown sync resource";
+  it now names the mechanism that actually populates the store:
+  `cipp-cli fanout --endpoint <endpoint> --all-tenants --save`.
+
+Thanks to Abhi Saini at Bearium Networks, who found both while running the
+connector against a live CIPP tenant.
+
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 

--- a/skills/cipp/cli/internal/cli/cipp_tenants.go
+++ b/skills/cipp/cli/internal/cli/cipp_tenants.go
@@ -46,6 +46,37 @@ func tenantFieldLookup(obj map[string]any, candidates ...string) string {
 	return ""
 }
 
+// tenantEnvelopeKeys are the wrapper keys a CIPP deployment may nest the
+// tenant array under. Matching is case-insensitive, so one entry covers both
+// the REST-convention and .NET renderings ("results" also matches "Results").
+// Current CIPP returns {"Results": [...]}; older builds return a bare array.
+var tenantEnvelopeKeys = []string{"results", "data", "value", "items"}
+
+// tenantEnvelopeArray pulls the tenant array out of a wrapper object. Returns
+// false when no candidate key holds an array, which is the signal to fall back
+// to treating the payload as a lone tenant object.
+func tenantEnvelopeArray(obj map[string]any) ([]map[string]any, bool) {
+	for _, want := range tenantEnvelopeKeys {
+		for k, v := range obj {
+			if !strings.EqualFold(k, want) {
+				continue
+			}
+			items, ok := v.([]any)
+			if !ok {
+				continue
+			}
+			out := make([]map[string]any, 0, len(items))
+			for _, it := range items {
+				if m, ok := it.(map[string]any); ok {
+					out = append(out, m)
+				}
+			}
+			return out, true
+		}
+	}
+	return nil, false
+}
+
 // parseTenantArray maps a raw JSON array of CIPP tenant objects into
 // tenantRefs, reading fields case-insensitively. Objects with no resolvable
 // defaultDomainName are dropped — a tenant we cannot scope a request to is not
@@ -55,10 +86,17 @@ func parseTenantArray(data json.RawMessage) ([]tenantRef, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		// Some CIPP deployments wrap the array; try a single object too.
 		var single map[string]any
-		if jerr := json.Unmarshal(data, &single); jerr == nil {
-			raw = []map[string]any{single}
-		} else {
+		if jerr := json.Unmarshal(data, &single); jerr != nil {
 			return nil, fmt.Errorf("parsing tenant list: %w", err)
+		}
+		// A wrapper must be unwrapped BEFORE the lone-tenant fallback: a
+		// {"Results": [...]} payload treated as one tenant resolves no
+		// defaultDomainName, so it is dropped and every --all-tenants fan-out
+		// silently reports zero tenants against a healthy CIPP.
+		if inner, ok := tenantEnvelopeArray(single); ok {
+			raw = inner
+		} else {
+			raw = []map[string]any{single}
 		}
 	}
 	out := make([]tenantRef, 0, len(raw))

--- a/skills/cipp/cli/internal/cli/cipp_tenants_test.go
+++ b/skills/cipp/cli/internal/cli/cipp_tenants_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 damienstevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestParseTenantArrayShapes locks the three payload shapes CIPP deployments
+// actually return. The {"Results": [...]} case is the regression guard: before
+// the envelope unwrap, that payload was treated as a single tenant object,
+// resolved no defaultDomainName, and every --all-tenants fan-out reported zero
+// tenants against a healthy CIPP.
+func TestParseTenantArrayShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string // expected defaultDomainName values, in order
+	}{
+		{
+			name: "bare array",
+			body: `[{"displayName":"Contoso","defaultDomainName":"contoso.onmicrosoft.com"}]`,
+			want: []string{"contoso.onmicrosoft.com"},
+		},
+		{
+			name: "Results envelope",
+			body: `{"Results":[{"displayName":"Contoso","defaultDomainName":"contoso.onmicrosoft.com"},
+			         {"displayName":"Fabrikam","defaultDomainName":"fabrikam.onmicrosoft.com"}],
+			         "Metadata":{"count":2}}`,
+			want: []string{"contoso.onmicrosoft.com", "fabrikam.onmicrosoft.com"},
+		},
+		{
+			name: "lowercase results envelope",
+			body: `{"results":[{"defaultDomainName":"contoso.onmicrosoft.com"}]}`,
+			want: []string{"contoso.onmicrosoft.com"},
+		},
+		{
+			name: "lone tenant object",
+			body: `{"displayName":"Contoso","defaultDomainName":"contoso.onmicrosoft.com"}`,
+			want: []string{"contoso.onmicrosoft.com"},
+		},
+		{
+			name: "objects without a domain are dropped",
+			body: `[{"displayName":"No domain"},{"defaultDomainName":"ok.onmicrosoft.com"}]`,
+			want: []string{"ok.onmicrosoft.com"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTenantArray(json.RawMessage(tc.body))
+			if err != nil {
+				t.Fatalf("parseTenantArray: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d tenants, want %d (%+v)", len(got), len(tc.want), got)
+			}
+			for i, want := range tc.want {
+				if got[i].DefaultDomainName != want {
+					t.Errorf("tenant %d domain = %q, want %q", i, got[i].DefaultDomainName, want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseTenantArrayRejectsGarbage keeps the error path honest — a payload
+// that is neither an array nor an object must surface as an error rather than
+// silently degrading to zero tenants.
+func TestParseTenantArrayRejectsGarbage(t *testing.T) {
+	if _, err := parseTenantArray(json.RawMessage(`"not json we can use"`)); err == nil {
+		t.Fatal("expected an error for a non-object, non-array payload")
+	}
+}

--- a/skills/cipp/cli/internal/cli/sync.go
+++ b/skills/cipp/cli/internal/cli/sync.go
@@ -132,14 +132,21 @@ Resource scoping:
 			// Empty-sync hint: this spec exposed no default sync resources, so
 			// `sync` cannot populate the store on its own. Emit a one-line note
 			// so users and agents understand the runtime no-op instead of
-			// seeing only `total_records: 0`. The store can still be populated
-			// by explicit --resources calls or single-fetch commands when the
-			// spec defines them.
+			// seeing only `total_records: 0`.
+			//
+			// HAND-FIX (handfixes.json: sync-empty-hint-points-at-fanout).
+			// The generated wording points at `--resources`, which is a dead end
+			// for CIPP: syncResourcePath()'s map is empty, so EVERY --resources
+			// value errors "unknown sync resource". CIPP's API is tenant-scoped
+			// end to end and exposes no bulk-list endpoints to iterate, so the
+			// real mechanism is per-endpoint fan-out across tenants. Reported by
+			// Abhi Saini (Bearium Networks) in the Compounding Teams Community
+			// Discussion, 2026-08-13.
 			if len(resources) == 0 {
 				if humanFriendly {
-					fmt.Fprintln(os.Stderr, "cipp-cli sync: no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands.")
+					fmt.Fprintln(os.Stderr, "cipp-cli sync: CIPP's API is tenant-scoped and exposes no bulk-list endpoints, so sync is a no-op here. Populate the store with: cipp-cli fanout --endpoint <endpoint> --all-tenants --save")
 				} else {
-					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_bulk_list_endpoints","detail":"no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands"}`)
+					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_bulk_list_endpoints","detail":"CIPP's API is tenant-scoped and exposes no bulk-list endpoints, so sync is a no-op here; populate the store with: cipp-cli fanout --endpoint <endpoint> --all-tenants --save"}`)
 				}
 			}
 

--- a/skills/cipp/handfixes.json
+++ b/skills/cipp/handfixes.json
@@ -1,0 +1,28 @@
+{
+  "slug": "cipp",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "Connector-specific edits to GENERATED/authored files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present (and banned anti-patterns absent) and fails CI if a reprint dropped one. Provenance: live-verification report from Abhi Saini (Bearium Networks) in the Compounding Teams Community Discussion, 2026-08-13 (badge flip PR #199).",
+  "handfixes": [
+    {
+      "id": "sync-empty-hint-points-at-fanout",
+      "summary": "The empty-sync hint tells the user to run `fanout --endpoint <x> --all-tenants --save`, not the press's generic `--resources` suggestion",
+      "why": "CIPP's API is tenant-scoped end to end and exposes no bulk-list endpoints, so `syncResourcePath()`'s path map is generated EMPTY and `knownSyncResourceNames()` returns nothing. The press's generic empty-sync hint tells the user to 'use --resources for explicit sync targets' - a dead end here, because every --resources value errors 'unknown sync resource'. The hint pointed at the one remedy that cannot work while the real mechanism (per-endpoint fan-out across tenants) went unmentioned. Abhi Saini hit exactly this and had to derive fanout from scratch with an agent. A reprint re-emits the generic wording.",
+      "status": "active",
+      "spec_encode_followup": "Press-side: a connector whose generated sync path-map is empty should emit a connector-aware remedy (or, per upstream cli-printing-press #3659 'gate zero-sync data surfaces', not advertise the sync surface at all) instead of pointing at --resources. Re-check on the next reprint - cipp is on the 4.24.0 engine and #3659 landed after it.",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "--all-tenants --save", "min_count": 2},
+        {"file": "cli/internal/cli/sync.go", "not_contains": "use --resources for explicit sync targets"}
+      ]
+    },
+    {
+      "id": "tenant-list-envelope-unwrap",
+      "summary": "parseTenantArray unwraps a {\"Results\": [...]} envelope before falling back to the lone-tenant path, so --all-tenants fan-out enumerates the fleet",
+      "why": "Current CIPP returns /ListTenants as {\"Results\":[...]}; the novel cross-tenant code only handled a bare array and fell back to 'treat the whole payload as one tenant object'. That object resolves no defaultDomainName, gets dropped, and every --all-tenants fan-out reports ZERO tenants against a healthy CIPP with a 6.6 KB response on the wire. The rest of the tree already knew the key - promoted_list-tenants.go writes the store from \"Results\" and sync.go's pageItemKeys lists results/Results - only the novel path missed it. cipp_tenants.go is a NOVEL (non-generated) file, so this survives a reprint as a carried novel; the assert guards against a novel-rewrite dropping it.",
+      "status": "active",
+      "asserts": [
+        {"file": "cli/internal/cli/cipp_tenants.go", "contains": "tenantEnvelopeArray", "min_count": 2},
+        {"file": "cli/internal/cli/cipp_tenants_test.go", "contains": "Results envelope", "min_count": 1}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #200. Closes #201.

Both defects were found by **Abhi Saini at Bearium Networks** running the connector against a live CIPP tenant, reported in the [Compounding Teams Community Discussion](https://compoundingteams.com/) — the same report that earned CIPP its live-verified badge (#199).

### 1. Fan-out found zero tenants (#200)

`parseTenantArray` only understood a bare array. Current CIPP returns `/ListTenants` as `{"Results": [...]}`, which fell through to the lone-tenant fallback, resolved no `defaultDomainName`, and was dropped as unusable — so `--all-tenants` fan-out and `posture` reported an **empty fleet** against a healthy CIPP with 6.6 KB on the wire. No error, just nothing.

Envelopes are now unwrapped before the lone-tenant fallback, matching `results`/`data`/`value`/`items` case-insensitively. `cipp_tenants_test.go` locks all four payload shapes plus the drop-no-domain and reject-garbage paths.

### 2. `sync` named a remedy that cannot work (#201)

CIPP's API is tenant-scoped end to end, so the generated sync path map is empty and `sync` is a structural no-op. It already warned rather than failing silently — but pointed at `--resources`, which always errors `unknown sync resource`. It now names the mechanism that populates the store: `fanout --endpoint <endpoint> --all-tenants --save`.

### Reprint survival

`sync.go` is generated. Both edits are recorded in the new `skills/cipp/handfixes.json` so `check_handfixes` fails CI if a reprint drops them. The sync entry carries an upstream follow-up: cli-printing-press #3659 ("gate zero-sync data surfaces") landed after CIPP was minted on the 4.24.0 engine — worth re-checking at the next reprint.

### Verification

- `go build ./...`, `go vet ./...`, `go test ./...` clean in `skills/cipp/cli`
- `check_handfixes.py` PASS (33 ledgers), `check_release_contract.py` PASS, `ci_guards.sh` PASS
- CHANGELOG entries added under the pending `0.1.1`; no version bump (0.1.1 is unreleased)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4oKfpeP1xRXY5ZSp7c5R5