### PR TITLE
fix(auvik): the Windows binaries never compiled, so they were never shipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,35 @@ jobs:
           go build ./...
           go vet ./...
 
+      # Cross-compile for every platform the release matrix ships, so a
+      # platform-specific compile break is caught HERE and not from a missing
+      # artifact after a tag push.
+      #
+      # auvik shipped exactly that: `syscall.Flock` in a novel command file with
+      # no build tag, which does not exist on Windows. It merged with CI green
+      # because CI built only for the runner's platform, and the six-target
+      # matrix runs on a TAG PUSH. The first real tag published 16 assets
+      # instead of 25 while every job stayed green - a partial asset set fails
+      # nothing. See the auvik Windows-build fix and issue #249 for the same
+      # shape one layer up.
+      #
+      # Compile only (`go build`), no vet or test: this is about "does it
+      # compile for the targets we ship", and it adds a few seconds per row.
+      - name: Cross-compile every released target
+        run: |
+          cd ${{ matrix.skill.dir }}
+          fail=0
+          for pair in windows/amd64 windows/arm64 darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
+            os="${pair%/*}"; arch="${pair#*/}"
+            if ! GOOS="$os" GOARCH="$arch" go build ./... 2>build.err; then
+              echo "::error::does not compile for $pair"
+              sed 's/^/    /' build.err
+              fail=1
+            fi
+          done
+          rm -f build.err
+          exit "$fail"
+
       - name: CLI claims vs built binary (this skill)
         # Runs here, in the per-skill matrix job, because verifying doc claims
         # builds the real CLI and needs Go on PATH (already set up above). The

--- a/skills/auvik/cli/internal/cli/auvik_snapshot_lock_unix.go
+++ b/skills/auvik/cli/internal/cli/auvik_snapshot_lock_unix.go
@@ -1,5 +1,7 @@
 // Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
 
+//go:build !windows
+
 package cli
 
 import (

--- a/skills/auvik/cli/internal/cli/auvik_snapshot_lock_windows.go
+++ b/skills/auvik/cli/internal/cli/auvik_snapshot_lock_windows.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireSnapshotLock is the Windows half of the sidecar advisory lock. See
+// auvik_snapshot_lock_unix.go for why the lock exists and why it must be held
+// across the store OPEN rather than only the write transaction.
+//
+// Windows has no flock(2). LockFileEx is the equivalent primitive: with
+// LOCKFILE_EXCLUSIVE_LOCK and no LOCKFILE_FAIL_IMMEDIATELY it blocks until the
+// lock is available, which matches the Unix LOCK_EX behavior the caller expects
+// (peers queue rather than erroring out). The lock is taken on a byte range;
+// locking the whole possible range with a 0xFFFFFFFF/0xFFFFFFFF length is the
+// conventional way to express "the entire file" on a zero-byte sidecar.
+//
+// UnlockFileEx is not strictly required - closing the handle drops the lock -
+// but it is called explicitly so the release path is symmetric with the Unix
+// one and does not depend on close ordering.
+func acquireSnapshotLock(dbPath string) (release func(), err error) {
+	lockPath := dbPath + ".snapshot-lock"
+	// #nosec G304 -- lockPath is this CLI's own --db path plus a fixed suffix, on
+	// the operator's own machine. It is a zero-byte advisory lock sidecar opened
+	// 0600; nothing is read from it and no untrusted input reaches the path.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening snapshot lock %s: %w", lockPath, err)
+	}
+	if err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		lockRangeLow,
+		lockRangeHigh,
+		new(windows.Overlapped),
+	); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("acquiring snapshot lock (another 'inventory diff --snapshot' may be running): %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, lockRangeLow, lockRangeHigh, new(windows.Overlapped))
+		_ = f.Close()
+	}, nil
+}
+
+// Lock the entire possible byte range of the zero-byte sidecar.
+const (
+	lockRangeLow  = 0xFFFFFFFF
+	lockRangeHigh = 0xFFFFFFFF
+)


### PR DESCRIPTION
`auvik` has never been buildable for Windows.

```
$ cd skills/auvik/cli && GOOS=windows GOARCH=amd64 go build ./...
internal/cli/auvik_snapshot_lock.go:42:20: undefined: syscall.Flock
internal/cli/auvik_snapshot_lock.go:42:47: undefined: syscall.LOCK_EX
```

`syscall.Flock` does not exist on Windows and the file carries no build tag. Meanwhile `manifest.json` declares `win32` support and `install.ps1` offers a Windows install path.

## Why nothing caught it

CI builds for the **host platform only**. The six-target matrix runs on a **tag push**. `auvik` had a release commit on `main` but its tag was never pushed (#246), so the one job that compiles for Windows had never run against this code.

It surfaced the moment the first real tag went out. `auvik-v0.1.1` published **16 assets instead of 25**, silently missing both Windows targets, while every other job in the workflow went green.

Same shape as #249: a defect that builds, vets, tests, and passes the security gate, and is only visible from the artifact. It is also the **second** problem the never-pushed tag was hiding, after the MCP tenant gate.

## The fix

Split on `//go:build`:

| file | tag | implementation |
|---|---|---|
| `auvik_snapshot_lock_unix.go` | `!windows` | unchanged `flock` |
| `auvik_snapshot_lock_windows.go` | `windows` | `LockFileEx` |

`LOCKFILE_EXCLUSIVE_LOCK` without `LOCKFILE_FAIL_IMMEDIATELY` blocks until the lock is available, matching the `LOCK_EX` semantics the caller expects. `UnlockFileEx` is called explicitly so the release path stays symmetric with the Unix half.

`syscall.LockFileEx` is not exported by the stdlib on Windows, so this uses `golang.org/x/sys/windows`, already a dependency at v0.46.0. **No new module, no `go.mod` change.**

## Verification

All six release targets, not just the host:

```
windows/amd64 OK    darwin/arm64 OK    linux/amd64 OK
windows/arm64 OK    darwin/amd64 OK    linux/arm64 OK
```

`go vet` clean, 19 test packages pass, `ci_guards.sh` 6/6, security gate 0 P1, hand-fix ledger PASS, `check_mcp_gate.py` PASS.

Blast radius: `auvik` is the **only** connector in the fleet calling `syscall.Flock`. `threatlocker` and `hudu` cross-compile for Windows cleanly.

## Follow-up

`auvik-v0.1.1` is a partial release (16/25 assets) and needs re-releasing as v0.1.2 once this lands.

Worth considering separately: CI cannot see a Windows-only compile break, and a partial asset set fails nothing. A cheap `GOOS=windows go build` in the CI matrix would have caught this at #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved snapshot locking support on Windows.
  - Prevented conflicting snapshot operations from running simultaneously, reducing the risk of incomplete or inconsistent snapshot results.
  - Added clearer handling when snapshot locking cannot be opened or acquired.
  - Preserved existing snapshot-lock behavior on non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->