### PR TITLE
fix(mcp): stop the tenant gate default-denying every non-mirror tool (#249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: No default-denied MCP tool (this skill)
         # Hard gate: boot this skill's MCP server over stdio and call the tools
         # the tenant-gate middleware wraps in-process, asserting none answers a
-        # gate refusal. Issue #249 shipped two connectors where 6 tools each
+        # gate refusal. Issue #249 shipped three connectors where 6 tools each
         # were dead while build, vet, go test, the security gate and tools/list
         # were all green - only tools/call could see it. Needs no credentials
         # and runs in about a second on a warm build cache.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,12 @@ jobs:
         # files (go test stays green); this turns that into a loud failure.
         # No-op for skills without a ledger. See docs/reprint-survival.md.
         run: python3 tools/maintainer/check_handfixes.py --slug ${{ matrix.skill.name }}
+
+      - name: No default-denied MCP tool (this skill)
+        # Hard gate: boot this skill's MCP server over stdio and call the tools
+        # the tenant-gate middleware wraps in-process, asserting none answers a
+        # gate refusal. Issue #249 shipped two connectors where 6 tools each
+        # were dead while build, vet, go test, the security gate and tools/list
+        # were all green - only tools/call could see it. Needs no credentials
+        # and runs in about a second on a warm build cache.
+        run: python3 tools/maintainer/check_mcp_gate.py --slug ${{ matrix.skill.name }}

--- a/skills/auvik/cli/internal/mcp/platform_gate.go
+++ b/skills/auvik/cli/internal/mcp/platform_gate.go
@@ -38,7 +38,7 @@ func requireFreshTenantGate(s *server.MCPServer, next server.ToolHandlerFunc) se
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 		if session == nil {
-			return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
+			return next(ctx, request)
 		}
 		defer session.ZeroCredentials()
 		return next(platform.ContextWithSession(ctx, session), request)

--- a/skills/auvik/cli/internal/mcp/platform_gate_test.go
+++ b/skills/auvik/cli/internal/mcp/platform_gate_test.go
@@ -121,3 +121,36 @@ func TestMCPTypedInvocationUsesSingleFreshTenantGate(t *testing.T) {
 		t.Fatalf("typed handler calls = %d, want 1", handlerCalls)
 	}
 }
+
+func TestMCPUngatedInvocationUsesRealVerifier(t *testing.T) {
+	originalVerify := verifyFreshMCPInvocation
+	t.Cleanup(func() { verifyFreshMCPInvocation = originalVerify })
+	verifyFreshMCPInvocation = cli.VerifyMCPInvocation
+
+	session, err := cli.VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatalf("real MCP verifier returned an error: %v", err)
+	}
+	if session != nil {
+		session.ZeroCredentials()
+		t.Skip("this CLI registers a platform source")
+	}
+
+	handlerCalls := 0
+	s := server.NewMCPServer("tenant-gate-conformance", "test")
+	result, err := requireFreshTenantGate(s, func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		handlerCalls++
+		return mcplib.NewToolResultText("ok"), nil
+	})(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "ungated-conformance", Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("ungated wrapper returned protocol error: %v", err)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("ungated handler calls = %d, want 1", handlerCalls)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("ungated handler was blocked by the tenant gate: %#v", result)
+	}
+}

--- a/skills/auvik/handfixes.json
+++ b/skills/auvik/handfixes.json
@@ -1,0 +1,35 @@
+{
+  "slug": "auvik",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "Connector-specific edits a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present (and every banned anti-pattern still absent) and fails CI if a reprint dropped one. Schema and rationale: docs/reprint-survival.md. This ledger was created by the fix for issue #249.",
+  "handfixes": [
+    {
+      "id": "mcp-tenant-gate-allows-ungated-invocation",
+      "summary": "the MCP tenant gate falls through to the tool handler when no platform source is registered, instead of default-denying every non-mirror tool",
+      "why": "cli.VerifyMCPInvocation returns (nil, nil) when registeredPlatformSource is nil, which means 'there is nothing to gate' - and no connector in this repo registers a platform source (registerPlatformSource has zero callers outside internal/cli/platform_client.go). The 4.30.1/4.30.2 gate read that nil session as a failure and answered 'MCP tenant gate is not configured' for every tool that is not a Cobra mirror. Cobra mirrors carry pp:tenant-gate = \"child-cli\" and pass through, so the damage was invisible in a tool count: 6 tools per connector were dead while the server still listed them. Those 6 are the entire offline-mirror surface (context, search, sql) plus the entire code-orchestration surface (<prefix>_search / _get / _execute) - exactly the capabilities this connector's own description says a plain read-only MCP does not ship. Measured over stdio before the fix: 6/6 returned isError with the gate message; after, all 6 reach their handler. Fixed upstream in cli-printing-press 4.30.3 (issue #4157, PR #4171); this is the surgical back-port, byte-identical to what 4.30.3 emits. TestMCPUngatedInvocationUsesRealVerifier is the regression test that ships with the 4.30.3 template: it drives the wrapper with the REAL verifier (not the fake the other two tests install) and fails if the handler is blocked. Reverting either the fall-through or the test fails check_handfixes.py.",
+      "status": "upstreamed",
+      "spec_encode_followup": "Already fixed in the press at 4.30.3 (mvanhorn/cli-printing-press#4171). A reprint on 4.30.3 or later regenerates both the fall-through and the conformance test, so this entry exists to keep the back-port from being dropped by a reprint on an older engine or by a regen-merge that resurrects the 4.30.2 body.",
+      "asserts": [
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "not_contains": "NewToolResultError(\"MCP tenant gate is not configured\")"
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "contains": "return next(ctx, request)",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "func TestMCPUngatedInvocationUsesRealVerifier(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "verifyFreshMCPInvocation = cli.VerifyMCPInvocation",
+          "min_count": 1
+        }
+      ]
+    }
+  ]
+}

