### PR TITLE
docs(unifi-network): the installer does not register the skill

### DIFF
--- a/skills/unifi-network/guide.md
+++ b/skills/unifi-network/guide.md
@@ -6,7 +6,7 @@ unifi-network-cli wraps the full local Network integration API (devices, clients
 
 ## Install
 
-This CLI ships as a Claude Code Skill and MCP server in [Servosity/msp-skills](https://github.com/Servosity/msp-skills). The installer places the `unifi-network-cli` and `unifi-network-mcp` binaries and registers the skill with your agent:
+This CLI ships as a Claude Code Skill and MCP server in [Servosity/msp-skills](https://github.com/Servosity/msp-skills). The installer places the `unifi-network-cli` and `unifi-network-mcp` binaries on your PATH. Registering the skill with your agent, and wiring `unifi-network-mcp` into Claude Desktop or ChatGPT, are separate steps - see the [README](./README.md) install table and [mcp-install.md](./mcp-install.md):
 
 1. macOS / Linux:
    ```bash


### PR DESCRIPTION
One sentence. `guide.md` said the installer "places the binaries and registers the skill with your agent."

It does not. `install.sh` downloads two binaries into `~/.local/bin`, chmods them, clears the macOS quarantine xattr, and prints two doc links; `install.ps1` adds a user-PATH append. Nothing registers anything — which the skill's own README already reflects, listing registration as a separate per-agent step.

Found by an adversarial review of the cork PR (#224), where the same sentence had been copied verbatim. Fixing it at the source so the next connector does not inherit it.

Docs-only: no tag, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)