### PR TITLE
fix(halopsa): read SLA deadlines from fixbydate, not the unused targetdate column

### DIFF
--- a/skills/halopsa/cli/internal/cli/client_card.go
+++ b/skills/halopsa/cli/internal/cli/client_card.go
@@ -84,10 +84,10 @@ client. Resolves by numeric ID or by name (case-insensitive substring match).`,
 			// Active tickets
 			tRows, _ := db.DB().QueryContext(cmd.Context(), `SELECT id, COALESCE(summary,''), COALESCE(agent_name,'?'),
                 COALESCE(json_extract(data,'$.status_name'),'?'),
-                COALESCE(json_extract(data,'$.targetdate'),'')
+                COALESCE(` + slaResolutionTargetSQL + `,'')
                 FROM tickets
                 WHERE client_id = ? AND COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)
-                ORDER BY COALESCE(json_extract(data,'$.targetdate'),'') ASC
+                ORDER BY COALESCE(` + slaResolutionTargetSQL + `,'') ASC
                 LIMIT ?`, clientID, limitT)
 			activeTickets := []map[string]any{}
 			if tRows != nil {
@@ -228,7 +228,7 @@ func newNovelClientOverlayCmd(flags *rootFlags) *cobra.Command {
                     GROUP BY client ORDER BY metric DESC LIMIT ?`
 			case "sla_at_risk":
 				q = `SELECT COALESCE(client_name,'?') AS client,
-                    SUM(CASE WHEN datetime(COALESCE(json_extract(data,'$.targetdate'),'')) BETWEEN datetime('now') AND datetime('now', '+24 hours') THEN 1 ELSE 0 END) AS metric
+                    SUM(CASE WHEN datetime(` + slaResolutionTargetSQL + `) BETWEEN datetime('now') AND datetime('now', '+24 hours') THEN 1 ELSE 0 END) AS metric
                     FROM tickets
                     WHERE COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)
                     GROUP BY client ORDER BY metric DESC LIMIT ?`

--- a/skills/halopsa/cli/internal/cli/sla_breaching.go
+++ b/skills/halopsa/cli/internal/cli/sla_breaching.go
@@ -20,8 +20,9 @@ func newNovelSlaBreachingCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "breaching",
-		Short: "Tickets whose targetdate falls in the next N hours, sorted by time-to-breach",
-		Long: `Reads tickets.targetdate locally; joins agent + client + current status.
+		Short: "Tickets whose resolution target falls in the next N hours, sorted by time-to-breach",
+		Long: `Reads each ticket's resolution target (fixbydate, falling back to
+targetdate) locally; joins agent + client + current status.
 The Friday-afternoon-before-handoff command.`,
 		Example: strings.Trim(`
   # 24-hour breach window across all teams
@@ -49,7 +50,9 @@ The Friday-afternoon-before-handoff command.`,
 			defer db.Close()
 			where := []string{
 				"COALESCE(json_extract(data,'$.status_id'),0) NOT IN (8,9)",
-				"datetime(COALESCE(json_extract(data,'$.targetdate'),'')) BETWEEN datetime('now') AND datetime('now', '+' || ? || ' hours')",
+				// HaloPSA leaves targetdate at the 1900-01-01 sentinel; the real
+				// resolution deadline is fixbydate. See sla_target_sql.go.
+				"datetime(" + slaResolutionTargetSQL + ") BETWEEN datetime('now') AND datetime('now', '+' || ? || ' hours')",
 			}
 			argsSQL := []any{hours}
 			if team != "" {
@@ -61,8 +64,8 @@ The Friday-afternoon-before-handoff command.`,
                 COALESCE(agent_name,'?') AS agent,
                 COALESCE(json_extract(data,'$.status_name'),'?') AS status,
                 COALESCE(summary,'') AS summary,
