### PR TITLE
security(unifi-network): allowlist two vetted G304 false-positives

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -285,6 +285,16 @@
       "file": "cli/internal/cliutil/testenv/sandbox_unix.go",
       "rule": "G302",
       "reason": "FLEET (generated, printing-press 4.30.2+). Test-only helper (takes *testing.T) that chmods a temp sandbox DIRECTORY to 0700; never compiled into a shipped binary."
+    },
+    {
+      "file": "skills/unifi-network/cli/internal/cli/novel_common.go",
+      "rule": "G304",
+      "reason": "Reads drift's own snapshot JSON under the CLI's resolved state dir (novel-snapshots/, created 0700). Path is filepath.Join(stateDir, '<table>-<siteID>.json') where table comes from an internal allowlist and siteID is returned by resolveSiteIDLocal (novel_common.go:140), which matches the --site flag against sites already present in the local SQLite mirror and returns the gateway's own site id - the raw flag value never reaches the path. Local-user file under their own home; no privilege boundary crossed. Annotated //nolint:gosec at the call site."
+    },
+    {
+      "file": "skills/unifi-network/cli/internal/cli/newcomer.go",
+      "rule": "G304",
+      "reason": "Same pattern as the novel_common.go G304 entry: reads newcomer's own first-seen JSON at filepath.Join(stateDir, 'newcomer-first-seen-<siteID>.json'), siteID resolved from the synced mirror via resolveSiteIDLocal, not raw user input. Local-user file under their own home. Annotated //nolint:gosec at the call site."
     }
   ]
 }


### PR DESCRIPTION
Base-policy PR for the incoming `unifi-network` connector. **Merge this before the skill PR** — `security-gate.yml` reads `security_suppressions.json` from the trusted base (`--policy-base $BASE_SHA`), so an entry added inline to a skill PR is ignored and that PR's gate stays red.

Two `gosec` G304 ("potential file inclusion via variable") findings, both vetted as false positives.

## What the code does

Both call sites read a JSON file the connector wrote itself, under the CLI's own resolved state directory (`novel-snapshots/`, created `0700`):

- `cli/internal/cli/novel_common.go:225` — `drift`'s per-site config snapshot, at `filepath.Join(stateDir, "<table>-<siteID>.json")`
- `cli/internal/cli/newcomer.go:36` — `newcomer`'s first-seen record, at `filepath.Join(stateDir, "newcomer-first-seen-<siteID>.json")`

## Why they are safe

`table` comes from an internal allowlist. `siteID` is **not** the raw `--site` flag: `resolveSiteIDLocal` (`novel_common.go:140`) queries `SELECT id, data FROM resources WHERE resource_type = 'sites'` and matches the flag value against sites already synced into the local SQLite mirror, returning the gateway's own site id. A traversal string passed to `--site` matches nothing and errors out before any path is built.

Both call sites already carry a `//nolint:gosec` annotation with this rationale; the gate does not honor inline annotations by design, hence the base-policy entry.

No privilege boundary is crossed either way — these are files under the invoking user's own home directory, read by a CLI that user is running.

## Effect

With these two entries on the base, `check_security_gate.py --slug unifi-network` goes from `[BLOCK] 2 P1 / 8 findings` to `[pass] 0 P1 / 6 findings` — the same six P2s (`plaintext-http` ×2, `G104` ×4) that the already-green `threatlocker` connector carries from the same generated files.

Diff is +10 lines, appended; a JSON round-trip check confirms no existing entry was reordered or mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN2oRrdN4wGier4kws9JUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added documented security suppressions for approved local state file access in the UniFi Network connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->