### PR TITLE
fix(halopsa): share the ticket-agent SQL across standup, workload, age-out and client card

### DIFF
--- a/skills/halopsa/cli/internal/cli/agent_workload.go
+++ b/skills/halopsa/cli/internal/cli/agent_workload.go
@@ -55,13 +55,17 @@ func newNovelAgentWorkloadCmd(flags *rootFlags) *cobra.Command {
 				argsSQL = append(argsSQL, team, team)
 			}
 			// Open counts + oldest age
-			openSQL := `SELECT
-                COALESCE(NULLIF(agent_name,''),'(unassigned)') AS agent,
+			// Agent and age both come from the shared scoped CTE; agent_name and
+			// datecreated are blank on every synced row. See
+			// ticket_agent_sql.go and issue #211.
+			openSQL := ticketAgentScopedCTE + `
+                SELECT
+                agent_label AS agent,
                 COUNT(*) AS open_count,
-                CAST(MAX(julianday('now') - julianday(datecreated)) AS INTEGER) AS oldest_days
-                FROM tickets
+                CAST(MAX(julianday('now') - julianday(created_at)) AS INTEGER) AS oldest_days
+                FROM scoped
                 WHERE COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9) ` + whereTeam + `
-                GROUP BY agent`
+                GROUP BY agent_label`
 			rows, err := db.DB().QueryContext(cmd.Context(), openSQL, argsSQL...)
 			if err != nil {
 				return fmt.Errorf("workload open: %w", err)
@@ -85,9 +89,10 @@ func newNovelAgentWorkloadCmd(flags *rootFlags) *cobra.Command {
 				byAgent[e.Agent] = &e
 			}
 			// Touched in window: tickets whose lastactiondate falls within
-			touchedSQL := `SELECT COALESCE(NULLIF(agent_name,''),'(unassigned)'), COUNT(*) FROM tickets
-                WHERE datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated)) >= datetime(?) ` + whereTeam + `
-                GROUP BY agent_name`
+			touchedSQL := ticketAgentScopedCTE + `
+                SELECT agent_label, COUNT(*) FROM scoped
+                WHERE datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at)) >= datetime(?) ` + whereTeam + `
+                GROUP BY agent_label`
 			tArgs := append([]any{t.Format(time.RFC3339)}, argsSQL...)
 			if tRows, terr := db.DB().QueryContext(cmd.Context(), touchedSQL, tArgs...); terr == nil {
 				defer tRows.Close()

--- a/skills/halopsa/cli/internal/cli/client_card.go
+++ b/skills/halopsa/cli/internal/cli/client_card.go
@@ -82,10 +82,11 @@ client. Resolves by numeric ID or by name (case-insensitive substring match).`,
 			card["sites"] = sites
 
 			// Active tickets
-			tRows, _ := db.DB().QueryContext(cmd.Context(), `SELECT id, COALESCE(summary,''), COALESCE(agent_name,'?'),
+			tRows, _ := db.DB().QueryContext(cmd.Context(), ticketAgentScopedCTE+`
+                SELECT id, COALESCE(summary,''), COALESCE(agent_label,'?'),
                 COALESCE(json_extract(data,'$.status_name'),'?'),
                 COALESCE(json_extract(data,'$.targetdate'),'')
-                FROM tickets
+                FROM scoped
                 WHERE client_id = ? AND COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)
                 ORDER BY COALESCE(json_extract(data,'$.targetdate'),'') ASC
                 LIMIT ?`, clientID, limitT)
@@ -221,9 +222,13 @@ func newNovelClientOverlayCmd(flags *rootFlags) *cobra.Command {
                     WHERE COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)
                     GROUP BY client ORDER BY metric DESC LIMIT ?`
 			case "stale":
-				q = `SELECT COALESCE(client_name,'?') AS client,
-                    SUM(CASE WHEN (julianday('now') - julianday(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated))) > 7 THEN 1 ELSE 0 END) AS metric
-                    FROM tickets
+				// Uses the scoped CTE for created_at: tickets.datecreated is
+				// blank on every synced row, so the staleness window silently
+				// measured against nothing. See ticket_agent_sql.go.
+				q = ticketAgentScopedCTE + `
+                    SELECT COALESCE(client_name,'?') AS client,
+                    SUM(CASE WHEN (julianday('now') - julianday(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at))) > 7 THEN 1 ELSE 0 END) AS metric
+                    FROM scoped
                     WHERE COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)
                     GROUP BY client ORDER BY metric DESC LIMIT ?`
 			case "sla_at_risk":

--- a/skills/halopsa/cli/internal/cli/standup.go
+++ b/skills/halopsa/cli/internal/cli/standup.go
@@ -59,15 +59,21 @@ Run 'halopsa-cli sync' first.`,
 				argsSQL = append(argsSQL, team)
 			}
 			// Tickets closed in window
-			closedSQL := `SELECT
-                COALESCE(NULLIF(agent_name,''), '(unassigned)') AS who,
+			// Resolves the agent from the synced agent records and groups on a
+			// key that cannot collide with tickets.who; see ticket_agent_sql.go
+			// and issue #211. Without both, every closure bucketed to
+			// "(unassigned)" while the actions-based hours below attributed
+			// correctly, which is the split symptom the issue describes.
+			closedSQL := ticketAgentScopedCTE + `
+            SELECT
+                agent_label AS who,
                 COUNT(*) AS closed,
                 COALESCE(client_name, '?') AS top_client
-            FROM tickets
+            FROM scoped
             WHERE json_extract(data, '$.status_id') IN (8,9)
-              AND datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated)) >= datetime(?)
+              AND datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at)) >= datetime(?)
               ` + whereTeam + `
-            GROUP BY who
+            GROUP BY agent_label
             ORDER BY closed DESC LIMIT ?`
 			argsSQL = append(argsSQL, limit)
 			rows, err := db.DB().QueryContext(cmd.Context(), closedSQL, argsSQL...)

--- a/skills/halopsa/cli/internal/cli/ticket_agent_sql.go
+++ b/skills/halopsa/cli/internal/cli/ticket_agent_sql.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Hand-authored (novel file, not generated).
+//
+// Shared SQL for the novel ticket commands, lifted out of buildTriageQuery so
+// the family fixed in #209 stays fixed in one place. See issue #211.
+//
+// Two independent defects, both of which have to be handled together:
+//
+//  1. tickets.agent_name and tickets.datecreated are generated columns HaloPSA
+//     never populates. The ticket payload carries agent_id and dateoccurred
+//     instead, so both columns are blank on every synced row: a command reading
+//     agent_name labels every ticket "(unassigned)" or "?", and one reading
+//     datecreated reports every age as 0.
+//
+//  2. The grouping key must not be named "who". The generated tickets table has
+//     a real who TEXT column that is NULL on every row, and SQLite resolves
+//     GROUP BY names against source columns before output aliases, so
+//     "... AS who ... GROUP BY who" groups by that NULL column and collapses
+//     every agent into a single row no matter what the SELECT computed.
+//
+// Defect 2 hides defect 1: resolving the name per row still yields one bucket
+// while the grouping key collides, which is why both fixes ship together.
+//
+// Commands reading FROM actions rather than FROM tickets are deliberately left
+// alone. The actions table has no who column, so their "GROUP BY who" binds the
+// output alias correctly, and they already attribute to real agents.
+
+package cli
+
+// ticketAgentScopedCTE opens a `scoped` CTE exposing every tickets column plus
+// two resolved ones:
+//
+//	agent_label - the agent's name, resolved from the synced agent records via
+//	              agent_id. A populated agent_name still wins, so a future Halo
+//	              version (or an includeagent sync) needs no change here.
+//	created_at  - the ticket's creation timestamp, falling through to
+//	              dateoccurred when datecreated is blank.
+//
+// Neither name exists as a real tickets column, so neither can collide the way
+// "who" does. Callers append their own SELECT ... FROM scoped and must group on
+// agent_label rather than on an output alias.
+const ticketAgentScopedCTE = `WITH scoped AS (
+                SELECT t.*,
+                    COALESCE(NULLIF(t.agent_name, ''), a.agent_label, '(unassigned)') AS agent_label,
+                    COALESCE(NULLIF(t.datecreated, ''), json_extract(t.data, '$.dateoccurred')) AS created_at
+                FROM tickets t
+                LEFT JOIN (
+                    SELECT CAST(id AS INTEGER) AS agent_ref_id,
+                           json_extract(data, '$.name') AS agent_label
+                    FROM resources
+                    WHERE resource_type = 'agent'
+                ) a ON a.agent_ref_id = t.agent_id
+            )`

--- a/skills/halopsa/cli/internal/cli/ticket_agent_sql_test.go
+++ b/skills/halopsa/cli/internal/cli/ticket_agent_sql_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored: guards the shared ticket-agent SQL fragment and its use by the
+// novel commands named in issue #211. See skills/halopsa/handfixes.json
+// (novel-commands-share-ticket-agent-sql).
+
+package cli
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// scopedFixture mirrors a real Halo sync: agent_name and datecreated blank on
+// every ticket, the agent names living in resources, and a real but NULL `who`
+// column on tickets. Adds client_name and summary so the client-facing
+// projections can be exercised too.
+func scopedFixture(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "scoped.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	mustExec(t, db, `CREATE TABLE tickets (
+		id INTEGER PRIMARY KEY,
+		data JSON NOT NULL,
+		agent_id INTEGER,
+		agent_name TEXT,
+		datecreated TEXT,
+		client_name TEXT,
+		summary TEXT,
+		team TEXT,
+		who TEXT
+	)`)
+	mustExec(t, db, `CREATE TABLE resources (
+		id TEXT NOT NULL,
+		resource_type TEXT NOT NULL,
+		data JSON NOT NULL,
+		PRIMARY KEY (resource_type, id)
+	)`)
+	mustExec(t, db, `INSERT INTO resources (id, resource_type, data) VALUES
+		('11','agent','{"id":11,"name":"Ada"}'),
+		('22','agent','{"id":22,"name":"Grace"}')`)
+	// Two closed tickets for Ada, one for Grace, one with no agent at all.
+	mustExec(t, db, `INSERT INTO tickets (id, data, agent_id, agent_name, datecreated, client_name, summary, team, who) VALUES
+		(1,'{"status_id":8,"dateoccurred":"2020-01-01T00:00:00Z","lastactiondate":"2020-02-01T00:00:00Z"}',11,'','','Acme','a',NULL,NULL),
+		(2,'{"status_id":9,"dateoccurred":"2020-06-01T00:00:00Z","lastactiondate":"2020-07-01T00:00:00Z"}',11,'','','Acme','b',NULL,NULL),
+		(3,'{"status_id":8,"dateoccurred":"2021-01-01T00:00:00Z","lastactiondate":"2021-02-01T00:00:00Z"}',22,'','','Beta','c',NULL,NULL),
+		(4,'{"status_id":8,"dateoccurred":"2021-03-01T00:00:00Z","lastactiondate":"2021-04-01T00:00:00Z"}',99,'','','Beta','d',NULL,NULL)`)
+	return db
+}
+
+// TestScopedCTEResolvesAgentsAndDoesNotCollapse is the core regression for the
+// family: grouping on agent_label must produce one row per agent, where the
+// pre-fix "AS who ... GROUP BY who" collapsed everything into a single bucket
+// because tickets.who is a real NULL column.
+func TestScopedCTEResolvesAgentsAndDoesNotCollapse(t *testing.T) {
+	db := scopedFixture(t)
+
+	rows, err := db.Query(ticketAgentScopedCTE + `
+		SELECT agent_label, COUNT(*) FROM scoped
+		WHERE json_extract(data,'$.status_id') IN (8,9)
+		GROUP BY agent_label ORDER BY agent_label`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[string]int{}
+	for rows.Next() {
+		var label string
+		var n int
+		if err := rows.Scan(&label, &n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[label] = n
+	}
+	want := map[string]int{"Ada": 2, "Grace": 1, "(unassigned)": 1}
+	if len(got) != len(want) {
+		t.Fatalf("got %d groups (%v), want %d; the grouping key collapsed", len(got), got, len(want))
+	}
+	for label, n := range want {
+		if got[label] != n {
+			t.Errorf("%s = %d, want %d", label, got[label], n)
+		}
+	}
+}
+
+// TestScopedCTEFallsThroughToDateoccurred pins the created_at fallback, which
+// is what reported every age as 0 while datecreated is blank.
+func TestScopedCTEFallsThroughToDateoccurred(t *testing.T) {
+	db := scopedFixture(t)
+	var oldest int
+	if err := db.QueryRow(ticketAgentScopedCTE + `
+		SELECT CAST(MAX(julianday('now') - julianday(created_at)) AS INTEGER) FROM scoped`).Scan(&oldest); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if oldest <= 0 {
+		t.Fatalf("oldest age = %d, want > 0; datecreated is blank so created_at must use dateoccurred", oldest)
+	}
+}
+
+// TestScopedCTEPrefersPopulatedAgentName keeps the fallback ordering safe, so a
+// future Halo version (or an includeagent sync) that does populate agent_name
+// still wins over the join.
+func TestScopedCTEPrefersPopulatedAgentName(t *testing.T) {
+	db := scopedFixture(t)
+	mustExec(t, db, `UPDATE tickets SET agent_name = 'From Payload' WHERE id = 1`)
+
+	var label string
+	if err := db.QueryRow(ticketAgentScopedCTE + `SELECT agent_label FROM scoped WHERE id = 1`).Scan(&label); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if label != "From Payload" {
+		t.Fatalf("agent_label = %q, want the populated agent_name to win", label)
+	}
+}
+
+// TestScopedCTEAliasesCannotCollide guards the trap that caused the original
+// bug: neither derived name may exist as a real tickets column, or GROUP BY
+// would bind the column instead of the alias.
+func TestScopedCTEAliasesCannotCollide(t *testing.T) {
+	db := scopedFixture(t)
+	for _, alias := range []string{"agent_label", "created_at"} {
+		var n int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('tickets') WHERE name = ?`, alias).Scan(&n); err != nil {
+			t.Fatalf("pragma: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("tickets has a real %q column; the alias would collide exactly like `who` does", alias)
+		}
+	}
+}
+
+// TestNovelTicketCommandsUseSharedFragment is the source-level guard: the
+// commands #211 names must read through the fragment rather than the blank
+// generated columns, and must not reintroduce the colliding grouping key.
+func TestNovelTicketCommandsUseSharedFragment(t *testing.T) {
+	groupByWho := regexp.MustCompile(`GROUP BY\s+who\b`)
+	for _, file := range []string{
+		"standup.go",
+		"agent_workload.go",
+		"tickets_ageout.go",
+		"client_card.go",
+	} {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		src := string(b)
+		if !strings.Contains(src, "ticketAgentScopedCTE") {
+			t.Errorf("%s does not use ticketAgentScopedCTE; it would read the blank agent_name/datecreated columns", file)
+		}
+		// Only the tickets-backed aggregates are in scope. Commands reading
+		// FROM actions legitimately group on `who` because actions has no such
+		// column, so restrict the ban to queries selecting FROM tickets.
+		for _, stmt := range strings.Split(src, "`") {
+			if !strings.Contains(stmt, "FROM tickets") && !strings.Contains(stmt, "FROM scoped") {
+				continue
+			}
+			if groupByWho.MatchString(stmt) {
+				t.Errorf("%s groups a tickets-backed query by `who`, which binds the real NULL column", file)
+			}
+		}
+	}
+}

