### PR TITLE
security(base): vet printing-press 4.30.2 generated-code findings + allowlist jsonschema/v6

### DIFF
--- a/tools/maintainer/dep_allowlist.json
+++ b/tools/maintainer/dep_allowlist.json
@@ -45,6 +45,7 @@
     "github.com/quic-go/quic-go",
     "github.com/refraction-networking/utls",
     "github.com/remyoudompheng/bigfft",
+    "github.com/santhosh-tekuri/jsonschema/v6",
     "github.com/spf13/cast",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",

--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -245,6 +245,46 @@
       "file": "cli/internal/learn/journal.go",
       "rule": "G117",
       "reason": "FLEET (generated). The marshaled struct field SessionKey is a local journal SESSION IDENTIFIER (JournalSessionKey()), not a credential; gosec G117 name-matches the field name against a secret pattern. No secret is serialized."
+    },
+    {
+      "file": "cli/internal/platform/gate.go",
+      "rule": "G101",
+      "reason": "FLEET (generated, printing-press 4.30.2+). The flagged line is the GateOutcome status enum (GateInvalidCredentials = \"invalid_credentials\"); it is a result label, not a credential. No secret material is present in the file."
+    },
+    {
+      "file": "cli/internal/platform/migration.go",
+      "rule": "G202",
+      "reason": "FLEET (generated, printing-press 4.30.2+). SQLite's VACUUM INTO does not accept a bound parameter for its destination, so the path must be concatenated. The value is an internally-derived store path (never user SQL), single-quotes are escaped by doubling, the parent dir is created 0700 and the result is chmod 0600. No injection surface."
+    },
+    {
+      "file": "cli/internal/platform/profile.go",
+      "rule": "G304",
+      "reason": "FLEET (generated, printing-press 4.30.2+). Reads the CLI's own profile file from a path the CLI derives from its config/XDG dirs, matching the already-vetted fleet entries for cli/internal/cliutil/paths.go and cli/internal/config/config.go."
+    },
+    {
+      "file": "cli/internal/platform/ratelimit.go",
+      "rule": "G304",
+      "reason": "FLEET (generated, printing-press 4.30.2+). Reads the CLI's own rate-limit state file from a CLI-derived cache path; same class as the vetted cli/internal/cache/cache.go entry."
+    },
+    {
+      "file": "cli/internal/store/store.go",
+      "rule": "G304",
+      "reason": "FLEET (generated). Opens the CLI's own SQLite store at a CLI-derived path (XDG data dir or --db), not attacker-controlled input; same class as the vetted cli/internal/cli/export.go and import.go entries."
+    },
+    {
+      "file": "cli/internal/platform/profile.go",
+      "rule": "G302",
+      "reason": "FLEET (generated, printing-press 4.30.2+). The 0700 mode is applied to a DIRECTORY (os.MkdirAll/os.Chmod on filepath.Dir); 0700 is the correct restrictive mode for a directory, since 0600 would make it non-traversable. The profile file itself is written 0600."
+    },
+    {
+      "file": "cli/internal/client/client.go",
+      "rule": "G302",
+      "reason": "FLEET (generated). The 0700 mode is applied to the cache DIRECTORY; the cache file itself is written with os.WriteFile(..., 0o600) on the following line."
+    },
+    {
+      "file": "cli/internal/cliutil/testenv/sandbox_unix.go",
+      "rule": "G302",
+      "reason": "FLEET (generated, printing-press 4.30.2+). Test-only helper (takes *testing.T) that chmods a temp sandbox DIRECTORY to 0700; never compiled into a shipped binary."
     }
   ]
 }


### PR DESCRIPTION
Base-policy PR. **Merge this first** — the threatlocker reprint PR (#208 fix) stays red until it lands, because CI reads `security_suppressions.json` and `dep_allowlist.json` from the trusted base, never from the connector PR.

## What this is

printing-press **4.30.2** introduces `internal/platform/*` and `internal/cliutil/testenv/*`, bumps `mcp-go`, and adds new G304/G302 sites in already-vetted generated files. threatlocker is the first connector reprinted onto 4.30.2; every subsequent one carries these byte-identically, so the suppressions are **slug-relative (fleet-wide)**, not scoped to one skill.

## The 8 gosec entries — each read, not pattern-matched

| Rule | File | Why it is a false positive |
|---|---|---|
| G101 | `platform/gate.go` | The flagged line is the `GateOutcome` status enum (`GateInvalidCredentials = "invalid_credentials"`). A result label, no secret material. |
| G202 | `platform/migration.go` | SQLite's `VACUUM INTO` accepts no bound parameter for its destination, so the path must be concatenated. Value is internally derived (never user SQL), single-quotes escaped by doubling, parent dir 0700, result chmod 0600. |
| G304 | `platform/profile.go`, `platform/ratelimit.go`, `store/store.go` | Open the CLI's own files at CLI-derived config/cache/data paths. Same class already vetted for `cliutil/paths.go`, `config/config.go`, `cache/cache.go`. |
| G302 | `platform/profile.go`, `client/client.go`, `testenv/sandbox_unix.go` | 0700 is applied to **directories**, where it is the correct restrictive mode (0600 would make them non-traversable). The data files themselves are written 0600; the testenv helper is test-only and never ships in a binary. |

## The dependency

`github.com/santhosh-tekuri/jsonschema/v6 v6.0.2` — indirect, reached only via `cmd/<slug>-mcp -> mark3labs/mcp-go/server -> jsonschema/v6` (`go mod why` confirms the single path). mcp-go is already allowlisted. It is the long-standing, widely-used Go JSON Schema validator, not a typosquat.

## Receipt

With this branch as `--policy-base`, threatlocker reports **0 P1**:

```
[pass] threatlocker (full): 0 P1 / 6 findings
```

Remaining findings are pre-existing P2 classes (plaintext-http matches on scheme-checking code, G104 unhandled errors in generated code) and do not gate.

Note: a genuine finding in the same run was **fixed, not suppressed** — `golang.org/x/text` was bumped 0.14.0 to 0.41.0 in the connector PR to clear GO-2026-5970 (fixed in 0.39.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7tMKDKvTPcnWNpc3DbbL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated approved dependency and security configuration records.
  * Documented reviewed security findings and their accepted safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->