### PR TITLE
fix(ci): unblock outside contributors - DCO, UTF-8 on Windows, AEO on markdown-only skills

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -97,7 +97,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add catalog.json README.md docs/_data/catalog.json docs/skills/ docs/llms.txt docs/llms-full.txt docs/_data/pending.json
-          git commit -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+          git commit -s -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
           # Push with a self-heal loop: the concurrency group serializes the
           # common case, but a peer commit can still land between our checkout
           # and our push (e.g. a release_batch push). Derived files are
@@ -123,7 +123,7 @@ jobs:
               exit 0
             fi
             git add catalog.json README.md docs/_data/catalog.json docs/skills/ docs/llms.txt docs/llms-full.txt docs/_data/pending.json
-            git commit -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+            git commit -s -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
           done
           echo "::error::could not push derived files after 5 attempts"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Vocabulary contract (banned + required terms)
         run: python3 tools/maintainer/check_vocabulary.py
 
+      - name: AEO contract (answer-first, unique titles, connector formula)
+        run: python3 tools/maintainer/check_aeo.py
+
       - name: Video assets (skills that opt in via has_video)
         run: python3 tools/maintainer/check_video_assets.py
 

--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -188,7 +188,7 @@ jobs:
             echo "No changes to commit (already live-verified?)."
             exit 0
           fi
-          git commit -m "badge: $SLUG live-verified via #$ISSUE"
+          git commit -s -m "badge: $SLUG live-verified via #$ISSUE"
           # Self-heal push loop: the concurrency group serializes the common
           # case, but a peer commit (release_batch push, catalog bot) can land
           # between our checkout and our push. The badge flip is recomputable,
@@ -218,7 +218,7 @@ jobs:
               echo "now in sync after peer commit - nothing left to push"
               exit 0
             fi
-            git commit -m "badge: $SLUG live-verified via #$ISSUE"
+            git commit -s -m "badge: $SLUG live-verified via #$ISSUE"
           done
           echo "::error::could not push the badge flip after 5 attempts"
           exit 1

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -56,7 +56,7 @@ def _plugin_version(skill_dir: Path) -> str:
     pj = skill_dir / ".claude-plugin" / "plugin.json"
     if pj.exists():
         try:
-            return json.loads(pj.read_text()).get("version", "0.0.0")
+            return json.loads(pj.read_text(encoding="utf-8")).get("version", "0.0.0")
         except (OSError, ValueError):
             return "0.0.0"
     return "0.0.0"
@@ -85,7 +85,7 @@ def build_entry(skill_dir: Path) -> dict:
         manifest_path = skill_dir / "manifest.json"
         if not manifest_path.exists():
             raise SystemExit(f"missing manifest.json for skill {slug}")
-        manifest = json.loads(manifest_path.read_text())
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         version = manifest.get("version", "0.0.0")
 
     entry = {
@@ -384,7 +384,7 @@ def render_agent_can_do() -> str:
                 f"skills/{meta.get('source_dir', slug)}/page.json missing - "
                 "every connector needs one for the agent-can-do block."
             )
-        outcomes = json.loads(page_path.read_text()).get("outcomes", [])
+        outcomes = json.loads(page_path.read_text(encoding="utf-8")).get("outcomes", [])
         if not outcomes:
             raise SystemExit(f"page.json for '{slug}' has no outcomes.")
         for o in outcomes[:per_skill]:
@@ -461,7 +461,7 @@ def main() -> int:
     generated_at = dt.date.today().isoformat()
     if CATALOG.exists():
         try:
-            prev = json.loads(CATALOG.read_text())
+            prev = json.loads(CATALOG.read_text(encoding="utf-8"))
             if prev.get("schema_version") == 1 and prev.get("skills") == skills:
                 generated_at = prev.get("generated_at", generated_at)
         except Exception:
@@ -472,12 +472,12 @@ def main() -> int:
         "generated_at": generated_at,
         "skills": skills,
     }
-    CATALOG.write_text(json.dumps(catalog, indent=2) + "\n")
+    CATALOG.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
 
     DOCS_CATALOG.parent.mkdir(parents=True, exist_ok=True)