--- a/skills/halopsa/cli/internal/cli/tickets_ageout.go
+++ b/skills/halopsa/cli/internal/cli/tickets_ageout.go
@@ -54,13 +54,14 @@ through the API per ticket.`,
 				where = append(where, "(LOWER(COALESCE(json_extract(data,'$.status_name'),''))=LOWER(?) OR LOWER(COALESCE(json_extract(data,'$.status'),''))=LOWER(?))")
 				argsSQL = append(argsSQL, status, status)
 			}
-			where = append(where, "(julianday('now') - julianday(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated))) >= ?")
+			where = append(where, "(julianday('now') - julianday(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at))) >= ?")
 			argsSQL = append(argsSQL, staleDays)
-			q := `SELECT id, COALESCE(client_name,'?'), COALESCE(agent_name,'?'),
+			q := ticketAgentScopedCTE + `
+                SELECT id, COALESCE(client_name,'?'), COALESCE(agent_label,'?'),
                 COALESCE(json_extract(data,'$.status_name'), json_extract(data,'$.status'), '?'),
-                COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated),
+                COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at),
                 COALESCE(summary,'')
-                FROM tickets WHERE ` + strings.Join(where, " AND ") + ` ORDER BY id LIMIT ?`
+                FROM scoped WHERE ` + strings.Join(where, " AND ") + ` ORDER BY id LIMIT ?`
 			argsSQL = append(argsSQL, limit)
 			rows, err := db.DB().QueryContext(cmd.Context(), q, argsSQL...)
 			if err != nil {
@@ -190,17 +191,18 @@ Backed by incremental sync; replaces brittle 'tickets updated since' ETLs.`,
 				return fmt.Errorf("opening local database: %w\nRun 'halopsa-cli sync' first.", err)
 			}
 			defer db.Close()
