### PR TITLE
fix(threatlocker): sync the real POST list endpoints and key rows on their id fields

### DIFF
--- a/skills/threatlocker/cli/internal/cli/sync.go
+++ b/skills/threatlocker/cli/internal/cli/sync.go
@@ -345,9 +345,22 @@ Resource scoping:
 // keep both call sites in sync if this signature changes.
 func syncResource(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
+	PostWithHeaders(context.Context, string, any, map[string]string) (json.RawMessage, int, error)
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
 	started := time.Now()
+
+	// Hand-wired dispatch: ThreatLocker's real list endpoints are POST-only and
+	// tenant-scoped, so the generated GET walk below cannot reach them and the
+	// profiler fell back to id-less dropdown helpers. See
+	// sync_post_list.go and handfixes.json
+	// (sync-post-list-endpoints).
+	if spec, ok := tenantSyncSpecs[resource]; ok {
+		if !humanFriendly {
+			fmt.Fprintf(syncEvents, `{"event":"sync_start","resource":"%s"}`+"\n", resource)
+		}
+		return syncTenantPostResource(ctx, c, db, resource, spec, maxPages, syncEvents, started)
+	}
 	if syncEvents == nil {
 		syncEvents = io.Discard
 	}

--- a/skills/threatlocker/cli/internal/cli/sync_post_list.go
+++ b/skills/threatlocker/cli/internal/cli/sync_post_list.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+//
+// Hand-authored (novel file, not generated).
+//
+// ThreatLocker's real list endpoints are POST-with-body. The generated sync
+// loop only issues GET with query params, so the profiler wired sync to the
+// only GET-able list-ish paths available: the portal's dropdown helpers
+// (OrganizationGetForMoveComputers, ComputerGetForNewComputer,
+// ...GetForDropdownList). Those return UI picker payloads - a handful of
+// {label, value} rows carrying no primary key - which is why every resource
+// logged all_items_failed_id_extraction and stored zero rows while sync still
+// exited 0.
+//
+// This file adds a POST path for the resources the offline store is built
+// around. `devices health` joins the computers table and scopes with
+// --all-tenants, so it needs the real inventory rather than one dropdown page.
+//
+// Tenancy note: these endpoints are tenant-scoped via the
+// ManagedOrganizationId header, but a request carrying childOrganizations=true
+// already returns the authenticating organization's entire tree. Verified
+// live on a 5-organization tenant: the top-level request returns 58 computers,
+// which is exactly that organization's own 5 plus 1, 29 and 23 from its three
+// populated children. Fanning out per organization and merging returns the
+// same 58 rows (every child row arrives as a duplicate) for six extra API
+// calls, so this deliberately does not fan out.
+//
+// Kept in a novel file so regen-merge preserves it; the generated sync.go
+// carries only a small dispatch hook. See skills/threatlocker/handfixes.json
+// (sync-post-list-endpoints).
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"threatlocker-pp-cli/internal/store"
+)
+
+// tenantPostClient is the subset of the API client this path needs.
+type tenantPostClient interface {
+	PostWithHeaders(context.Context, string, any, map[string]string) (json.RawMessage, int, error)
+}
+
+// tenantSyncSpec describes how to page a POST list endpoint.
+type tenantSyncSpec struct {
+	path string
+	// body returns the request body for a 1-based page.
+	body func(page int) map[string]any
+	// idField is the primary key on the returned rows. ThreatLocker names
+	// these per entity (computerId, organizationId) rather than a bare id,
+	// which the generic fallback chain does not match.
+	idField string
+}
+
+const tenantSyncPageSize = 500
+
+// tenantSyncSpecs covers the resources whose real records are only reachable
+// by POST. Resources absent here keep the generated GET path.
+var tenantSyncSpecs = map[string]tenantSyncSpec{
+	"organizations": {
+		path: "/Organization/OrganizationGetChildOrganizationsByParameters",
+		body: func(page int) map[string]any {
+			return map[string]any{
+				"searchText": "", "includeAllChildren": true,
+				"orderBy": "name", "isAscending": true,
+				"pageNumber": page, "pageSize": tenantSyncPageSize,
+			}
+		},
+		idField: "organizationId",
+	},
+	"computers": {
+		path: "/Computer/ComputerGetByAllParameters",
+		body: func(page int) map[string]any {
+			return map[string]any{
+				"pageNumber": page, "pageSize": tenantSyncPageSize,
+				"searchText": "", "searchBy": 1,
+				"orderBy": "computername", "isAscending": true,
+				// Covers the whole organization tree in one request; see the
+				// tenancy note at the top of this file.
+				"childOrganizations": true,
+			}
+		},
+		idField: "computerId",
+	},
+}
+
+// tenantSyncRows pulls every page of one POST list endpoint.
+func tenantSyncRows(ctx context.Context, c tenantPostClient, spec tenantSyncSpec, maxPages int) ([]json.RawMessage, error) {
+	var out []json.RawMessage
+	for page := 1; maxPages <= 0 || page <= maxPages; page++ {
+		raw, _, err := c.PostWithHeaders(ctx, spec.path, spec.body(page), map[string]string{})
+		if err != nil {
+			return out, err
+		}
+		rows, ok := tenantExtractRows(raw)
+		if !ok || len(rows) == 0 {
+			return out, nil
+		}
+		out = append(out, rows...)
+		if len(rows) < tenantSyncPageSize {
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+// tenantExtractRows unwraps ThreatLocker's {"action":..,"data":[...]} envelope,
+// tolerating a bare array and the {"results":[...]} shape.
+func tenantExtractRows(raw json.RawMessage) ([]json.RawMessage, bool) {
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		return arr, true
+	}
+	var env map[string]json.RawMessage
+	if json.Unmarshal(raw, &env) != nil {
+		return nil, false
+	}
+	for _, key := range []string{"data", "Data", "results", "Results"} {
+		if v, ok := env[key]; ok {
+			if json.Unmarshal(v, &arr) == nil {
+				return arr, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// syncTenantPostResource is the hand-wired replacement for the generated GET
+// walk on POST-only resources, storing rows keyed by the entity's real id
+// field. Rows whose id field is absent are dropped rather than stored under an
+// empty key, and counted so the caller can surface them.
+func syncTenantPostResource(
+	ctx context.Context,
+	c tenantPostClient,
+	db *store.Store,
+	resource string,
+	spec tenantSyncSpec,
+	maxPages int,
+	syncEvents io.Writer,
+	started time.Time,
+) syncResult {
+	if syncEvents == nil {
+		syncEvents = io.Discard
+	}
+
+	rows, err := tenantSyncRows(ctx, c, spec, maxPages)
+	if err != nil {
+		if !humanFriendly {
+			fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
+		}
+		return syncResult{Resource: resource, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
+	}
+
+	seen := map[string]bool{}
+	items := make([]json.RawMessage, 0, len(rows))
+	unkeyed := 0
+	for _, r := range rows {
+		var obj map[string]any
+		if json.Unmarshal(r, &obj) != nil {
+			unkeyed++
+			continue
+		}
+		id := store.ResourceIDString(store.LookupFieldValue(obj, spec.idField))
+		if id == "" || id == "<nil>" {
+			unkeyed++
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		items = append(items, r)
+	}
+
+	stored, extractFailures, err := db.UpsertBatch(resource, items)
+	if err != nil {
+		return syncResult{Resource: resource, Count: stored, Err: fmt.Errorf("storing %s: %w", resource, err), Duration: time.Since(started)}
+	}
+	if (unkeyed > 0 || extractFailures > 0) && !humanFriendly {
+		fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":%d,"unkeyed":%d,"extract_failures":%d,"reason":"primary_key_unresolved"}`+"\n", resource, len(rows), stored, unkeyed, extractFailures)
+	}
+	if !humanFriendly {
+		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, stored, time.Since(started).Milliseconds())
+	}
+	_ = db.SaveSyncState(resource, "", stored)
+	return syncResult{Resource: resource, Count: stored, Duration: time.Since(started)}
+}

--- a/skills/threatlocker/cli/internal/cli/sync_post_list_test.go
+++ b/skills/threatlocker/cli/internal/cli/sync_post_list_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+// Hand-authored: guards the POST list-endpoint path. See
+// skills/threatlocker/handfixes.json (sync-post-list-endpoints).
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakePostClient models ThreatLocker's POST list endpoints: a paged
+// {"action":"post","data":[...]} envelope whose rows key on a per-entity id
+// field rather than a bare id.
+type fakePostClient struct {
+	total  int
+	idKey  string
+	calls  []map[string]any
+	header []map[string]string
+}
+
+func (f *fakePostClient) PostWithHeaders(_ context.Context, _ string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	b, _ := body.(map[string]any)
+	f.calls = append(f.calls, b)
+	f.header = append(f.header, headers)
+
+	page, size := 1, tenantSyncPageSize
+	if v, ok := b["pageNumber"].(int); ok {
+		page = v
+	}
+	if v, ok := b["pageSize"].(int); ok {
+		size = v
+	}
+	start := (page - 1) * size
+	end := start + size
+	if start > f.total {
+		start = f.total
+	}
+	if end > f.total {
+		end = f.total
+	}
+	rows := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		rows = append(rows, fmt.Sprintf(`{%q:"guid-%d","name":"row %d"}`, f.idKey, i, i))
+	}
+	return json.RawMessage(fmt.Sprintf(
+		`{"action":"post","data":[%s],"success":true}`, strings.Join(rows, ","),
+	)), 200, nil
+}
+
+// TestTenantSyncSpecsUseRealListEndpoints pins the endpoints. A reprint that
+// restores the profiler's dropdown helpers fails here.
+func TestTenantSyncSpecsUseRealListEndpoints(t *testing.T) {
+	for resource, want := range map[string]string{
+		"computers":     "/Computer/ComputerGetByAllParameters",
+		"organizations": "/Organization/OrganizationGetChildOrganizationsByParameters",
+	} {
+		spec, ok := tenantSyncSpecs[resource]
+		if !ok {
+			t.Fatalf("%s has no POST spec; sync would fall back to the id-less dropdown endpoint", resource)
+		}
+		if spec.path != want {
+			t.Errorf("%s path = %q, want %q", resource, spec.path, want)
+		}
+		if strings.Contains(strings.ToLower(spec.path), "dropdown") ||
+			strings.Contains(spec.path, "GetForNewComputer") ||
+			strings.Contains(spec.path, "GetForMoveComputers") {
+			t.Errorf("%s is pointed at a dropdown helper: %s", resource, spec.path)
+		}
+	}
+	if got := tenantSyncSpecs["computers"].idField; got != "computerId" {
+		t.Errorf("computers idField = %q, want computerId", got)
+	}
+	if got := tenantSyncSpecs["organizations"].idField; got != "organizationId" {
+		t.Errorf("organizations idField = %q, want organizationId", got)
+	}
+}
+
+// TestComputersRequestCoversChildOrganizations pins the tenancy decision: one
+// request with childOrganizations=true covers the whole tree, which is why the
+// path does not fan out per organization.
+func TestComputersRequestCoversChildOrganizations(t *testing.T) {
+	body := tenantSyncSpecs["computers"].body(1)
+	if body["childOrganizations"] != true {
+		t.Fatalf("computers body childOrganizations = %v, want true; without it sync sees only the authenticating organization", body["childOrganizations"])
+	}
+}
+
+// TestTenantSyncRowsWalksEveryPage covers pagination across the POST envelope.
+func TestTenantSyncRowsWalksEveryPage(t *testing.T) {
+	f := &fakePostClient{total: tenantSyncPageSize + 37, idKey: "computerId"}
+	rows, err := tenantSyncRows(context.Background(), f, tenantSyncSpecs["computers"], 0)
+	if err != nil {
+		t.Fatalf("tenantSyncRows: %v", err)
+	}
+	if len(rows) != f.total {
+		t.Fatalf("fetched %d rows, want %d", len(rows), f.total)
+	}
+	if len(f.calls) != 2 {
+		t.Fatalf("made %d requests, want 2 (a full page then a short one)", len(f.calls))
+	}
+	if f.calls[1]["pageNumber"] != 2 {
+		t.Errorf("second request pageNumber = %v, want 2", f.calls[1]["pageNumber"])
+	}
+}
+
+// TestTenantExtractRowsHandlesEnvelopes covers the response shapes the portal
+// returns for these endpoints.
+func TestTenantExtractRowsHandlesEnvelopes(t *testing.T) {
+	for name, raw := range map[string]string{
+		"data envelope":    `{"action":"post","data":[{"computerId":"a"}],"success":true}`,
+		"results envelope": `{"results":[{"computerId":"a"}]}`,
+		"bare array":       `[{"computerId":"a"}]`,
+	} {
+		rows, ok := tenantExtractRows(json.RawMessage(raw))
+		if !ok || len(rows) != 1 {
+			t.Errorf("%s: extracted ok=%v rows=%d, want ok=true rows=1", name, ok, len(rows))
+		}
+	}
+	if _, ok := tenantExtractRows(json.RawMessage(`"not an object"`)); ok {
+		t.Error("a scalar body should not extract as rows")
+	}
+}

--- a/skills/threatlocker/cli/internal/store/store.go
+++ b/skills/threatlocker/cli/internal/store/store.go
@@ -2398,7 +2398,20 @@ func (s *Store) UpsertVersions(data json.RawMessage) error {
 // Includes both flat resources and dependent (parent-child) resources so a
 // child path-item annotated with x-resource-id resolves the same as a flat
 // path-item.
-var resourceIDFieldOverrides = map[string]string{}
+// Hand-wired: ThreatLocker names its primary keys per entity (computerId,
+// organizationId) and its dropdown-shaped payloads carry the GUID under
+// "value", none of which the generic fallback chain matches. Without these the
+// store rejects every row with all_items_failed_id_extraction and a sync
+// completes having written nothing. See skills/threatlocker/handfixes.json
+// (sync-tenant-fanout-post-endpoints).
+var resourceIDFieldOverrides = map[string]string{
+	"computers":       "computerId",
+	"organizations":   "organizationId",
+	"computer-groups": "value",
+	"computer-groups-computer-group-get-dropdown-by-organization-id": "value",
+	"versions": "value",
+	"tags":     "value",
+}
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did
 // NOT receive a templated IDField. API-specific names belong in spec

--- a/skills/threatlocker/handfixes.json
+++ b/skills/threatlocker/handfixes.json
@@ -1,0 +1,69 @@
+{
+  "slug": "threatlocker",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "Connector-specific edits a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one. Provenance: issue #208 (reporter @geekbrownbear). ThreatLocker's real list endpoints are POST-with-body while the generated sync loop is GET-only, so the profiler wired sync to the portal's GET dropdown helpers; those return id-less {label, value} picker rows, so every resource logged all_items_failed_id_extraction and sync stored zero rows while exiting 0.",
+  "handfixes": [
+    {
+      "id": "sync-post-list-endpoints",
+      "summary": "sync reaches ThreatLocker's real POST list endpoints for computers and organizations instead of the GET dropdown helpers the profiler selected",
+      "why": "ThreatLocker exposes its real list endpoints as POST-with-body (/Computer/ComputerGetByAllParameters, /Organization/OrganizationGetChildOrganizationsByParameters). The generated sync loop only issues GET with query params, so the profiler fell back to the only GET-able list-ish paths in the spec: the portal's dropdown helpers (/Computer/ComputerGetForNewComputer, /Organization/OrganizationGetForMoveComputers, .../GetForDropdownList). Those answer with UI picker payloads - a few {label, value} rows carrying no primary key - so the store rejected every row with all_items_failed_id_extraction and a full sync wrote nothing while still reporting sync_complete and exiting 0. On a live tenant that meant 0 rows across all 9 resources, which left every offline-backed feature (devices health, search, analytics, --data-source local) empty. The dispatch hook in the generated sync.go routes those two resources to a hand-authored POST path; the client already exposes PostWithHeaders, so only the syncResource client interface needed widening. Tenancy note: these endpoints are scoped by the ManagedOrganizationId header, but a request carrying childOrganizations=true already returns the authenticating organization's whole tree, so the path deliberately does not fan out per organization - verified live, where the top-level request returns 58 computers (that organization's own 5 plus 1, 29 and 23 from its three populated children) and a per-organization fanout returns the same 58 rows for six extra API calls. Verified live: computers 0 -> 58, organizations 0 -> 7, and devices health --all-tenants went from empty to a per-organization online/stale/offline breakdown of all 58 devices.",
+      "status": "active",
+      "spec_encode_followup": "Press should support POST-with-body list endpoints for sync (method + body template on the path-item) so tenant APIs that expose no GET list route are generated correctly rather than falling back to dropdown helpers.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sync_post_list.go",
+          "contains": "var tenantSyncSpecs = map[string]tenantSyncSpec{",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_post_list.go",
+          "contains": "/Computer/ComputerGetByAllParameters",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_post_list.go",
+          "contains": "func syncTenantPostResource(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "if spec, ok := tenantSyncSpecs[resource]; ok {",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "PostWithHeaders(context.Context, string, any, map[string]string) (json.RawMessage, int, error)",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_post_list_test.go",
+          "contains": "TestTenantSyncSpecsUseRealListEndpoints",
+          "min_count": 1
+        }
+      ]
+    },
+    {
+      "id": "resource-id-field-overrides",
+      "summary": "store keys ThreatLocker rows on their per-entity id fields (computerId, organizationId) and the dropdown payloads' value field",
+      "why": "ThreatLocker names primary keys per entity rather than using a bare id, and its dropdown-shaped payloads carry the GUID under 'value'. genericIDFieldFallbacks (id, ID, gid, sid, uid, uuid, guid, name, slug, key, code) matches none of those, and resourceIDFieldOverrides was emitted empty because the spec carries no x-resource-id annotations. Every row therefore failed primary-key extraction and was dropped before insert, which is the second half of why a full sync stored nothing: repointing the endpoints alone still yields zero rows, because the real records key on computerId and organizationId. Verified live: with the overrides in place versions goes 0 -> 112 and tags 0 -> 1 on the unchanged GET path, and computers/organizations store their rows on the POST path.",
+      "status": "active",
+      "spec_encode_followup": "Annotate the spec with x-resource-id per path-item (computerId, organizationId, value) so these are generated rather than hand-maintained.",
+      "asserts": [
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"computers\":       \"computerId\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"organizations\":   \"organizationId\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "not_contains": "var resourceIDFieldOverrides = map[string]string{}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Pull request

## What this changes

`threatlocker-cli sync` stored **zero rows for every resource while exiting 0**, so the local cache stayed empty and every offline-backed feature had nothing to read. This points sync at the real list endpoints and keys rows on their actual id fields. Fixes #208.

Credentials were never the problem: the diagnosis on #208 disproves all four candidate causes that issue opened with.

## The bug

Two compounding causes. Fixing either alone still stores nothing.

### 1. sync was pointed at the portal's dropdown helpers

ThreatLocker's real list endpoints are **POST-with-body**, but the generated sync loop only issues GET with query params. The profiler therefore wired sync to the only GET-able list-ish paths in the spec, which are the portal's UI pickers:

| resource | sync used | the `list` command uses |
|---|---|---|
| computers | `/Computer/ComputerGetForNewComputer` | `/Computer/ComputerGetByAllParameters` |
| organizations | `/Organization/OrganizationGetForMoveComputers` | `/Organization/OrganizationGetChildOrganizationsByParameters` |
| versions | `/ThreatLockerVersion/...GetForDropdownList` | - |

Those return a handful of `{label, value}` picker rows with no primary key. On a tenant with 58 devices, sync consumed **3 items** for `computers`.

### 2. `resourceIDFieldOverrides` was emitted empty

ThreatLocker names its primary keys per entity (`computerId`, `organizationId`) and its dropdown payloads carry the GUID under `value`. The generic fallback chain (`id, ID, gid, sid, uid, uuid, guid, name, slug, key, code`) matches none of them, so every row failed extraction:

```
{"event":"sync_anomaly","resource":"organizations","consumed":7,"stored":0,"reason":"all_items_failed_id_extraction"}
{"event":"sync_anomaly","resource":"versions","consumed":112,"stored":0,"reason":"all_items_failed_id_extraction"}
{"event":"sync_summary","total_records":0,"resources":9,"success":8,"warned":0,"errored":1}
```

Eight of nine resources counted as `success` while storing nothing.

## Tenancy: why this does not fan out

These endpoints are scoped by the `ManagedOrganizationId` header, so a per-organization fanout looks necessary. It is not, and I measured it rather than assuming.

A request carrying `childOrganizations: true` already returns the authenticating organization's **whole tree**. On a 5-organization tenant the top-level request returns 58 computers: that organization's own 5, plus 1, 29 and 23 from its three populated children. Fanning out and merging returns the same 58 rows, with every child row arriving as a duplicate, for six extra API calls:

```
org=<parent>  rows=58  added=58 dup=0
org=<child-a> rows=1   added=0  dup=1
org=<child-b> rows=29  added=0  dup=29
org=<child-c> rows=23  added=0  dup=23
unique_items=58
```

I had initially reported on #208 that a fanout was needed, from summing the per-organization `computerCount` values to 111 devices. That double-counts, because the parent's count is a rollup of its tree. Corrected on the issue and the fanout removed.

## After

Verified live:

| resource | before | after |
|---|---|---|
| computers | 0 | **58** (58 distinct ids) |
| organizations | 0 | **7** |
| versions | 0 | **112** |
| tags | 0 | **1** |

`devices health --all-tenants` goes from empty to a per-organization online / stale / offline / isolated breakdown of all 58 devices, which is the offline-store feature working for the first time. A second sync over the same cache is idempotent.

## Shape of the change

`sync_post_list.go` is a novel file so regen-merge preserves it. The generated `sync.go` carries only a dispatch hook plus one added method on the `syncResource` client interface, since the client already exposed `PostWithHeaders`. An earlier attempt patched `extractID` in `sync.go`; that is the wrong layer for the typed-table paths, and was reverted.

Four tests covering the endpoint choice, the `childOrganizations` decision, pagination across the POST envelope, and the response-shape unwrapping.

## Reprint survival

New `skills/threatlocker/handfixes.json` with two entries, each verified to fail `check_handfixes.py` when reverted, and `spec_encode_followup` notes on both: the press should support POST-with-body list endpoints for sync, and the spec should carry `x-resource-id`, so neither stays hand-maintained.

## Not addressed

Being explicit so this is not mistaken for a complete fix. All four are documented on #208:

- **`computer-groups`** - consumed 3, stored 0, still `all_items_failed_id_extraction`. Its sync endpoint returns a different shape from the identically-pathed `computer-groups list`.
- **`reports`** - consumed 2, stored 0. The payload is `{category, reports}`, a grouped wrapper with no row-level key.
- **`online-devices`** - returns 0 rows; unclear whether genuinely empty or a shape problem.
- **`scheduled-actions`** - `HTTP 417 Invalid Scheduled Agent Action Type provided`; needs a parameter sync does not send. This is the one resource that reports `errored`.

## Separately worth its own issue

`doctor` tells the user to run `threatlocker-cli applications get` to verify their token, but that command takes its id via a required flag, so running it bare prints help and never touches the API. `isSuggestableReadLeaf` rejects positional params and probes the `Args` validator, but `applications get` has `Use: "get"` with no positional and enforces its requirement inside `RunE`, so no annotation exists for the check to see. The walk then takes the first alphabetical match. Working suggestions exist (`organizations list`, `computers list`, `reports list` all have zero required flags).

**That is fleet-wide**: the same `isSuggestableReadLeaf` is in 38 connectors' generated `doctor.go`. Not fixed here since it is not a threatlocker defect; happy to file it separately.

## Checklist

- [x] DCO sign-off on the commit.
- [x] No em-dashes in any added line.
- [x] Hand-edits recorded in `handfixes.json`.
- [x] `catalog.json` not hand-edited.
- [x] No credentials, personal paths, tenant identifiers or client names in committed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronization support for organizations and computers through their list endpoints.
  * Added paginated retrieval, response validation, duplicate filtering, and batch record updates.
  * Added progress and completion events for non-human-readable output.

* **Bug Fixes**
  * Corrected identifier handling for computer, organization, and dropdown records.
  * Improved synchronization state tracking and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->