-    DOCS_CATALOG.write_text(json.dumps(build_docs_catalog(skills), indent=2) + "\n")
+    DOCS_CATALOG.write_text(json.dumps(build_docs_catalog(skills), indent=2) + "\n", encoding="utf-8")
 
-    readme = README.read_text()
+    readme = README.read_text(encoding="utf-8")
     new_readme = replace_block(
         readme,
         "<!-- catalog:start -->",
@@ -502,15 +502,15 @@ def main() -> int:
         f"img.shields.io/badge/skills-{connector_count}-green",
         new_readme,
     )
-    README.write_text(new_readme)
+    README.write_text(new_readme, encoding="utf-8")
 
     # Regenerate the it-works issue form's skill dropdown so a reporter can pick
     # the exact connector (not be forced into "other"); the catalog.yml drift
     # gate keeps it in lockstep with the registry. Skipped gracefully if the
     # form is absent (e.g. a partial checkout).
     if IT_WORKS_FORM.exists():
-        form = IT_WORKS_FORM.read_text()
-        IT_WORKS_FORM.write_text(render_it_works_form(form, skills))
+        form = IT_WORKS_FORM.read_text(encoding="utf-8")
+        IT_WORKS_FORM.write_text(render_it_works_form(form, skills), encoding="utf-8")
 
     # Re-render every connector's docs page in the same pass, so a registry
     # change (live-verified flip, display rename) or a page.json edit shows up

--- a/tools/maintainer/build-llms.py
+++ b/tools/maintainer/build-llms.py
@@ -155,7 +155,7 @@ def load_page_data(slug: str, meta: dict, cat: dict) -> dict:
         "governance_summary": "",
     }
     if page_json.exists():
-        pj = json.loads(page_json.read_text())
+        pj = json.loads(page_json.read_text(encoding="utf-8"))
         # page.json's real keys are outcome_intro / question / command (the
         # schema render_docs_page.py consumes). The old q/cmd/intro reads
         # silently returned empty strings and the fallback parser papered
@@ -172,7 +172,7 @@ def load_page_data(slug: str, meta: dict, cat: dict) -> dict:
     # Fallback: parse the rendered docs page.
     md = DOCS / "skills" / f"{slug}.md"
     if md.exists():
-        fm, body = split_front_matter(md.read_text())
+        fm, body = split_front_matter(md.read_text(encoding="utf-8"))
         # Intro = first prose paragraph after the H1 + banner blockquote + the
         # badge notice + the vocab one-liner.
         data["intro"] = first_intro_paragraph(body)
@@ -246,7 +246,7 @@ def why_pillars() -> list[tuple[str, str]]:
     md = DOCS / "why-msp-skills.md"
     if not md.exists():
         return []
-    _, body = split_front_matter(md.read_text())
+    _, body = split_front_matter(md.read_text(encoding="utf-8"))
     out: list[tuple[str, str]] = []
     for m in re.finditer(r"^##\s+(.+?)\s*$(.*?)(?=^##\s|\Z)", body, re.DOTALL | re.MULTILINE):
         head = strip_md(m.group(1))
@@ -266,7 +266,7 @@ def glossary_definition() -> str:
     md = DOCS / "what-is-an-mcp-server.md"
     if not md.exists():
         return ""
-    _, body = split_front_matter(md.read_text())
+    _, body = split_front_matter(md.read_text(encoding="utf-8"))
     for b in re.split(r"\n\s*\n", body):
         s = b.strip()
         if not s or s.startswith(("#", ">", "<", "{%", "|")):
@@ -386,7 +386,7 @@ def render_full(pages: list[dict]) -> str:
 
 
 def main() -> int:
-    catalog = json.loads(CATALOG.read_text())
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     cat_by_slug = {c["name"]: c for c in catalog.get("skills", [])}
     meta = registry.skills()  # sorted by slug
 

--- a/tools/maintainer/check_aeo.py
+++ b/tools/maintainer/check_aeo.py
@@ -33,6 +33,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/maintainer module)
+
 ROOT = Path(__file__).resolve().parent.parent.parent
 DOCS = ROOT / "docs"
 