--- a/skills/threatlocker/cli/internal/mcp/platform_gate.go
+++ b/skills/threatlocker/cli/internal/mcp/platform_gate.go
@@ -38,7 +38,7 @@ func requireFreshTenantGate(s *server.MCPServer, next server.ToolHandlerFunc) se
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 		if session == nil {
-			return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
+			return next(ctx, request)
 		}
 		defer session.ZeroCredentials()
 		return next(platform.ContextWithSession(ctx, session), request)

--- a/skills/threatlocker/cli/internal/mcp/platform_gate_test.go
+++ b/skills/threatlocker/cli/internal/mcp/platform_gate_test.go
@@ -121,3 +121,36 @@ func TestMCPTypedInvocationUsesSingleFreshTenantGate(t *testing.T) {
 		t.Fatalf("typed handler calls = %d, want 1", handlerCalls)
 	}
 }
+
+func TestMCPUngatedInvocationUsesRealVerifier(t *testing.T) {
+	originalVerify := verifyFreshMCPInvocation
+	t.Cleanup(func() { verifyFreshMCPInvocation = originalVerify })
+	verifyFreshMCPInvocation = cli.VerifyMCPInvocation
+
+	session, err := cli.VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatalf("real MCP verifier returned an error: %v", err)
+	}
+	if session != nil {
+		session.ZeroCredentials()
+		t.Skip("this CLI registers a platform source")
+	}
+
+	handlerCalls := 0
+	s := server.NewMCPServer("tenant-gate-conformance", "test")
+	result, err := requireFreshTenantGate(s, func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		handlerCalls++
+		return mcplib.NewToolResultText("ok"), nil
+	})(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "ungated-conformance", Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("ungated wrapper returned protocol error: %v", err)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("ungated handler calls = %d, want 1", handlerCalls)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("ungated handler was blocked by the tenant gate: %#v", result)
+	}
+}

--- a/skills/threatlocker/handfixes.json
+++ b/skills/threatlocker/handfixes.json
@@ -269,6 +269,34 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "mcp-tenant-gate-allows-ungated-invocation",
+      "summary": "the MCP tenant gate falls through to the tool handler when no platform source is registered, instead of default-denying every non-mirror tool",
+      "why": "cli.VerifyMCPInvocation returns (nil, nil) when registeredPlatformSource is nil, which means 'there is nothing to gate' - and no connector in this repo registers a platform source (registerPlatformSource has zero callers outside internal/cli/platform_client.go). The 4.30.1/4.30.2 gate read that nil session as a failure and answered 'MCP tenant gate is not configured' for every tool that is not a Cobra mirror. Cobra mirrors carry pp:tenant-gate = \"child-cli\" and pass through, so the damage was invisible in a tool count: 6 tools per connector were dead while the server still listed them. Those 6 are the entire offline-mirror surface (context, search, sql) plus the entire code-orchestration surface (<prefix>_search / _get / _execute) - exactly the capabilities this connector's own description says a plain read-only MCP does not ship. Measured over stdio before the fix: 6/6 returned isError with the gate message; after, all 6 reach their handler. Fixed upstream in cli-printing-press 4.30.3 (issue #4157, PR #4171); this is the surgical back-port, byte-identical to what 4.30.3 emits. TestMCPUngatedInvocationUsesRealVerifier is the regression test that ships with the 4.30.3 template: it drives the wrapper with the REAL verifier (not the fake the other two tests install) and fails if the handler is blocked. Reverting either the fall-through or the test fails check_handfixes.py.",
+      "status": "upstreamed",
+      "spec_encode_followup": "Already fixed in the press at 4.30.3 (mvanhorn/cli-printing-press#4171). A reprint on 4.30.3 or later regenerates both the fall-through and the conformance test, so this entry exists to keep the back-port from being dropped by a reprint on an older engine or by a regen-merge that resurrects the 4.30.2 body.",
+      "asserts": [
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "not_contains": "NewToolResultError(\"MCP tenant gate is not configured\")"
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "contains": "return next(ctx, request)",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "func TestMCPUngatedInvocationUsesRealVerifier(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "verifyFreshMCPInvocation = cli.VerifyMCPInvocation",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }

--- a/skills/unifi-network/cli/internal/mcp/platform_gate.go
+++ b/skills/unifi-network/cli/internal/mcp/platform_gate.go
@@ -38,7 +38,7 @@ func requireFreshTenantGate(s *server.MCPServer, next server.ToolHandlerFunc) se
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 		if session == nil {
-			return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
+			return next(ctx, request)
 		}
 		defer session.ZeroCredentials()
 		return next(platform.ContextWithSession(ctx, session), request)

--- a/skills/unifi-network/cli/internal/mcp/platform_gate_test.go
+++ b/skills/unifi-network/cli/internal/mcp/platform_gate_test.go
@@ -121,3 +121,36 @@ func TestMCPTypedInvocationUsesSingleFreshTenantGate(t *testing.T) {
 		t.Fatalf("typed handler calls = %d, want 1", handlerCalls)
 	}
 }
