### PR TITLE
chore(halopsa): re-stamp cli_hash_at_release to the content v0.2.4 actually shipped

### DIFF
--- a/tools/maintainer/skills.json
+++ b/tools/maintainer/skills.json
@@ -556,7 +556,7 @@
       "cli_hash": "sha256:7f32f6aa9fb0c80e2554a1a686885aef265e130a3d50e6fb8f45a998256a9f95",
       "template_version": 3,
       "version": "0.2.4",
-      "cli_hash_at_release": "sha256:378cfa62da341ea5fd4bdb9ac143dca8d8bb4c996ecb248085050eee0fc006dc",
+      "cli_hash_at_release": "sha256:0410ba0021238d41899af932e7a192d08cd11bfb183b4687c557c746bb9bdc9d",
       "has_video": true,
       "featured": 4,
       "install_auth_hint": "Then authenticate with `halopsa-cli auth login` (Configuration > Integrations > Halo PSA API in your tenant gives you the credentials)",


### PR DESCRIPTION
One-line correction. `skills.json` recorded a `cli_hash_at_release` for halopsa that never shipped, so `release_state` reported halopsa as `binary-pending` permanently.

## What happened

`release.py` stamps `cli_hash_at_release` at the moment it bumps the version. On #214 I ran the bump, then addressed a round of review findings, then committed. The version stayed correct at `0.2.4`, but the stamp captured the CLI as it stood mid-review rather than as it shipped.

```
stamped : sha256:378cfa62...   <- CLI mid-review
shipped : sha256:0410ba00...   <- CLI at the halopsa-v0.2.4 tag
```

The CLI tree at `main` is byte-identical to the `halopsa-v0.2.4` tag (`git diff HEAD halopsa-v0.2.4 -- skills/halopsa/cli` is empty), so the current hash is what shipped.

## Effect

```
before: halopsa   binary-pending   0.2.4   halopsa-v0.2.4   hash-match no
after:  halopsa   up-to-date       0.2.4   halopsa-v0.2.4   hash-match yes
```

Left alone, the release queue would keep offering halopsa as owing a binary release that has already been cut.

## Why it is a text replacement rather than a JSON rewrite

Round-tripping this file through `json.dump(..., ensure_ascii=False)` rewrites unrelated sibling entries, unescaping Pipedrive's `OÜ` to `OÜ`. That is a hygiene-guard failure with nothing to do with this change. The edit asserts a single occurrence of the old hash and replaces exactly that, so the diff is one line.

## Note for the future

The ordering trap is general: **stamp the version last, after the final code change.** Anything that edits the CLI after `release.py` runs silently invalidates the stamp, and the only symptom is a release-queue entry that never clears.