-			where := []string{"datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated)) >= datetime(?)"}
+			where := []string{"datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at)) >= datetime(?)"}
 			argsSQL := []any{t.Format(time.RFC3339)}
 			if mine {
 				where = append(where, "json_extract(data,'$.is_mine') = 1")
 			}
-			q := `SELECT id, COALESCE(client_name,'?') AS client,
-                COALESCE(agent_name,'?') AS agent,
+			q := ticketAgentScopedCTE + `
+                SELECT id, COALESCE(client_name,'?') AS client,
+                COALESCE(agent_label,'?') AS agent,
                 COALESCE(json_extract(data,'$.status_name'),'?') AS status,
                 COALESCE(summary,'') AS summary,
-                COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated) AS last_action
-                FROM tickets WHERE ` + strings.Join(where, " AND ") + `
+                COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), created_at) AS last_action
+                FROM scoped WHERE ` + strings.Join(where, " AND ") + `
                 ORDER BY last_action DESC LIMIT ?`
 			argsSQL = append(argsSQL, limit)
 			rows, err := db.DB().QueryContext(cmd.Context(), q, argsSQL...)

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -144,6 +144,60 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "novel-commands-share-ticket-agent-sql",
+      "summary": "standup, agent workload, tickets age-out and client card read agents and ticket ages through the shared ticketAgentScopedCTE instead of the blank agent_name/datecreated columns (issue #211)",
+      "why": "The two defects fixed for triage in #209 were present verbatim in the other novel ticket commands, which #211 filed after triage was verified but the rest could not be without a live tenant. Confirmed against one: standup bucketed all 15 closures onto '(unassigned)' while its actions-backed hours column attributed correctly (the FROM tickets half collides, the FROM actions half does not, exactly as #211 predicted); agent workload put all 8 open tickets and all 59 touches under '(unassigned)' and reported oldest_days 0 for every agent; tickets age-out and client card printed agent '?' on every row. Both causes must be fixed together, because the grouping-key collision hides the agent join: resolving the name per row still yields a single bucket while GROUP BY binds tickets.who, a real column that is NULL on every row, ahead of the output alias. ticket_agent_sql.go is a novel file holding one CTE that exposes agent_label (resolved from the synced agent records via agent_id, with a populated agent_name still preferred) and created_at (datecreated falling through to dateoccurred). Neither alias exists as a real tickets column, so neither can collide the way who does. Commands reading FROM actions are deliberately untouched: actions has no who column, their grouping already binds the alias, and they already attribute correctly. Verified live after the change: standup splits 15 closures 9/3/3 across real agents, agent workload reports 3/3/2 open with oldest_days 7/168/6 matching triage on the same cache, and age-out plus client card name every agent.",
+      "status": "active",
+      "spec_encode_followup": "None available: these are hand-written novel commands, not generated, so the press cannot derive the fallbacks. The ledger entry is the backstop against a reprint or a new command reintroducing the pattern.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/ticket_agent_sql.go",
+          "contains": "const ticketAgentScopedCTE",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/ticket_agent_sql.go",
+          "contains": "AS agent_label",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/ticket_agent_sql.go",
+          "contains": "AS created_at",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/standup.go",
+          "contains": "ticketAgentScopedCTE",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/agent_workload.go",
+          "contains": "ticketAgentScopedCTE",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/tickets_ageout.go",
+          "contains": "ticketAgentScopedCTE",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/client_card.go",
+          "contains": "ticketAgentScopedCTE",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/ticket_agent_sql_test.go",
+          "contains": "TestScopedCTEResolvesAgentsAndDoesNotCollapse",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/ticket_agent_sql_test.go",
+          "contains": "TestNovelTicketCommandsUseSharedFragment",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Pull request

## What this changes

Applies the `triage` fix from #209 to the four other novel ticket commands, verified against the live tenant #211 asked for. Closes #211 for `standup`, `agent workload`, `tickets age-out` and `client card`.

## Verified broken first

All four reproduce exactly as #211 predicted, on v0.2.3 with a freshly synced cache (1265 tickets, 8243 actions, 3 agents):

| command | before |
|---|---|
| `standup` | all 15 closures bucketed onto `(unassigned)` |
| `agent workload` | `(unassigned)` held open=8 and touched=59; real agents 0/0; `oldest_days: 0` for everyone |
| `tickets age-out` | `"agent": "?"` on every row |
| `client card` | `"agent": "?"` on every active ticket |

`standup` shows both halves in one output, which is the clearest confirmation of the distinction in the issue:

```json
{"agent":"(unassigned)","closed":15,"hours_logged":0}
{"agent":"<agent-a>",   "closed":0, "hours_logged":6}
{"agent":"<agent-b>",   "closed":0, "hours_logged":2}
```

The `FROM tickets` aggregate collapses; the `FROM actions` aggregate attributes correctly, because `actions` has no real `who` column.

## The fix

`ticket_agent_sql.go` (novel file) holds one shared CTE lifted from `buildTriageQuery`, exposing two resolved columns over `tickets.*`:

- **`agent_label`** - the agent name resolved from the synced agent records via `agent_id`. A populated `agent_name` still wins, so a future Halo version or an `includeagent` sync needs no change here.
- **`created_at`** - `datecreated` falling through to `dateoccurred`.

Both defects have to be fixed together. **The grouping-key collision hides the agent join**: resolving the name per row still returns a single bucket while `GROUP BY` binds `tickets.who`, a real column that is NULL on every row, ahead of the output alias. That cost me a debugging cycle on `triage` originally, so it is worth stating plainly for anyone extending this to further commands.

Neither alias exists as a real `tickets` column, so neither can collide the way `who` does. `TestScopedCTEAliasesCannotCollide` pins that, because recreating the trap while fixing it is the obvious failure mode.

**Commands reading `FROM actions` are deliberately untouched** (`standup.go:95`, `agent_workload.go:107`), as the issue advises. Their grouping already binds the alias, they already attribute correctly, and rewriting them would risk the half that works.

## One thing worth flagging for review

`client overlay --metric stale` also read `datecreated`, from a query that does **not** use the CTE. Because the SQL lives in a Go string, referencing `created_at` there compiled cleanly and would only have failed at runtime. It is wrapped in the CTE too, and `client overlay --metric stale` is verified to return results.

## After

| command | after |
|---|---|
| `standup` | 15 closures split **9 / 3 / 3** across real agents |
| `agent workload` | **3 / 3 / 2** open, `oldest_days` **7 / 168 / 6** |
| `tickets age-out` | every ticket names its agent |
| `client card` | every ticket names its agent |

The workload figures cross-check against `triage` on the same cache - 8 open total and identical oldest-day values - so this is corroborated rather than merely "looks populated now".

Five tests, one confirmed to fail when a command is reverted to the old SQL. `go build`, `go vet` and `go test ./...` all pass.

## Reprint survival

Recorded as `novel-commands-share-ticket-agent-sql`, verified to fail `check_handfixes.py` when reverted. These are hand-written novel commands rather than generated, so there is no `spec_encode_followup` available: the press cannot derive the fallbacks, which makes the ledger the only backstop against a new command reintroducing the pattern.

## Not addressed

`sla scorecard` reports **0 of 88** closed tickets meeting their SLA target on this tenant. It is on both lists in #211 and the number is suspicious, but a genuine 0% is possible and I did not confirm a defect. Left for separate diagnosis rather than an assumed fix.

`sla breaching` returns 0 tickets in window, which `triage` independently corroborates on the same cache, so there is no evidence of a defect there. `tickets reopens` degrades cleanly with an explicit note and is unrelated to this family.

## Checklist

- [x] DCO sign-off on the commit.
- [x] No em-dashes in any added line.
- [x] Hand-edits recorded in `handfixes.json`.
- [x] `catalog.json` not hand-edited.
- [x] No credentials, personal paths, tenant identifiers, agent names or client names in committed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ticket reporting across workload, standup, client, and age-out views by consistently associating tickets with agents.
  * Added reliable fallbacks for unassigned agents and missing ticket creation dates.
  * Prevented inconsistent grouping and display results in ticket-based commands.

* **Tests**
  * Added regression coverage for agent grouping, date handling, name precedence, and ticket query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->