### PR TITLE
fix(ci): make the gitleaks allowlist cross-platform by matching the fixture literal, not its path

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,7 +6,12 @@
 useDefault = true
 
 [allowlist]
-description = "Synthetic JWT fixtures in the vendored CLI tests (not credentials; built from repeated characters, see the test comments)."
-paths = [
-  '''skills/.*/cli/internal/cliutil/jwtshape_test\.go''',
+description = "The synthetic RS256 JWT header in the vendored cliutil/jwtshape_test.go fixtures (not a credential; the payload/signature are strings.Repeat, see the test comments)."
+# Content match, not a path match: gitleaks reports platform-native paths on
+# --no-git scans, so a path pattern either breaks on Windows ('/'-only, #235) or,
+# with [/\\], can be spoofed on Linux by a filename containing literal
+# backslashes. The exact public literal can never equal a real secret.
+regexTarget = "secret"
+regexes = [
+  '''^eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFvNi1PYzAyQlZHTF9GbnBDeE5JMiJ9\.$''',
 ]


### PR DESCRIPTION
Fixes #235 — reported by @geekbrownbear, found while getting #224 green.

## Problem

The gitleaks allowlist suppressed the synthetic JWT fixtures (`skills/*/cli/internal/cliutil/jwtshape_test.go`) by a forward-slash-only path regex. gitleaks reports platform-native paths on `--no-git` scans, so on Windows the pattern never matched: a local run showed one `generic-api-key` finding per connector (61 on current main) instead of CI's result, burying the real signal.

## Why not the both-separator path pattern

The issue's suggested `[/\\]` variant fixes Windows but was rejected by adversarial review: on Linux, backslash is a valid filename character, so a contributor could commit a file literally named `skills\evil\cli\internal\cliutil\jwtshape_test.go` and CI would suppress real secrets inside it. Any path pattern that matches Windows-native paths carries that ambiguity.

## Fix

All 61 findings share exactly one captured secret — the synthetic RS256 JWT header literal (the payload/signature are `strings.Repeat`). The allowlist now matches that literal by content (`regexTarget = "secret"`, fully anchored) instead of by path. This is:

- **separator-independent** — the Windows local run now matches CI;
- **un-spoofable** — the only exempt value is already-public synthetic metadata, never credential material;
- **strictly tighter** — a real secret planted *inside* a fixture file is now flagged, where the old path allowlist suppressed it.

## Receipts (CI-pinned gitleaks 8.18.4, local)

| check | result |
| --- | --- |
| clean tree scan | 0 findings |
| no-allowlist enumeration | 61 findings, 1 distinct secret (the fixture literal) |
| planted AKIA key in a backslash-named file | flagged |
| planted AKIA key inside a real `jwtshape_test.go` | flagged |
| codex adversarial review (round 2) | PASS |

Windows closure is the reporter's re-test, invited on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rxj5F2GZiEjg6gqhzBBJ4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret scanning rules to recognize the synthetic JWT header by its content.
  * Improved cross-platform path handling and clarified protections against file path spoofing.
  * Added an exact match for the public JWT header literal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->