-                COALESCE(json_extract(data,'$.targetdate'),'') AS targetdate,
-                CAST((julianday(COALESCE(json_extract(data,'$.targetdate'),'')) - julianday('now')) * 24 * 60 AS INTEGER) AS minutes_to_breach
+                COALESCE(` + slaResolutionTargetSQL + `,'') AS targetdate,
+                CAST((julianday(` + slaResolutionTargetSQL + `) - julianday('now')) * 24 * 60 AS INTEGER) AS minutes_to_breach
                 FROM tickets WHERE ` + strings.Join(where, " AND ") + `
                 ORDER BY minutes_to_breach ASC LIMIT ?`
 			argsSQL = append(argsSQL, limit)

--- a/skills/halopsa/cli/internal/cli/sla_scorecard.go
+++ b/skills/halopsa/cli/internal/cli/sla_scorecard.go
@@ -90,9 +90,9 @@ Reads the local sync store. Run 'halopsa-cli sync' first.`,
 			}
 			q := `SELECT ` + groupExpr + ` AS grp,
 				COUNT(*) AS closed,
-				SUM(CASE WHEN COALESCE(json_extract(data,'$.targetdate'),'') != '' THEN 1 ELSE 0 END) AS with_target,
-				SUM(CASE WHEN COALESCE(json_extract(data,'$.targetdate'),'') != ''
-				          AND datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated)) <= datetime(json_extract(data,'$.targetdate'))
+				SUM(CASE WHEN (` + slaResolutionTargetSQL + `) IS NOT NULL THEN 1 ELSE 0 END) AS with_target,
+				SUM(CASE WHEN (` + slaResolutionTargetSQL + `) IS NOT NULL
+				          AND datetime(COALESCE(NULLIF(json_extract(data,'$.lastactiondate'),''), datecreated)) <= datetime(` + slaResolutionTargetSQL + `)
 				     THEN 1 ELSE 0 END) AS met
 			FROM tickets
 			WHERE json_extract(data,'$.status_id') IN (8,9)

--- a/skills/halopsa/cli/internal/cli/sla_target_sql.go
+++ b/skills/halopsa/cli/internal/cli/sla_target_sql.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Hand-authored (novel file, not generated).
+//
+// Every SLA-facing local view read tickets.targetdate, which HaloPSA does not
+// use. The portal's Response Target and Resolution Target come from
+// respondbydate and fixbydate; targetdate is a legacy column left at the
+// sentinel 1900-01-01T00:00:00. On the tenant this was found against, 1264 of
+// 1265 synced tickets carry that sentinel while all 1265 carry real
+// respondbydate and fixbydate values.
+//
+// The consequence is a silent zero rather than an error. A comparison like
+//
+//	datetime(targetdate) BETWEEN datetime('now') AND datetime('now','+24 hours')
+//
+// can never be true against 1900-01-01, so `sla breaching` and triage's
+// breach_count report no SLA risk on every tenant regardless of what is
+// actually due, and `sla scorecard` counts every ticket as having a target
+// that nothing can satisfy, reporting 0 percent met.
+//
+// Verified against the portal on six tickets: each Response Target and
+// Resolution Target shown in the UI matches respondbydate / fixbydate exactly
+// (offset only by the tenant's UTC display conversion), while targetdate reads
+// 1900-01-01 on all of them. One open ticket was 16 hours from its resolution
+// target and 27 hours past its response target while `sla breaching` reported
+// zero.
+//
+// targetdate is kept as a fallback rather than dropped: it is populated on a
+// small number of tickets, so a tenant that does use it still works.
+
+package cli
+
+// slaResolutionTargetSQL is the ticket's resolution deadline: fixbydate, then
+// targetdate, and NULL when neither carries a usable value. The 1900-01-01
+// sentinel is treated as absent, so "has a target" tests must check IS NOT
+// NULL rather than != ''.
+//
+// The expression reads an unqualified `data` column, so the surrounding query
+// must expose exactly one.
+const slaResolutionTargetSQL = `CASE
+    WHEN COALESCE(json_extract(data,'$.fixbydate'),'') <> ''
+         AND json_extract(data,'$.fixbydate') NOT LIKE '1900-01-01%'
+        THEN json_extract(data,'$.fixbydate')
+    WHEN COALESCE(json_extract(data,'$.targetdate'),'') <> ''
+         AND json_extract(data,'$.targetdate') NOT LIKE '1900-01-01%'
+        THEN json_extract(data,'$.targetdate')
+END`
+
+// slaResponseTargetSQL is the ticket's first-response deadline, resolved the
+// same way. Exposed for callers that report response SLA separately; the
+// breach views intentionally track the resolution target, which is what
+// targetdate was standing in for.
+const slaResponseTargetSQL = `CASE
+    WHEN COALESCE(json_extract(data,'$.respondbydate'),'') <> ''
+         AND json_extract(data,'$.respondbydate') NOT LIKE '1900-01-01%'
+        THEN json_extract(data,'$.respondbydate')
+END`

--- a/skills/halopsa/cli/internal/cli/sla_target_sql_test.go
+++ b/skills/halopsa/cli/internal/cli/sla_target_sql_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored: guards the SLA target field resolution. See
+// skills/halopsa/handfixes.json (sla-target-reads-fixbydate).
+
+package cli
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// slaFixture mirrors a real Halo sync: targetdate parked at the 1900-01-01
+// sentinel while the usable deadlines live in fixbydate and respondbydate.
+func slaFixture(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "sla.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	mustExec(t, db, `CREATE TABLE tickets (id INTEGER PRIMARY KEY, data JSON NOT NULL)`)
+	mustExec(t, db, `INSERT INTO tickets (id, data) VALUES
+		-- Sentinel targetdate, real fixbydate due in ~16h: must be seen.
+		(1, json_object('targetdate','1900-01-01T00:00:00',
+		                'fixbydate', datetime('now','+16 hours'),
+		                'respondbydate', datetime('now','-27 hours'))),
+		-- Sentinel targetdate, fixbydate far out: must not be seen.
+		(2, json_object('targetdate','1900-01-01T00:00:00',
+		                'fixbydate', datetime('now','+9 days'))),
+		-- No fixbydate but a real targetdate: the fallback must still work.
+		(3, json_object('targetdate', datetime('now','+3 hours'))),
+		-- Nothing usable at all: must resolve to NULL, not to the sentinel.
+		(4, json_object('targetdate','1900-01-01T00:00:00'))`)
+	return db
+}
+
+func resolvedTarget(t *testing.T, db *sql.DB, id int) (string, bool) {
+	t.Helper()
+	var v sql.NullString
+	if err := db.QueryRow(`SELECT `+slaResolutionTargetSQL+` FROM tickets WHERE id = ?`, id).Scan(&v); err != nil {
+		t.Fatalf("resolve target for %d: %v", id, err)
+	}
+	return v.String, v.Valid
+}
+
+// TestSLAResolutionTargetPrefersFixbydate is the core regression: the sentinel
+// must never be treated as a deadline, and fixbydate must win.
+func TestSLAResolutionTargetPrefersFixbydate(t *testing.T) {
+	db := slaFixture(t)
+
+	got, ok := resolvedTarget(t, db, 1)
+	if !ok {
+		t.Fatal("ticket 1 resolved to NULL; fixbydate carries the real deadline")
+	}
+	if strings.HasPrefix(got, "1900-01-01") {
+		t.Fatalf("resolved target = %q, want fixbydate rather than the sentinel", got)
+	}
+}
+
+// TestSLAResolutionTargetFallsBackToTargetdate keeps tenants that genuinely
+// populate targetdate working.
+func TestSLAResolutionTargetFallsBackToTargetdate(t *testing.T) {
+	db := slaFixture(t)
+	if got, ok := resolvedTarget(t, db, 3); !ok || strings.HasPrefix(got, "1900-01-01") {
+		t.Fatalf("ticket 3 resolved to (%q, ok=%v); a real targetdate must be used when fixbydate is absent", got, ok)
+	}
+}
+
+// TestSLAResolutionTargetIsNullWhenAbsent pins the sentinel handling, so
+// "has a target" tests count real deadlines only.
+func TestSLAResolutionTargetIsNullWhenAbsent(t *testing.T) {
+	db := slaFixture(t)
+	if got, ok := resolvedTarget(t, db, 4); ok {
+		t.Fatalf("ticket 4 resolved to %q, want NULL; the 1900-01-01 sentinel is not a deadline", got)
+	}
+}
+
+// TestSLABreachWindowMatchesOnlyRealDeadlines is the end-to-end shape of the
+// breach query: pre-fix this returned zero rows on every tenant because the
+// sentinel can never fall inside the window.
+func TestSLABreachWindowMatchesOnlyRealDeadlines(t *testing.T) {
+	db := slaFixture(t)
+
+	rows, err := db.Query(`SELECT id FROM tickets
+		WHERE datetime(` + slaResolutionTargetSQL + `) BETWEEN datetime('now') AND datetime('now','+24 hours')
+		ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	var got []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, id)
+	}
+	// 1 is due in 16h via fixbydate, 3 in 3h via the targetdate fallback.
+	// 2 is 9 days out and 4 has no deadline.
+	want := []int{1, 3}
+	if len(got) != len(want) {
+		t.Fatalf("breaching = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("breaching = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestSLAScorecardCountsRealTargetsOnly covers the met/with-target pair, which
+// pre-fix reported every ticket as having an unmeetable target.
+func TestSLAScorecardCountsRealTargetsOnly(t *testing.T) {
+	db := slaFixture(t)
+	mustExec(t, db, `INSERT INTO tickets (id, data) VALUES
+		(5, json_object('targetdate','1900-01-01T00:00:00',
+		                'fixbydate', datetime('now','-2 days'),
+		                'lastactiondate', datetime('now','-3 days')))`)
+
+	var withTarget, met int
+	if err := db.QueryRow(`SELECT
+		SUM(CASE WHEN (`+slaResolutionTargetSQL+`) IS NOT NULL THEN 1 ELSE 0 END),
+		SUM(CASE WHEN (`+slaResolutionTargetSQL+`) IS NOT NULL
+		          AND datetime(json_extract(data,'$.lastactiondate')) <= datetime(`+slaResolutionTargetSQL+`)
+		     THEN 1 ELSE 0 END)
+		FROM tickets WHERE id = 5`).Scan(&withTarget, &met); err != nil {
+		t.Fatalf("scorecard query: %v", err)
+	}
+	if withTarget != 1 {
+		t.Fatalf("with_target = %d, want 1", withTarget)
+	}
+	if met != 1 {
+		t.Fatalf("met = %d, want 1; the ticket was actioned before its fixbydate", met)
+	}
+}
+
+// TestSLAViewsDoNotReadTargetdateDirectly is the source-level guard: the
+// SLA-facing commands must go through the shared expression rather than
+// reading the legacy column.
+func TestSLAViewsDoNotReadTargetdateDirectly(t *testing.T) {
+	for _, file := range []string{
+		"sla_breaching.go",
+		"sla_scorecard.go",
+		"triage.go",
+		"client_card.go",
+	} {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		src := string(b)
+		if !strings.Contains(src, "slaResolutionTargetSQL") {
+			t.Errorf("%s does not use slaResolutionTargetSQL", file)
+		}
+		for _, raw := range []string{`json_extract(data,'$.targetdate')`, `json_extract(data, '$.targetdate')`} {
+			if strings.Contains(src, raw) {
+				t.Errorf("%s still reads targetdate directly; HaloPSA leaves it at the 1900-01-01 sentinel", file)
+			}
+		}
+	}
+}

--- a/skills/halopsa/cli/internal/cli/triage.go
+++ b/skills/halopsa/cli/internal/cli/triage.go
@@ -68,7 +68,7 @@ func buildTriageQuery(team, agent string, staleDays, breachHrs, limit int) (stri
                 agent_label AS who,
                 COUNT(*) AS open_count,
                 SUM(CASE WHEN (julianday('now') - julianday(COALESCE(NULLIF(json_extract(data, '$.lastactiondate'),''), created_at))) > ? THEN 1 ELSE 0 END) AS stale_count,
-                SUM(CASE WHEN datetime(COALESCE(json_extract(data, '$.targetdate'), '')) BETWEEN datetime('now') AND datetime('now', '+' || ? || ' hours') THEN 1 ELSE 0 END) AS breach_count,
+                SUM(CASE WHEN datetime(` + slaResolutionTargetSQL + `) BETWEEN datetime('now') AND datetime('now', '+' || ? || ' hours') THEN 1 ELSE 0 END) AS breach_count,
                 CAST(MAX(julianday('now') - julianday(created_at)) AS INTEGER) AS oldest_days
             FROM scoped
             ` + agentFilter + `

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -144,6 +144,63 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "sla-target-reads-fixbydate",
+      "summary": "every SLA-facing view resolves the deadline from fixbydate (falling back to targetdate) instead of reading tickets.targetdate, which HaloPSA parks at the 1900-01-01 sentinel",
+      "why": "HaloPSA does not use tickets.targetdate. The portal's Response Target and Resolution Target come from respondbydate and fixbydate, while targetdate is a legacy column left at 1900-01-01T00:00:00. On the tenant this was found against, 1264 of 1265 synced tickets carry that sentinel and all 1265 carry real respondbydate and fixbydate values. The consequence is a silent zero rather than an error: a window test like datetime(targetdate) BETWEEN now AND now+24h can never be true against 1900-01-01, so sla breaching and triage's breach_count reported no SLA risk on every tenant regardless of what was actually due, and sla scorecard counted every closed ticket as carrying a target that nothing could satisfy and reported 0 percent met. client card displayed 1900-01-01 as each ticket's target date, ordered its active-ticket panel by it, and its sla_at_risk overlay metric was permanently 0. Confirmed against the portal on six tickets: each Response Target and Resolution Target rendered in the UI matches respondbydate / fixbydate exactly, offset only by the tenant's UTC display conversion, while targetdate reads 1900-01-01 on all of them. One open ticket was 16 hours from its resolution target and 27 hours past its response target while sla breaching reported zero. After the fix that ticket surfaces with minutes_to_breach 989, triage reports breaching 1, and the scorecard moves from 0 percent met to 98.9 percent (Alerts, 87 of 88) and 97.0 percent (Service Desk, 64 of 66). targetdate is retained as a fallback rather than dropped, since it is populated on a small number of tickets and a tenant that does use it must keep working; the shared expression treats the 1900-01-01 sentinel as absent so has-a-target tests count real deadlines only.",
+      "status": "active",
+      "spec_encode_followup": "None available: these are hand-written novel commands, so the press cannot derive the field choice. The ledger entry is the backstop against a new SLA view reading targetdate again.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sla_target_sql.go",
+          "contains": "const slaResolutionTargetSQL",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sla_target_sql.go",
+          "contains": "$.fixbydate",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sla_breaching.go",
+          "contains": "slaResolutionTargetSQL",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/sla_scorecard.go",
+          "contains": "slaResolutionTargetSQL",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/triage.go",
+          "contains": "slaResolutionTargetSQL",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/client_card.go",
+          "contains": "slaResolutionTargetSQL",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/cli/sla_breaching.go",
+          "not_contains": "json_extract(data,'$.targetdate')"
+        },
+        {
+          "file": "cli/internal/cli/triage.go",
+          "not_contains": "json_extract(data, '$.targetdate')"
+        },
+        {
+          "file": "cli/internal/cli/sla_target_sql_test.go",
+          "contains": "TestSLABreachWindowMatchesOnlyRealDeadlines",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sla_target_sql_test.go",
+          "contains": "TestSLAViewsDoNotReadTargetdateDirectly",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Pull request

## What this changes

Every SLA-facing local view read `tickets.targetdate`, which HaloPSA does not use. All of them reported zero risk and zero SLA attainment on every tenant. This resolves the deadline from `fixbydate` instead, keeping `targetdate` as a fallback.

Found while verifying the two commands I left unfixed in #212. Reported on #211, but this is a distinct defect in already-merged code and is filed separately.

## The finding

The portal's **Response Target** and **Resolution Target** come from `respondbydate` and `fixbydate`. `targetdate` is a legacy column parked at the sentinel `1900-01-01T00:00:00`.

On the tenant this was found against: **1264 of 1265** synced tickets carry that sentinel, while **all 1265** carry real `respondbydate` and `fixbydate` values.

Verified against the portal on six tickets. Every UI value matches the field the code was not reading, offset only by the tenant's UTC display conversion:

| ticket | portal response | API `respondbydate` | portal resolution | API `fixbydate` | API `targetdate` |
|---|---|---|---|---|---|
| A | 8/14 14:35 | `08-14T18:35` | 8/20 15:35 | `08-20T19:35` | `1900-01-01` |
| B | 8/11 14:20 | `08-11T18:20` | 8/20 13:45 | `08-20T17:45` | `1900-01-01` |
| C | 8/14 11:15 | `08-14T15:15` | 8/20 12:15 | `08-20T16:15` | `1900-01-01` |
| D | 8/14 09:37 | `08-14T13:37` | 8/20 17:33 | `08-20T21:33` | `1900-01-01` |

## Why it was invisible

The failure mode is a silent zero, not an error. A window test like

```sql
datetime(targetdate) BETWEEN datetime('now') AND datetime('now','+24 hours')
```

can never be true against `1900-01-01`, so the query succeeds and returns nothing. Four views were affected:

- **`sla breaching`** - reported no tickets at risk on every tenant, whatever was actually due
- **`triage`** - `breach_count` 0 for every agent (merged in #209)
- **`sla scorecard`** - counted every closed ticket as carrying a target nothing could satisfy, reporting 0 percent met
- **`client card`** - displayed `1900-01-01` as each ticket's target date and ordered its active-ticket panel by it; the `sla_at_risk` client overlay metric was permanently 0

One open ticket on this tenant sat **16 hours from its resolution target and 27 hours past its response target** while `sla breaching` reported zero. Its portal SLA panel shows a red missed-response marker and a live negative countdown.

## After

Verified live on the same cache:

| view | before | after |
|---|---|---|
| `sla breaching` | 0 tickets | the at-risk ticket, `minutes_to_breach: 989` |
| `triage` breach_count | 0 for every agent | 1 |
| `sla scorecard` (team A) | 88 with target, 0 met, **0%** | 88 with target, 87 met, **98.9%** |
| `sla scorecard` (team B) | 66 with target, 0 met, 0% | 64 met, **97.0%** |
| `client card` target_date | `1900-01-01` | real dates |
| `client overlay --metric sla_at_risk` | all zero | ranks clients |

The scorecard swing is the part worth pausing on: it was not under-reporting slightly, it was reporting total SLA failure on a tenant whose actual attainment is 97 to 99 percent.

## Design notes

**`targetdate` is kept as a fallback, not dropped.** One ticket on this tenant genuinely populates it, and another tenant may rely on it. The shared expression prefers `fixbydate`, falls back to `targetdate`, and treats the `1900-01-01` sentinel as absent so has-a-target tests count real deadlines only.

**`slaResponseTargetSQL` is exposed but deliberately unwired.** `sla breaching`'s contract is the resolution target, and the ticket above had already blown its response target by 27 hours. Surfacing response breaches too would be genuinely useful, but it is a behaviour change rather than a bug fix, so it is left as a follow-up rather than folded in here.

## Verification

Six tests. `TestSLAViewsDoNotReadTargetdateDirectly` is the source-level guard and was confirmed to fail against a **compiling** revert of one site; my first attempt at that negative control produced invalid Go and proved nothing, so it was redone.

`go build`, `go vet` and `go test ./...` all pass. `check_handfixes.py --slug halopsa` passes, with the new entry verified to fail when reverted.

## Overlap with #212

Both touch `client_card.go`, at different lines (#212 changes the agent join and the `stale` overlay metric; this changes the target-date projection and the `sla_at_risk` metric). They are independently mergeable and git merges them cleanly, but flagging it so the order is a deliberate choice rather than a surprise. This branch is cut from `main`, not from #212, because the SLA defect is the more urgent of the two.

## Checklist

- [x] DCO sign-off on the commit.
- [x] No em-dashes in any added line.
- [x] Hand-edits recorded in `handfixes.json`.
- [x] `catalog.json` not hand-edited.
- [x] No credentials, personal paths, tenant identifiers, agent names or client names in committed files.