@@ -190,14 +193,22 @@ def main() -> int:
 
         permalink = fm.get("permalink", "")
 
-        # A GENERATED per-connector page (the formula assertions 3 + 4 apply only
-        # to these). The hand-authored hub at docs/skills/index.md sits in the
-        # same directory but carries no skill_name, so it is NOT a connector page.
-        is_connector_page = md.parent.name == "skills" and "skill_name" in fm
+        # A GENERATED per-skill page. The hand-authored hub at docs/skills/index.md
+        # sits in the same directory but carries no skill_name, so it is not one.
+        skill_name = fm.get("skill_name", "").strip()
+        is_skill_page = md.parent.name == "skills" and bool(skill_name)
+
+        # The formula assertions (3 + 4) say the page must be titled and must open
+        # as "there is an MCP server for <vendor>". That describes a VENDOR
+        # CONNECTOR. A markdown-only skill (connect-tool, the concierge) is not an
+        # MCP server for a vendor, so the formula does not describe it - asserting
+        # it anyway just makes an honest page permanently red. Uniqueness
+        # (assertion 2) and the answer-first word limit still apply to every page.
+        is_connector_page = is_skill_page and not registry.is_markdown_only(skill_name)
 
         # --- Assertion 2: unique title + description for the required pages. ---
         require_unique = (
-            is_connector_page or permalink in REQUIRE_TITLE_DESC_PERMALINKS
+            is_skill_page or permalink in REQUIRE_TITLE_DESC_PERMALINKS
         )
         if require_unique:
             title = fm.get("title", "").strip()

--- a/tools/maintainer/check_dco.sh
+++ b/tools/maintainer/check_dco.sh
@@ -10,28 +10,49 @@
 set -uo pipefail
 cd "$(dirname "$0")/../.." || exit 1
 
+# Check only the commits THIS branch introduces - never one already on main.
+# A contributor who rebases onto a newer main pulls in our own bot commits
+# ("chore: regenerate derived files [bot]"), which carry no sign-off. Failing
+# someone for commits they did not write is a wall, not a gate: excluding
+# origin/main as well as the base sha is what keeps the check about their work.
+excludes=()
+if git rev-parse --verify -q origin/main >/dev/null; then
+  excludes+=(origin/main)
+fi
+
 if [ -n "${BASE:-}" ] && [ -n "${HEAD:-}" ]; then
-  range="${BASE}..${HEAD}"
+  tip="${HEAD}"
+  excludes+=("${BASE}")
 else
