### PR TITLE
security(gate): suppress the 4.30.3 gosec G101 name-based FP in generated doctor.go

### DIFF
--- a/tools/maintainer/security_suppressions.json
+++ b/tools/maintainer/security_suppressions.json
@@ -300,6 +300,11 @@
       "file": "skills/connect-tool/bootstrap.ps1",
       "rule": "script-powershell-rce",
       "reason": "The `iex` match is inside a SINGLE-QUOTED STRING LITERAL that bootstrap.ps1 appends to its missing-dependency list and PRINTS to the user: 'uv  powershell -ExecutionPolicy ByPass -c \"irm https://astral.sh/uv/install.ps1 | iex\"'. It is the vendor's documented install command shown as advice; bootstrap.ps1 never executes it. Whole-line comments are already stripped before scanning, but a string literal is not a comment. Vetted 2026-08-14."
+    },
+    {
+      "file": "cli/internal/cli/doctor.go",
+      "rule": "G101",
+      "reason": "FLEET (generated, printing-press 4.30.3+). gosec G101 HIGH-severity / LOW-confidence false-positive on the identifier NAME in `credentialRemediation := \"run auth set-token or auth logout\"` inside collectCredentialsLocationReport: the literal is the doctor command's user-facing REMEDIATION HINT (it names two of the CLI's own subcommands), not credential material. Introduced by press 4.30.3 (#4198 'align auth set-token references with command surface'), so it will surface on every connector reprinted at 4.30.3 or later. Same name-based FP class as the existing auth.go / client.go `tokenURL` entries (#109) and internal/platform/gate.go GateInvalidCredentials. Confirmed with `gosec -fmt json -include=G101 ./...` in skills/servosity/cli: 2 issues, both HIGH/LOW, both name-based. Surfaced by the servosity 4.30.3 reprint."
     }
   ]
 }


### PR DESCRIPTION
## What

One base-owned suppression entry for a gosec `G101` false positive that printing-press **4.30.3** introduces into every generated connector.

## The finding

4.30.3 ([#4198](https://github.com/mvanhorn/cli-printing-press/issues/4198), "align auth set-token references with command surface") added this line to the generated `collectCredentialsLocationReport` in `cli/internal/cli/doctor.go`:

```go
credentialRemediation := "run auth set-token or auth logout"
```

gosec `G101` fires **HIGH severity / LOW confidence** on the *identifier name* (`credential...`). The literal is the `doctor` command's user-facing remediation hint, naming two of the CLI's own subcommands. There is no credential material in the file.

## Why fleet-scoped

The path is slug-relative (`cli/internal/cli/doctor.go`), because the file is byte-identical in every connector printed at 4.30.3 or later. This is the same scoping the existing `cli/internal/cli/auth.go` and `cli/internal/client/client.go` `tokenURL` entries use, and the same FP class as `cli/internal/platform/gate.go` `GateInvalidCredentials`.

## Receipt

In `skills/servosity/cli`:

```
gosec -fmt json -include=G101 ./...
```

reports exactly 2 issues, both `HIGH`/`LOW` and both name-based:

| file | line | identifier |
| --- | --- | --- |
| `internal/platform/gate.go` | 22 | `GateInvalidCredentials` (already suppressed) |
| `internal/cli/doctor.go` | 477 | `credentialRemediation` (this entry) |

`check_security_gate.py --slug servosity` goes from `[BLOCK] 1 P1 / 9 findings` to `0 P1` with this entry in place; the remaining 8 are P2.

## Why a separate PR

`tools/maintainer/security_suppressions.json` is CODEOWNERS-gated to `@Servosity` and the security-gate workflow fails any PR that edits it, so a suppression can never be self-granted from the diff that needs it. This PR touches no `skills/`, so its own gate scope is empty.

The servosity 4.30.3 reprint PR stays red on the security gate until this merges; it then rebases onto main and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