+
+func TestMCPUngatedInvocationUsesRealVerifier(t *testing.T) {
+	originalVerify := verifyFreshMCPInvocation
+	t.Cleanup(func() { verifyFreshMCPInvocation = originalVerify })
+	verifyFreshMCPInvocation = cli.VerifyMCPInvocation
+
+	session, err := cli.VerifyMCPInvocation(context.Background())
+	if err != nil {
+		t.Fatalf("real MCP verifier returned an error: %v", err)
+	}
+	if session != nil {
+		session.ZeroCredentials()
+		t.Skip("this CLI registers a platform source")
+	}
+
+	handlerCalls := 0
+	s := server.NewMCPServer("tenant-gate-conformance", "test")
+	result, err := requireFreshTenantGate(s, func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		handlerCalls++
+		return mcplib.NewToolResultText("ok"), nil
+	})(context.Background(), mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "ungated-conformance", Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("ungated wrapper returned protocol error: %v", err)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("ungated handler calls = %d, want 1", handlerCalls)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("ungated handler was blocked by the tenant gate: %#v", result)
+	}
+}

--- a/skills/unifi-network/handfixes.json
+++ b/skills/unifi-network/handfixes.json
@@ -107,6 +107,34 @@
           "min_count": 3
         }
       ]
+    },
+    {
+      "id": "mcp-tenant-gate-allows-ungated-invocation",
+      "summary": "the MCP tenant gate falls through to the tool handler when no platform source is registered, instead of default-denying every non-mirror tool",
+      "why": "cli.VerifyMCPInvocation returns (nil, nil) when registeredPlatformSource is nil, which means 'there is nothing to gate' - and no connector in this repo registers a platform source (registerPlatformSource has zero callers outside internal/cli/platform_client.go). The 4.30.1/4.30.2 gate read that nil session as a failure and answered 'MCP tenant gate is not configured' for every tool that is not a Cobra mirror. Cobra mirrors carry pp:tenant-gate = \"child-cli\" and pass through, so the damage was invisible in a tool count: 6 tools per connector were dead while the server still listed them. Those 6 are the entire offline-mirror surface (context, search, sql) plus the entire code-orchestration surface (<prefix>_search / _get / _execute) - exactly the capabilities this connector's own description says a plain read-only MCP does not ship. Measured over stdio before the fix: 6/6 returned isError with the gate message; after, all 6 reach their handler. Fixed upstream in cli-printing-press 4.30.3 (issue #4157, PR #4171); this is the surgical back-port, byte-identical to what 4.30.3 emits. TestMCPUngatedInvocationUsesRealVerifier is the regression test that ships with the 4.30.3 template: it drives the wrapper with the REAL verifier (not the fake the other two tests install) and fails if the handler is blocked. Reverting either the fall-through or the test fails check_handfixes.py.",
+      "status": "upstreamed",
+      "spec_encode_followup": "Already fixed in the press at 4.30.3 (mvanhorn/cli-printing-press#4171). A reprint on 4.30.3 or later regenerates both the fall-through and the conformance test, so this entry exists to keep the back-port from being dropped by a reprint on an older engine or by a regen-merge that resurrects the 4.30.2 body.",
+      "asserts": [
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "not_contains": "NewToolResultError(\"MCP tenant gate is not configured\")"
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate.go",
+          "contains": "return next(ctx, request)",
+          "min_count": 2
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "func TestMCPUngatedInvocationUsesRealVerifier(",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/mcp/platform_gate_test.go",
+          "contains": "verifyFreshMCPInvocation = cli.VerifyMCPInvocation",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }

--- a/tools/maintainer/README.md
+++ b/tools/maintainer/README.md
@@ -15,6 +15,7 @@ the statusline, you do not need anything in this folder - see the root
 | `check_release_contract.py` | Asserts install scripts and release assets agree on names. |
 | `check_md_links.py` | Verifies relative Markdown links resolve. |
 | `check_dco.sh` | Verifies every commit carries a DCO `Signed-off-by` line. |
+| `check_mcp_gate.py` | Boots a skill's MCP server over stdio and asserts no registered tool is default-denied by the tenant gate. Needs no credentials. |
 | `ci_guards.sh` | Repo hygiene: no em-dashes, no personal paths, no obvious secrets. |
 | `gen_governance.py` | Drafts a skill's `governance.md` from its CLI surface. |
 | `registry.py` | Shared loader for `skills.json` (the single source of truth for skills). |

--- a/tools/maintainer/README.md
+++ b/tools/maintainer/README.md
@@ -15,7 +15,7 @@ the statusline, you do not need anything in this folder - see the root
 | `check_release_contract.py` | Asserts install scripts and release assets agree on names. |
 | `check_md_links.py` | Verifies relative Markdown links resolve. |
 | `check_dco.sh` | Verifies every commit carries a DCO `Signed-off-by` line. |
-| `check_mcp_gate.py` | Boots a skill's MCP server over stdio and asserts no registered tool is default-denied by the tenant gate. Needs no credentials. |
+| `check_mcp_gate.py` | Boots a skill's MCP server over stdio and asserts the tenant gate does not default-deny. Probes the read-only tools the gate wraps in-process; skips Cobra mirrors (the child CLI gates those) and destructive tools. Needs no credentials. |
 | `ci_guards.sh` | Repo hygiene: no em-dashes, no personal paths, no obvious secrets. |
 | `gen_governance.py` | Drafts a skill's `governance.md` from its CLI surface. |
 | `registry.py` | Shared loader for `skills.json` (the single source of truth for skills). |

--- a/tools/maintainer/check_mcp_gate.py
+++ b/tools/maintainer/check_mcp_gate.py
@@ -50,8 +50,12 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SKILLS = os.path.join(REPO, "skills")
 
-# The refusal the 4.30.1/4.30.2 gate emitted. Matched case-insensitively on a
-# substring so a reworded variant of the same default-deny still trips.
+# The refusal the 4.30.1/4.30.2 gate emitted, matched case-insensitively on a
+# substring. This names the KNOWN wording; it is not the only net. A refusal
+# phrased differently is still caught by is_protocol_error() whenever it
+# surfaces as a JSON-RPC error object, which is the shape a Go-error return
+# takes. Verified: a gate mutated to return errors.New("nope, denied for
+# unrelated reasons") fails this check on all five probes.
 GATE_REFUSAL = "tenant gate is not configured"
 
 GATE_OWNER_KEY = "pp:tenant-gate"
@@ -126,12 +130,42 @@ HANDSHAKE = [
 
 
 def result_text(message: dict) -> str:
-    result = message.get("result") or {}
+    """Every string the server sent back for one tools/call, result OR error.
+
+    A refusal can arrive two ways. The gate we are hunting returns
+    `NewToolResultError(...)`, which is a normal `result` carrying an error
+    content block - but a variant that returns a non-nil Go error instead
+    surfaces as a JSON-RPC `error` OBJECT with no `result` at all. Reading only
+    `result.content[].text` scores that second shape as a clean answer, because
+    the response still has an `id` and so counts as answered. That is a
+    false-GREEN in the one check whose entire job is to catch a default-deny:
+    verified by mutating the gate to `return nil, errors.New("MCP tenant gate
+    is not configured")`, which denied every tool while this script printed
+    `ok` for all five probes and exited 0.
+    """
     parts = []
+    result = message.get("result") or {}
     for block in result.get("content") or []:
         if isinstance(block, dict) and "text" in block:
             parts.append(str(block["text"]))
+    error = message.get("error")
+    if isinstance(error, dict):
+        for key in ("message", "data"):
+            val = error.get(key)
+            if val:
+                parts.append(str(val))
     return "\n".join(parts)
+
+
+def is_protocol_error(message: dict) -> bool:
+    """True when the server answered with a JSON-RPC error object.
+
+    A tool that cannot answer at all is a failure regardless of wording: it is
+    either the gate refusing under a phrasing we did not predict, or the server
+    breaking. Matching the known refusal string is the specific signal;
+    this is the backstop that does not depend on guessing the words.
+    """
+    return isinstance(message.get("error"), dict)
 
 
 def check_slug(slug: str, timeout: int, verbose: bool) -> tuple[str, list[str]]:
@@ -223,6 +257,12 @@ def check_slug(slug: str, timeout: int, verbose: bool) -> tuple[str, list[str]]:
             if GATE_REFUSAL in text.lower():
                 failures.append(
                     f"[{slug}] MCP tool `{name}` is DEFAULT-DENIED by the tenant gate: "
+                    f"{' '.join(text.split())[:160]}"
+                )
+            elif is_protocol_error(message):
+                failures.append(
+                    f"[{slug}] MCP tool `{name}` answered with a JSON-RPC error instead of "
+                    f"a result, so it never reached its handler: "
                     f"{' '.join(text.split())[:160]}"
                 )
             elif verbose:

--- a/tools/maintainer/check_mcp_gate.py
+++ b/tools/maintainer/check_mcp_gate.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Boot a skill's MCP server and prove no in-process tool is default-denied.
+
+Why this exists
+---------------
+A connector printed on cli-printing-press 4.30.1/4.30.2 shipped an
+`internal/mcp/platform_gate.go` whose middleware answered
+
+    MCP tenant gate is not configured
+
+for every tool that is NOT a Cobra mirror. Cobra mirrors carry the
+`pp:tenant-gate: "child-cli"` meta and passed straight through, so the damage
+was invisible to every gate the repo had: it built, it vetted, `go test` was
+green, the security gate was clean, and `tools/list` still advertised all the
+tools. Only a `tools/call` over stdio showed 6 tools per connector answering an
+error instead of running. See issue #249.
+
+What this checks
+----------------
+Boot the MCP server, list its tools, and call the ones the tenant-gate
+middleware actually wraps in-process (everything without the `child-cli` meta).
+Fail if any of them comes back with a tenant-gate refusal.
+
+Deliberately narrow, so it cannot be flaky:
+
+* It needs NO credentials. The server boots and the in-process tools answer
+  with an empty environment, so CI passes nothing in.
+* It only calls tools annotated `readOnlyHint: true` and not
+  `destructiveHint: true`. The gate is one middleware wrapping every tool
+  alike, so the read-only subset proves the whole surface.
+* Only a tenant-gate refusal fails. Any other error (bad placeholder argument,
+  unreachable API, empty local store) passes: the point is that the handler
+  RAN, not that it succeeded.
+
+Usage:
+    python3 tools/maintainer/check_mcp_gate.py --slug threatlocker
+    python3 tools/maintainer/check_mcp_gate.py --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SKILLS = os.path.join(REPO, "skills")
+
+# The refusal the 4.30.1/4.30.2 gate emitted. Matched case-insensitively on a
+# substring so a reworded variant of the same default-deny still trips.
+GATE_REFUSAL = "tenant gate is not configured"
+
+GATE_OWNER_KEY = "pp:tenant-gate"
+CHILD_CLI = "child-cli"
+
+
+def mcp_main_dir(slug: str) -> str | None:
+    """Return the skill's MCP server main package, or None if it has no CLI."""
+    cmd_dir = os.path.join(SKILLS, slug, "cli", "cmd")
+    if not os.path.isdir(cmd_dir):
+        return None
+    for name in sorted(os.listdir(cmd_dir)):
+        if name.endswith("-mcp") and os.path.isdir(os.path.join(cmd_dir, name)):
+            return name
+    return None
+
+
+def placeholder_args(schema: dict) -> dict:
+    """Fill only the schema's required properties, with inert placeholders."""
+    props = schema.get("properties") or {}
+    args: dict = {}
+    for name in schema.get("required") or []:
+        kind = (props.get(name) or {}).get("type", "string")
+        if kind in ("number", "integer"):
+            args[name] = 1
+        elif kind == "boolean":
+            args[name] = False
+        elif kind == "array":
+            args[name] = []
+        elif kind == "object":
+            args[name] = {}
+        else:
+            args[name] = "mcp-gate-probe"
+    return args
+
+
+def drive(binary: str, messages: list[dict], timeout: int, home: str) -> list[dict]:
+    """Run one stdio session and return the JSON-RPC responses."""
+    payload = "".join(json.dumps(m) + "\n" for m in messages)
+    # Nothing but PATH and a throwaway HOME. The check must never depend on a
+    # developer's ambient credentials, an accidental real key must not reach a
+    # live API, and the probe must not touch anyone's real local store.
+    env = {"PATH": os.environ.get("PATH", ""), "HOME": home}
+    proc = subprocess.run(
+        [binary], input=payload, capture_output=True, text=True, env=env, timeout=timeout
+    )
+    out = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+HANDSHAKE = [
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "check_mcp_gate", "version": "1"},
+        },
+    },
+    {"jsonrpc": "2.0", "method": "notifications/initialized"},
+]
+
+
+def result_text(message: dict) -> str:
+    result = message.get("result") or {}
+    parts = []
+    for block in result.get("content") or []:
+        if isinstance(block, dict) and "text" in block:
+            parts.append(str(block["text"]))
+    return "\n".join(parts)
+
+
+def check_slug(slug: str, timeout: int, verbose: bool) -> tuple[str, list[str]]:
+    """Return (status, failures). status is one of pass / skip / fail."""
+    main_dir = mcp_main_dir(slug)
+    if main_dir is None:
+        return "skip", []
+
+    cli_dir = os.path.join(SKILLS, slug, "cli")
+    tmp = tempfile.mkdtemp(prefix="mcp-gate-")
+    binary = os.path.join(tmp, main_dir)
+    home = os.path.join(tmp, "home")
+    os.makedirs(home, exist_ok=True)
+    try:
+        build = subprocess.run(
+            ["go", "build", "-o", binary, "./cmd/" + main_dir],
+            cwd=cli_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if build.returncode != 0:
+            return "fail", [
+                f"[{slug}] could not build ./cmd/{main_dir}: {build.stderr.strip()[:400]}"
+            ]
+
+        listed = drive(
+            binary,
+            HANDSHAKE + [{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}],
+            timeout,
+            home,
+        )
+        tools = []
+        for message in listed:
+            if message.get("id") == 2:
+                tools = (message.get("result") or {}).get("tools") or []
+        if not tools:
+            return "fail", [f"[{slug}] MCP server listed no tools over stdio"]
+
+        # The tenant-gate middleware wraps every tool except the Cobra mirrors,
+        # which the child CLI gates itself. Probe the wrapped, read-only ones.
+        probes = []
+        wrapped = 0
+        for tool in tools:
+            meta = tool.get("_meta") or {}
+            if meta.get(GATE_OWNER_KEY) == CHILD_CLI:
+                continue
+            wrapped += 1
+            hints = tool.get("annotations") or {}
+            if not hints.get("readOnlyHint") or hints.get("destructiveHint"):
+                continue
+            probes.append(tool)
+
+        if wrapped == 0:
+            # Every tool is a Cobra mirror, so the middleware gates nothing and
+            # the #249 failure mode cannot occur here.
+            return "skip", []
+        if not probes:
+            return "fail", [
+                f"[{slug}] {wrapped} in-process MCP tool(s) exist but none is annotated "
+                "read-only, so the tenant gate cannot be probed safely. Widen this "
+                "check rather than leaving the surface unverified."
+            ]
+
+        calls = list(HANDSHAKE)
+        ids = {}
+        for offset, tool in enumerate(probes, start=10):
+            calls.append(
+                {
+                    "jsonrpc": "2.0",
+                    "id": offset,
+                    "method": "tools/call",
+                    "params": {
+                        "name": tool["name"],
+                        "arguments": placeholder_args(tool.get("inputSchema") or {}),
+                    },
+                }
+            )
+            ids[offset] = tool["name"]
+
+        answered = {m.get("id"): m for m in drive(binary, calls, timeout, home) if "id" in m}
+        failures = []
+        for call_id, name in sorted(ids.items()):
+            message = answered.get(call_id)
+            if message is None:
+                failures.append(f"[{slug}] MCP tool `{name}` never answered tools/call")
+                continue
+            text = result_text(message)
+            if GATE_REFUSAL in text.lower():
+                failures.append(
+                    f"[{slug}] MCP tool `{name}` is DEFAULT-DENIED by the tenant gate: "
+                    f"{' '.join(text.split())[:160]}"
+                )
+            elif verbose:
+                print(f"    ok  {name}")
+
+        if failures:
+            failures.append(
+                f"[{slug}] The gate must fall through when no platform source is "
+                "registered. See issue #249 and docs/reprint-survival.md; the fix "
+                "landed in cli-printing-press 4.30.3."
+            )
+            return "fail", failures
+        if verbose:
+            print(f"    {len(probes)} of {wrapped} in-process tool(s) probed")
+        return "pass", []
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slug", help="check one skill")
+    parser.add_argument("--all", action="store_true", help="check every skill with a CLI")
+    parser.add_argument("--timeout", type=int, default=300, help="per-step timeout in seconds")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if not args.slug and not args.all:
+        parser.error("pass --slug <slug> or --all")
+
+    if args.slug:
+        slugs = [args.slug]
+    else:
+        slugs = sorted(
+            d for d in os.listdir(SKILLS)
+            if not d.startswith("_") and os.path.isdir(os.path.join(SKILLS, d))
+        )
+
+    if shutil.which("go") is None:
+        print("SKIP: go is not on PATH; cannot boot any MCP server.")
+        return 0
+
+    failures = []
+    checked = skipped = 0
+    for slug in slugs:
+        if args.verbose:
+            print(f"==> {slug}")
+        status, slug_failures = check_slug(slug, args.timeout, args.verbose)
+        if status == "skip":
+            skipped += 1
+            continue
+        checked += 1
+        failures.extend(slug_failures)
+
+    if failures:
+        print("FAIL: MCP tools are default-denied by the tenant gate:\n")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print(f"PASS: no default-denied MCP tool in {checked} skill(s) ({skipped} without one).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/maintainer/release_matrix.py
+++ b/tools/maintainer/release_matrix.py
@@ -67,6 +67,7 @@ MACHINERY = (
     "tools/maintainer/registry.py",
     "tools/maintainer/check_cli_claims.py",
     "tools/maintainer/cli_hash.py",
+    "tools/maintainer/check_mcp_gate.py",
 )
 
 

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -60,6 +60,7 @@ if run python3 tools/maintainer/check_surface_coverage.py; then pass "surface co
 if run python3 tools/maintainer/check_media_block.py;     then pass "README media block";  else fail "README media block";  fi
 if run python3 tools/maintainer/check_handfixes.py;       then pass "hand-fix ledgers";    else fail "hand-fix ledgers";    fi
 if run python3 tools/maintainer/check_security_gate.py --all; then pass "security gate";   else fail "security gate";       fi
+if run python3 tools/maintainer/check_mcp_gate.py --all;  then pass "MCP tools callable";  else fail "MCP tools callable";  fi
 if run bash    tools/maintainer/ci_guards.sh;             then pass "repo hygiene guards"; else fail "repo hygiene guards"; fi
 
 echo "== Plugin manifest validation (claude plugin validate --strict) =="


### PR DESCRIPTION
Closes #249.

## The defect

`cli.VerifyMCPInvocation` returns `(nil, nil)` when `registeredPlatformSource`
is nil, which means "there is nothing to gate". No connector in this repo
registers a platform source: `registerPlatformSource` has zero callers outside
`internal/cli/platform_client.go`. The gate emitted by printing-press
4.30.1/4.30.2 read that nil session as a failure:

```go
if session == nil {
    return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
}
```

Cobra mirrors carry `pp:tenant-gate: "child-cli"` and passed through, so the
damage never showed up in a tool count. Everything else was dead: the whole
offline-mirror surface (`context`, `search`, `sql`) plus the whole
code-orchestration surface (`<prefix>_search` / `_get` / `_execute`).

## The fix

Surgical back-port of the 4.30.3 fix (`mvanhorn/cli-printing-press#4157`, fixed
by `#4171`), byte-identical to what 4.30.3 emits:

```diff
 		if session == nil {
-			return mcplib.NewToolResultError("MCP tenant gate is not configured"), nil
+			return next(ctx, request)
 		}
```

Plus `TestMCPUngatedInvocationUsesRealVerifier`, the conformance test that
ships with the 4.30.3 template. It drives the wrapper with the REAL verifier
rather than the fake the other two gate tests install, so it fails if the
handler is blocked.

**Not a reprint.** These trees carry recorded hand-fixes (`threatlocker` 7,
`unifi-network` 6), and a 4.30.3 reprint also introduces about 114 no-op parent
tools, a separate press defect.

`auvik` was never tagged (#246) so no broken binary shipped, but it carries the
same file and would have shipped broken on release. Fixed here too.

## Receipts: the stdio probe

Each MCP server built from this tree and driven over stdio (`initialize`,
`notifications/initialized`, `tools/list`, then one `tools/call` per tool).
`<prefix>_get` / `_execute` were given a real `endpoint_id` discovered from
`<prefix>_search` in the same session, so their answer is about the API rather
than about a bad argument.

### threatlocker (v0.3.0 tagged, press 4.30.2)

**Before**

```
# threatlocker-mcp-before  (37 tools registered)
  context                GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  search                 GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  sql                    GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  threatlocker_search    GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  threatlocker_get       GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  threatlocker_execute   GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  => gate-blocked: 6/6
```

**After**

```
# threatlocker-mcp-after  (37 tools registered)
  context                handler ran   isError=false { "api": "threatlocker", "archetype": "infrastructure", "auth": { "env_vars": [ { "description": "Set to your
  search                 handler ran   isError=false { "count": 0, "next_step": "Run threatlocker-cli sync to populate the local SQLite store before using MCP sear
  sql                    handler ran   isError=false { "columns": [ "ok" ], "count": 1, "resumable": false, "rows": [ { "ok": 1 } ], "store_status": "empty" }
  threatlocker_search    handler ran   isError=false { "count": 10, "results": [ { "endpoint_id": "versions.list", "method": "GET", "path": "/ThreatLockerVersion/T
  threatlocker_get       handler ran   isError=false { "endpoint_id": "versions.list", "method": "GET", "path": "/ThreatLockerVersion/ThreatLockerVersionGetForDrop
  threatlocker_execute   handler ran   isError=true  GET /ThreatLockerVersion/ThreatLockerVersionGetForDropdownList: Get "http://127.0.0.1:9/ThreatLockerVersion/Th
  => gate-blocked: 0/6
```

`threatlocker_execute` is `isError=true` because the probe pointed
`THREATLOCKER_BASE_URL` at a dead local port. That error is the proof: the
handler ran all the way to the HTTP layer instead of being refused at the gate.

### unifi-network (v0.1.0 tagged, press 4.30.1)

**Before**

```
# unifi-network-mcp-before  (48 tools registered)
  context                GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  search                 GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  sql                    GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  unifi_search           GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  unifi_get              GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  unifi_execute          GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  => gate-blocked: 6/6
```

**After**

```
# unifi-network-mcp-after  (48 tools registered)
  context                handler ran   isError=false { "api": "unifi", "archetype": "infrastructure", "auth": { "env_vars": [ { "description": "Set to your API cre
  search                 handler ran   isError=false { "count": 0, "next_step": "Run unifi-network-cli sync to populate the local SQLite store before using MCP sea
  sql                    handler ran   isError=false { "columns": [ "ok" ], "count": 1, "resumable": false, "rows": [ { "ok": 1 } ], "store_status": "empty" }
  unifi_search           handler ran   isError=false { "count": 10, "results": [ { "endpoint_id": "sites.traffic-matching-lists.delete", "method": "DELETE", "path"
  unifi_get              handler ran   isError=true  endpoint_id "sites.traffic-matching-lists.delete" is DELETE, but unifi_get only permits GET endpoints
  unifi_execute          handler ran   isError=true  unresolved path parameter {siteId}
  => gate-blocked: 0/6
```

Both `isError`s here are real handler answers about the endpoint the probe
happened to pick, not gate refusals.

### auvik (untagged, press 4.30.2)

**Before**

```
# auvik-mcp-before  (41 tools registered)
  context                GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  search                 GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  sql                    GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  auvik_search           GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  auvik_get              GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  auvik_execute          GATE-BLOCKED  isError=true  MCP tenant gate is not configured
  => gate-blocked: 6/6
```

**After**

```
# auvik-mcp-after  (41 tools registered)
  context                handler ran   isError=false { "api": "auvik", "archetype": "generic", "auth": { "env_vars": [ { "kind": "per_call", "name": "AUVIK_USERNAM
  search                 handler ran   isError=false { "count": 1, "results": [ { "id": "a1", "type": "alertInfo", "attributes": { "alertDefinitionId": "def-1", "d
  sql                    handler ran   isError=false { "columns": [ "ok" ], "count": 1, "resumable": false, "rows": [ { "ok": 1 } ], "store_status": "ready" }
  auvik_search           handler ran   isError=false { "count": 4, "results": [ { "endpoint_id": "settings.read-multiple-snmp-poller", "method": "GET", "path": "/v
  auvik_get              handler ran   isError=false { "endpoint_id": "settings.read-multiple-snmp-poller", "method": "GET", "path": "/v1/settings/snmppoller", "su
  auvik_execute          handler ran   isError=true  GET /v1/settings/snmppoller: Get "http://127.0.0.1:9/v1/settings/snmppoller": dial tcp 127.0.0.1:9: connect: c
  => gate-blocked: 0/6
```

## Hand-fix ledgers

Each connector's `handfixes.json` records the back-port with four asserts: the
banned refusal string must stay gone, the fall-through must be present, and
both markers of the conformance test must be present. `auvik` had no ledger, so
this creates one.

Every assert was verified load-bearing by reverting each half and confirming
`check_handfixes.py` fails, then restoring:

```
=== threatlocker : revert the fall-through (restore the 4.30.2 default-deny) ===
FAIL: hand-fix ledger regressions (a reprint may have clobbered a live-validated fix):

  - [threatlocker] handfix 'mcp-tenant-gate-allows-ungated-invocation' REGRESSED in cli/internal/mcp/platform_gate.go: banned anti-pattern `NewToolResultError("MCP tenant gate is not configured")` is present again. A reprint likely reintroduced it. See docs/reprint-survival.md.
  - [threatlocker] handfix 'mcp-tenant-gate-allows-ungated-invocation' REGRESSED in cli/internal/mcp/platform_gate.go: expected 2x `return next(ctx, request)`, found 1. A reprint likely clobbered it. Restore the hand-fix (or, if intentionally changed, update skills/threatlocker/handfixes.json). See docs/reprint-survival.md.

=== threatlocker : revert the conformance test ===
FAIL: hand-fix ledger regressions (a reprint may have clobbered a live-validated fix):

  - [threatlocker] handfix 'mcp-tenant-gate-allows-ungated-invocation' REGRESSED in cli/internal/mcp/platform_gate_test.go: expected 1x `func TestMCPUngatedInvocationUsesRealVerifier(`, found 0. A reprint likely clobbered it. ...
  - [threatlocker] handfix 'mcp-tenant-gate-allows-ungated-invocation' REGRESSED in cli/internal/mcp/platform_gate_test.go: expected 1x `verifyFreshMCPInvocation = cli.VerifyMCPInvocation`, found 0. A reprint likely clobbered it. ...

=== threatlocker : restored ===
PASS: hand-fix ledgers intact for 1 skill(s).
```

`unifi-network` and `auvik` produce the identical four failures under the same
treatment. Entries are `status: "upstreamed"`: 4.30.3 regenerates both halves,
so the ledger exists to stop a reprint on an older engine, or a regen-merge
resurrecting the 4.30.2 body, from silently dropping it.

## Second commit: a CI gate so this cannot recur

Nothing in this repo could see the defect. `go build`, `go vet`, `go test`,
`check_security_gate` and `check_surface_coverage` were all green, and
`tools/list` still advertised every tool with its full description. The bug
lived in the middleware between listing a tool and running it, so only a real
`tools/call` could expose it.

`tools/maintainer/check_mcp_gate.py` boots the skill's MCP server over stdio,
lists its tools, and calls the ones the tenant-gate middleware wraps in-process
(everything without the `pp:tenant-gate: "child-cli"` meta), failing if any
comes back with a gate refusal. It is kept deliberately narrow so it cannot
become flaky:

- **No credentials.** The server boots and answers with an empty environment,
  so CI passes nothing in and a real key can never reach a live API.
- **Hermetic HOME**, so the probe never touches a developer's local store.
- **Read-only tools only** (`readOnlyHint: true`, not `destructiveHint: true`).
  The gate is one middleware wrapping every tool alike, so the read-only subset
  proves the whole surface without invoking a write tool.
- **Only a gate refusal fails.** A bad placeholder argument, an unreachable API
  or an empty local store all pass: the point is that the handler RAN.

Proven to discriminate rather than pass blindly. Reverting the fall-through in
`threatlocker`:

```
### check_mcp_gate.py against the PRE-FIX (4.30.2) gate:
FAIL: MCP tools are default-denied by the tenant gate:

  - [threatlocker] MCP tool `context` is DEFAULT-DENIED by the tenant gate: MCP tenant gate is not configured
  - [threatlocker] MCP tool `search` is DEFAULT-DENIED by the tenant gate: MCP tenant gate is not configured
  - [threatlocker] MCP tool `sql` is DEFAULT-DENIED by the tenant gate: MCP tenant gate is not configured
  - [threatlocker] MCP tool `threatlocker_get` is DEFAULT-DENIED by the tenant gate: MCP tenant gate is not configured
  - [threatlocker] MCP tool `threatlocker_search` is DEFAULT-DENIED by the tenant gate: MCP tenant gate is not configured
  - [threatlocker] The gate must fall through when no platform source is registered. See issue #249 and docs/reprint-survival.md; the fix landed in cli-printing-press 4.30.3.
### exit code: 1

### restored:
PASS: no default-denied MCP tool in 1 skill(s) (0 without one).
### exit code: 0
```

Roughly one second per connector on a warm build cache, in the per-skill matrix
job where Go is already set up. Wired into the CI `build` job and
`verify_all.sh`. Skills without a CLI, and connectors whose every tool is a
Cobra mirror, are a no-op. It is a separate commit so it can be dropped if it
proves too slow for CI.

## Gates

| Check | threatlocker | unifi-network | auvik |
| --- | --- | --- | --- |
| `go build ./... && go vet ./... && go test ./...` | clean | clean | clean |
| `check_handfixes.py --slug` | PASS | PASS | PASS |
| `check_security_gate.py --slug` | 0 P1 / 6 P2 | 0 P1 / 6 P2 | 0 P1 / 6 P2 |
| `check_mcp_gate.py --slug` | PASS | PASS | PASS |
| stdio probe, previously-dead tools | 6/6 -> 0/6 | 6/6 -> 0/6 | 6/6 -> 0/6 |

`bash tools/maintainer/ci_guards.sh` passes, including the new guard 6 (Go
toolchain floor). No `go.mod` was touched. No em-dashes. All commits signed
off. No release, tag or `release.py` run: `threatlocker` and `unifi-network`
both need one to reach users, and that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MCP tool requests now proceed when no platform session or tenant configuration is present, instead of being incorrectly rejected.
  - Applied consistently across supported skills.

- **Tests**
  - Added regression coverage confirming ungated requests reach their handlers successfully.
  - Added automated validation for MCP tool calls across eligible skills.

- **Documentation**
  - Documented the new MCP validation check and related regression safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->