-  if git rev-parse --verify -q origin/main >/dev/null; then
-    range="origin/main..HEAD"
-  else
-    echo "No range given and no origin/main; checking HEAD only."
-    range="HEAD~1..HEAD 2>/dev/null || HEAD"
+  tip="HEAD"
+  if [ ${#excludes[@]} -eq 0 ]; then
+    echo "No range given and no origin/main; nothing to check."
+    exit 0
   fi
 fi
 
 fail=0
-# List commit hashes in the range (newest first).
-commits="$(git rev-list "${range}" 2>/dev/null || git rev-list HEAD)"
+# Commit hashes reachable from the tip but not from main or the base (newest first).
+commits="$(git rev-list "${tip}" --not "${excludes[@]}" 2>/dev/null)"
 if [ -z "${commits}" ]; then
-  echo "No commits in range ${range}; nothing to check."
+  echo "No new commits to check (nothing here that is not already on main)."
   exit 0
 fi
+
+# Our own CI bot. catalog.yml / live-verified.yml auto-commit regenerated derived
+# files, and those workflows also run on a CONTRIBUTOR'S FORK - so their branch can
+# carry bot commits they never wrote. Both workflows now sign off (`git commit -s`),
+# but branches opened before that fix still carry unsigned ones. DCO is a licensing
+# assertion about human contributions, not a security control, so exempting the bot
+# costs nothing and stops us failing people for our own commits.
+BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 
 for c in ${commits}; do
   # Skip merge commits (two-or-more parents).
   if [ "$(git rev-list --parents -n 1 "$c" | wc -w)" -gt 2 ]; then
+    continue
+  fi
+  if [ "$(git log -1 --format='%ae' "$c")" = "${BOT_EMAIL}" ]; then
     continue
   fi
   if ! git log -1 --format='%B' "$c" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
@@ -42,8 +63,17 @@ for c in ${commits}; do
 done
 
 if [ "$fail" -eq 0 ]; then
-  echo "DCO check passed for range ${range}."
+  echo "DCO check passed."
 else
-  echo "DCO check FAILED. Sign commits with 'git commit -s'." >&2
+  {
+    echo ""
+    echo "Sign-off missing on the commits listed above."
+    echo ""
+    echo "A sign-off is one line git adds for you. It says the code is yours to give."
+    echo "For your next commit:   git commit -s -m \"your message\""
+    echo "To fix the ones above:  git rebase --signoff origin/main   (then git push --force-with-lease)"
+    echo ""
+    echo "That is all this check wants. Nothing else about your contribution is in question."
+  } >&2
 fi
 exit "$fail"

--- a/tools/maintainer/check_registry_state.py
+++ b/tools/maintainer/check_registry_state.py
@@ -32,7 +32,7 @@ REGISTRY_REF = "origin/main:tools/maintainer/skills.json"
 
 def load_current() -> dict:
     try:
-        return json.loads(REGISTRY.read_text())["skills"]
+        return json.loads(REGISTRY.read_text(encoding="utf-8"))["skills"]
     except (OSError, json.JSONDecodeError, KeyError) as e:
         print(f"check_registry_state: cannot read {REGISTRY}: {e}")
         sys.exit(2)

--- a/tools/maintainer/check_release_contract.py
+++ b/tools/maintainer/check_release_contract.py
@@ -72,8 +72,8 @@ def main() -> int:
             continue
         checked += 1
         d = registry.skill_path(slug)
-        sh = (d / "install.sh").read_text()
-        ps = (d / "install.ps1").read_text()
+        sh = (d / "install.sh").read_text(encoding="utf-8")
+        ps = (d / "install.ps1").read_text(encoding="utf-8")
 
         sh_cli, sh_mcp = _sh_var(sh, "CLI_BIN"), _sh_var(sh, "MCP_BIN")
         ps_cli = (_ps_var(ps, "CliBin") or "").removesuffix(".exe")

--- a/tools/maintainer/gen_governance.py
+++ b/tools/maintainer/gen_governance.py
@@ -72,7 +72,7 @@ def auth_env(slug: str) -> list[str]:
     if not mf.exists():
         return []
     try:
-        m = json.loads(mf.read_text())
+        m = json.loads(mf.read_text(encoding="utf-8"))
         env = m.get("server", {}).get("mcp_config", {}).get("env", {})
         return sorted(env.keys())
     except Exception:
@@ -81,7 +81,7 @@ def auth_env(slug: str) -> list[str]:
 
 def has_dry_run(slug: str) -> bool:
     root = SKILLS_DIR / slug / "cli" / "internal" / "cli" / "root.go"
-    return root.exists() and bool(re.search(r"dry-run", root.read_text(), re.IGNORECASE))
+    return root.exists() and bool(re.search(r"dry-run", root.read_text(encoding="utf-8"), re.IGNORECASE))
 
 
 def sample(items: list[str], n: int = 8) -> str:

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -30,7 +30,7 @@ TARGETS = [
 
 
 def load() -> dict:
-    return json.loads(REGISTRY.read_text())
+    return json.loads(REGISTRY.read_text(encoding="utf-8"))
 
 
 def owner_repo() -> tuple[str, str]:
@@ -84,7 +84,7 @@ def slug_for_dir(dirname: str) -> str:
 def module_path(slug: str) -> str:
     """Read the Go module path from skills/<slug>/cli/go.mod."""
     gomod = SKILLS_DIR / slug / "cli" / "go.mod"
-    for line in gomod.read_text().splitlines():
+    for line in gomod.read_text(encoding="utf-8").splitlines():
         if line.startswith("module "):
             return line.split(None, 1)[1].strip()
     raise SystemExit(f"{slug}: no module line in {gomod}")

--- a/tools/maintainer/render_docs_page.py
+++ b/tools/maintainer/render_docs_page.py
@@ -96,7 +96,7 @@ def render_page(slug: str) -> Path:
             f"render_docs_page: {page_path} missing - every connector skill "
             "carries a page.json (the publish skill scaffolds a stub)"
         )
-    page = json.loads(page_path.read_text())
+    page = json.loads(page_path.read_text(encoding="utf-8"))
     vendor = entry.get("vendor", slug)
     display = entry.get("display_name", vendor)
     owner = entry.get("vendor_trademark_owner", vendor)
@@ -105,7 +105,7 @@ def render_page(slug: str) -> Path:
     desc = ""
     mf = skill_dir / "manifest.json"
     if mf.exists():
-        desc = json.loads(mf.read_text()).get("description", "")
+        desc = json.loads(mf.read_text(encoding="utf-8")).get("description", "")
     lv = entry.get("live_verified") or {}
     if lv.get("status") == "live-verified":
         verified_by = lv.get("verified_by") or "a real MSP"
@@ -308,7 +308,7 @@ Maintained by [Servosity](https://www.servosity.com) for the MSP community. Apac
 """
     out = ROOT / "docs" / "skills" / f"{slug}.md"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(text)
+    out.write_text(text, encoding="utf-8")
     return out
 
 


### PR DESCRIPTION
Three CI fixes that outside contributors hit before they hit anything about their own work. Found while working #224 (cork connector) and #206 (grab-cookie skill), which are both blocked on these.

## 1. We were failing contributors for our own bot commits

`catalog.yml` auto-commits regenerated derived files as `github-actions[bot]`, unsigned. That workflow **also runs on a contributor's fork**, so their branch carries bot commits they never wrote - and the DCO gate then failed their PR for them. #224's only `guards` failure was two of our commits.

- `catalog.yml` + `live-verified.yml` now `git commit -s` (the source fix).
- The gate exempts the CI bot's author email, so branches opened before that fix stop failing. DCO is a licensing assertion about human contributions, not a security control.
- The range now excludes anything already on `origin/main`, so rebasing onto a newer main cannot drag main's history into the check.
- The failure message says what a sign-off is and gives the one command that fixes an existing branch.

Verified four ways: unsigned human commit fails, unsigned bot commit passes, bot + unsigned human still fails, signed human commit passes. #224's real range goes from 2 failures to green.

## 2. The maintainer tools crashed on Windows

Every `read_text()`/`write_text()` in `tools/maintainer` took the platform default encoding. On Windows that is cp1252, so `build-catalog.py` wrote `catalog.json` correctly and then died with `UnicodeDecodeError`. The contributor on #206 reported exactly this, could not regenerate the catalog, and their PR went red on the drift gate as a result.

28 call sites across 7 files now pass `encoding="utf-8"`. Output is byte-identical - `build-catalog.py` and `build-llms.py` regenerate with zero drift.

Two files deliberately excluded: `check_security_gate.py` needs the same fix but is CODEOWNERS-gated and `security-gate.yml` hard-fails any PR that touches it, so it ships separately. `release.py`'s `write_text` is `Planner.write_text(path, text, summary)`, not pathlib, and takes no `encoding` argument.

## 3. `check_aeo` was red on main and nobody could see it

It asserts a skill page is titled `... MCP Server - Free, Open Source, Runs Locally | MSP Skills` and opens `Yes - there is an MCP server for ...`. That describes a vendor connector. `connect-tool` is not an MCP server for a vendor, so the formula never fit it - and the gate has been failing on `docs/skills/connect-tool.md` on main this whole time.

It was never wired into CI, only into `verify_all.sh`, so main stayed red silently and a contributor on #224 had to discover it and explain it was not their fault.

The formula assertions now apply only to non-markdown-only skills. Unique title + description and the answer-first word limit still apply to every skill page. Now wired into the `guards` job - fixed first, so CI goes green on the same commit that starts enforcing it.

Verified both directions: green on the current tree, still red when a real connector page's title formula is broken.

## Not in this PR

The security gate's markdown-only lane (the 4 phantom P1s that block #206) - separate PR, CODEOWNERS-gated.