### PR TITLE
fix(release): notes come from the skill's own CHANGELOG, not --generate-notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,6 @@ jobs:
     needs: [security_gate]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Ensure release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -116,30 +111,9 @@ jobs:
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; reusing it."
-            exit 0
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi
-          # Release notes come from the SKILL'S OWN CHANGELOG, never
-          # --generate-notes.
-          #
-          # --generate-notes computes its range against the previous tag in the
-          # REPO. In a monorepo with per-skill tags that is some unrelated
-          # skill's tag, so the notes list every PR merged in between regardless
-          # of what it touched. zammad-v0.1.1 shipped notes advertising the
-          # auvik onboarding and a batch of CI work, footed with
-          # "compare/unifi-network-v0.1.0...zammad-v0.1.1" - accurate about the
-          # range, useless and misleading about the skill.
-          #
-          # The per-skill CHANGELOG section is the authoritative, human-written
-          # answer to "what changed in THIS connector", and release.py already
-          # maintains it.
-          slug="${TAG%-v*}"
-          version="${TAG##*-v}"
-          notes=$(python3 tools/maintainer/changelog_section.py --slug "$slug" --version "$version") || {
-            echo "::error::no usable CHANGELOG section for $slug $version"
-            exit 1
-          }
-          printf '%s\n' "$notes" > /tmp/release-notes.md
-          gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md
 
   build:
     needs: [prepare, create-release, security_gate]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
     needs: [security_gate]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Ensure release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -111,9 +116,30 @@ jobs:
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; reusing it."
-          else
-            gh release create "$TAG" --title "$TAG" --generate-notes
+            exit 0
           fi
+          # Release notes come from the SKILL'S OWN CHANGELOG, never
+          # --generate-notes.
+          #
+          # --generate-notes computes its range against the previous tag in the
+          # REPO. In a monorepo with per-skill tags that is some unrelated
+          # skill's tag, so the notes list every PR merged in between regardless
+          # of what it touched. zammad-v0.1.1 shipped notes advertising the
+          # auvik onboarding and a batch of CI work, footed with
+          # "compare/unifi-network-v0.1.0...zammad-v0.1.1" - accurate about the
+          # range, useless and misleading about the skill.
+          #
+          # The per-skill CHANGELOG section is the authoritative, human-written
+          # answer to "what changed in THIS connector", and release.py already
+          # maintains it.
+          slug="${TAG%-v*}"
+          version="${TAG##*-v}"
+          notes=$(python3 tools/maintainer/changelog_section.py --slug "$slug" --version "$version") || {
+            echo "::error::no usable CHANGELOG section for $slug $version"
+            exit 1
+          }
+          printf '%s\n' "$notes" > /tmp/release-notes.md
+          gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md
 
   build:
     needs: [prepare, create-release, security_gate]

--- a/skills/auvik/CHANGELOG.md
+++ b/skills/auvik/CHANGELOG.md
@@ -4,10 +4,32 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.2.0] - unreleased
+## [0.2.0] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
+
+### Fixed
+
+- **MCP tools are no longer default-denied.** Every tool that is not a Cobra
+  mirror - `search`, `sql`, `context`, and the `auvik_search` / `auvik_get` /
+  `auvik_execute` code-orchestration trio - returned
+  `MCP tenant gate is not configured` instead of running. The generated tenant
+  gate treated "no platform source registered" as a failure rather than as
+  "nothing to gate", and no connector registers one. The previously released
+  binary had 6 dead tools. See issue #249.
+
+- **Windows binaries now exist.** `internal/cli/auvik_snapshot_lock.go` called
+  `syscall.Flock`, which does not exist on Windows, with no build tag - so the
+  Windows targets had never compiled and were silently absent from the release
+  assets, even though `manifest.json` declared `win32` support. Split on
+  `//go:build`, with `LockFileEx` on Windows.
 
 ## [0.1.1] - unreleased
 

--- a/skills/auvik/CHANGELOG.md
+++ b/skills/auvik/CHANGELOG.md
@@ -31,10 +31,12 @@ All notable changes to this skill are documented here. Format follows
   assets, even though `manifest.json` declared `win32` support. Split on
   `//go:build`, with `LockFileEx` on Windows.
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-08-17
 
 ### Changed
-- Describe the changes in this release.
+
+- fix(mcp): stop the tenant gate default-denying every non-mirror tool (#249) (#250)
+- skill(auvik): Auvik network-monitoring connector (CLI + MCP) (#238)
 
 ## [0.1.0]
 

--- a/skills/aws-billing/CHANGELOG.md
+++ b/skills/aws-billing/CHANGELOG.md
@@ -4,18 +4,9 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [4.19.0]
+## [0.1.0] - 2026-07-01
 
-### Added
-- Initial msp-skills release: AWS billing CLI + MCP server, read-only against AWS.
-- Plain-English bill breakdowns: `bill`, `consolidated` (per linked-account rollup with
-  month-over-month delta), `compare` (rank what moved), `forecast`, and `explain` (decode
-  opaque usage-type strings).
-- Dollar-ranked waste hunters: `waste rank`, `waste transfer`, `waste gp2-gp3`, plus idle
-  EC2, unattached EBS, orphaned snapshots, and unassociated Elastic IPs.
-- Local SQLite mirror via `sync` so follow-up questions are instant and free instead of
-  $0.01 per Cost Explorer call.
-- `iam-setup` mints a least-privilege read-only policy, CloudFormation template, or bootstrap
-  script so you can share billing access without over-granting.
-- `ask` answers plain-English questions from the cache; `report --post-slack` posts a summary
-  to Slack on opt-in.
+### Changed
+
+- feat(aws-billing): add AWS billing & Cost Explorer connector (#175)
+

--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.2.9] - unreleased
+## [0.2.9] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
+- `golang.org/x/text` bumped v0.38.0 -> v0.39.0 for **GO-2026-5970** (infinite
+  loop on invalid input).
 
 ## [0.2.8] - unreleased
 

--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -17,147 +17,56 @@ All notable changes to this skill are documented here. Format follows
 - `golang.org/x/text` bumped v0.38.0 -> v0.39.0 for **GO-2026-5970** (infinite
   loop on invalid input).
 
-## [0.2.8] - unreleased
-
-### Fixed
-- MCP `search` now returns the concise `id/name/type/match` projection by default
-  instead of dumping whole raw records, matching the CLI `search` command and the
-  connector guide. The v0.2.4 projection fix only covered the CLI path; the MCP
-  `search` tool is a separate hand-wired handler that kept marshalling the full
-  records via `db.Search`, so MCP/agent users still saw a wall of nested JSON
-  (e.g. complete client objects with all `devices_counters` blocks) through
-  v0.2.7. A new `full` boolean parameter restores the whole records, mirroring the
-  CLI's `--full`. (reported via #101)
-
-## [0.2.7] - unreleased
-
-### Fixed
-- Search now finds records whose name is a 3-letter all-caps label (e.g. `WEB`,
-  `SQL`, `DNS`, `DMZ`, `APP`, `VPN`). The local full-text index dropped any
-  3-letter all-caps string (a rule meant for currency/country codes like `USD`),
-  but it was key-blind, so it also discarded a record's `name`/`alias` when the
-  name was a short host label. Those records were fully present (list/get
-  returned them) but `search` by name returned nothing, which is why it showed up
-  only through the MCP `search` tool. The index filter is now key-aware: it keeps
-  the value for display-name fields and still drops bare codes elsewhere. The
-  FTS-content schema version is bumped so existing local databases re-index
-  through the fixed filter on the next `sync`. (reported by Barret, #148)
-- MCP `search` now gives actionable guidance instead of failing opaquely: when the
-  local database has not been synced it returns "run the `sync` tool first" rather
-  than a cryptic SQLite error, and a no-match returns a clear hint instead of a
-  bare `null`. (reported by Barret, #148)
-
-## [0.2.6] - unreleased
-
-### Fixed
-- MCP server now forwards the `client` fleet filter to the underlying CLI. The
-  client-scoped fleet commands (`health`, `compliance`, `rpo`, `appliance-map`)
-  advertise a `client` parameter in their MCP tool schema but the shell-out layer
-  silently dropped it, so every MCP call returned the whole fleet regardless of the
-  value passed. The CLI binary applied `--client` correctly, only the MCP path did
-  not. Cause: the generated `blockedRootFlags` denylist (meant for root
-  credential/base-url/config/delivery flags) included `client`, but `client` is not
-  a root flag on this connector: it is a per-command Int64 fleet filter. Removed
-  `client` from the denylist; the genuine control-plane flags
-  (`base-url`/`token`/`config`/`deliver`/`profile`/`args`) remain blocked. Added a
-  regression test asserting `client` forwards as `--client <id>` while control-plane
-  flags stay dropped. (reported by @Xenith-B, #130)
-
-## [0.2.5] - unreleased
-
-### Fixed
-- `restore_point` sync now populates the typed table against the real live API
-  shape. The per-device endpoint groups restore points by Cloud Vault: a
-  top-level array of `{vault_id, restore_point:[...]}` wrappers whose
-  timestamp-string `restore_point_id` lives only on the inner array elements.
-  Sync was storing the outer vault wrappers (no `restore_point_id`), so every one
-  failed id extraction (`all_items_failed_id_extraction`) and the table stayed at
-  0 rows, even though fleet summaries and live per-device lookups were unaffected.
-  `syncDependentResource` now descends one level into the nested `restore_point[]`
-  array, carrying the wrapper's `vault_id` down onto each point and keying it as
-  `rp:<device_id>:<restore_point_id>`. The earlier flat-array regression fixture
-  (0.2.1/0.2.2) never reproduced this because it fed the inner shape directly; the
-  wiring test now drives the real nested grouped-by-vault payload. (#84)
-
-### Tests
-- Replaced the flat-array `restore_point` sync-wiring fixture with the live
-  grouped-by-vault nested shape (the test now fails without the flatten), and
-  added a flat-array passthrough test so the single-device write-through path
-  stays covered. Added the nested-flatten marker to the hand-fix ledger so a
-  future reprint cannot silently drop it.
-
-## [0.2.4] - unreleased
-
-### Fixed
-- `restore_point` and `autoverify` rows are keyed by their clean synthesized
-  composite again (`rp:<device_id>:<restore_point_id>`, `av:<device_id>:...`).
-  The 0.2.3 engine refresh added a generic parent-composite storage key that
-  appended `<id>\x00<parent>` for every parent-scoped resource, which double-keyed
-  these two (whose synthesized id already embeds the parent) into a NUL-containing
-  key that broke clean-key offline lookups. The parent append is now skipped when
-  the id already carries the `rp:`/`av:` prefix; a bare native id still gets the
-  parent composite so same-id-different-parent rows don't collapse. (#101)
+## [0.2.8] - 2026-06-22
 
 ### Changed
-- `search` now returns a concise `id/name/type/match` projection by default
-  instead of dumping whole raw JSON records (a token sink for agents). Pass
-  `--full` for the whole records. (#101)
-- MCP tool auth-error hints no longer tell MCP-only users to "Run `axcient-cli
-  doctor`" (a CLI command they can't reach) and instead point to setting
-  `AXCIENT_API_KEY` in the MCP server's configuration. The CLI's own error hints
-  still reference `doctor`, which is correct for CLI users. (#101)
 
-### Tests
-- Restored the hand-authored regression tests for the `restore_point`,
-  `autoverify`-sync, and `--strict`-naming fixes that the 0.2.3 engine refresh
-  silently dropped, and added them to the hand-fix ledger so a future reprint
-  cannot drop them again. Added tests for the concise `search` projection.
+- fix(axcient): MCP search returns concise projection by default (Refs #101) (#152)
+
+## [0.2.7] - 2026-06-20
+
+### Changed
+
+- fix(axcient): search finds 3-letter all-caps names + MCP search guidance (#148) (#149)
+
+## [0.2.6] - 2026-06-17
+
+### Changed
+
+- fix(axcient): MCP forwards the per-command client fleet filter (#130) (#131)
+
+## [0.2.5] - 2026-06-16
+
+### Changed
+
+- fix(axcient): restore_point sync descends into nested per-vault array (v0.2.5) (#84) (#123)
+- chore(deps): patch x/crypto, quic-go, x/sys in axcient + connectwise-control (#120)
+
+## [0.2.4] - 2026-06-16
+
+### Changed
+
+- fix(axcient): search projection + MCP auth-hint + restore_point/autoverify storage-key regression (v0.2.4) (#102)
+- fleet: re-vendor 48 connectors to printing-press 4.24.0 engine (#96)
+- chore(fleet): press-version provenance + back-fill hand-fix ledgers (#91)
 
 ## [0.2.3] - unreleased
 
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 
-## [0.2.2] - unreleased
+## [0.2.2] - 2026-06-12
 
 ### Changed
-- Standardized the local-store refresh step on one canonical command, bare
-  `axcient-cli sync`, across the quick-start, the morning-sweep recipe, and every
-  fleet command's help text and empty-store hint. Previously the docs and
-  per-command hints suggested five different `--resources` scopes
-  (`clients,device`, `clients,device,autoverify`, `clients,device,appliance`,
-  `clients,device,vault,appliance`, and bare), so "refresh the mirror" was
-  ambiguous depending on which surface you followed. Bare `sync` pulls every
-  top-level resource plus all dependents (restore points, AutoVerify, client-device
-  maps), so it is the complete, unambiguous refresh. (Reported in #86.)
 
-### Tests
-- Added a sync-wiring regression test that drives the per-device restore_point
-  endpoint with the live item shape (timestamp-string `restore_point_id`, no
-  `device_id`) through `syncDependentResource`, proving the typed table populates
-  with the `rp:<device_id>:<restore_point_id>` key - end-to-end coverage that
-  complements the store-layer `restore_point` tests shipped in 0.2.1.
+- fix(axcient): one canonical sync-refresh command + restore_point wiring regression (v0.2.2) (#89)
 
-## [0.2.1] - unreleased
+## [0.2.1] - 2026-06-12
 
-### Fixed
-- `restore_point` sync no longer stores zero rows. The live x360Recover endpoint
-  keys recovery points by a timestamp string (`restore_point_id`,
-  `YYYY_MM_DD_HH_MM_SS`) with no numeric `id`; ID extraction now recognizes it
-  and composes a fleet-collision-safe `rp:<device_id>:<restore_point_id>` key, so
-  the restore-point table (and the offline/fleet history that depends on it)
-  populates. The live `device restore-point` write-through caches the same items
-  instead of warning "not cached locally".
-- `sync --resources <dependent>` (e.g. the documented
-  `--resources clients,device,autoverify`) no longer reports a spurious failure.
-  Dependent resources (`autoverify`, `restore_point`, `client_device`) have no
-  flat list endpoint and are synced per-parent; naming one previously enqueued it
-  as a flat resource that failed ("unknown sync resource"), visible under
-  `--strict` as `1 resource(s) failed to sync`. They are now excluded from the
-  flat pass and still sync via the parent cascade.
-- `sync` failure errors now name the failing resource(s)
-  (`N resource(s) failed to sync: <names>`) instead of only a count, making a
-  `--strict` failure diagnosable.
+### Changed
+
+- fix(axcient): restore_point sync ID extraction + dependent-name flat-sync failure + strict error names (v0.2.1) (#85)
+- feat(maintainer): hand-fix ledger + enforcing gate so connector fixes survive reprints (#81)
 
 ## [0.2.0] - 2026-06-11
 

--- a/skills/cipp/CHANGELOG.md
+++ b/skills/cipp/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.2] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.1] - unreleased
 

--- a/skills/connectwise-control/CHANGELOG.md
+++ b/skills/connectwise-control/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-06-16
 
 ### Changed
-- Describe the changes in this release.
+
+- chore(deps): patch x/crypto, quic-go, x/sys in axcient + connectwise-control (#120)
+- chore(connectwise-control,rewst): pin toolchain go1.26.4 (patched stdlib) (#118)
+- feat(connectwise-control): new Remote Access connector (ConnectWise Control / ScreenConnect, press 4.24.0) (#99)
 
 ## [0.1.0]
 

--- a/skills/connectwise-manage/CHANGELOG.md
+++ b/skills/connectwise-manage/CHANGELOG.md
@@ -25,10 +25,13 @@ All notable changes to this skill are documented here. Format follows
 - Documented the **large/historical tenant playbook** across SKILL.md, guide.md, README, and the MCP `context` tool's `query_tips`: scope a heavy sync with a conditions filter (`sync --param "conditions=lastUpdated > [<iso>]"`), keep reads local (`--data-source local` / `--type`), and raise `--timeout` on big datasets. Corrected the prior claim that sync is incremental - ConnectWise list endpoints declare no temporal-filter parameter, so a plain sync re-fetches in full and `--since` has no effect on the sync itself (#146).
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-06-06
 
 ### Changed
-- Maintenance and packaging updates.
+
+- skill: connectwise-manage - ConnectWise Manage PSA connector UPDATE to 4.22.0 reprint, zero-review pipeline (#33)
+- fix(install): honor GITHUB_TOKEN/GH_TOKEN in fetch_stdout across all skills (#31)
+- feat(surfaces): generate every skill-enumerating surface; media on GitHub; Servosity live-verified (#21)
 
 ## [0.1.0]
 

--- a/skills/cove/CHANGELOG.md
+++ b/skills/cove/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.4] - unreleased
+## [0.1.4] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.3]
 

--- a/skills/datto-bcdr/CHANGELOG.md
+++ b/skills/datto-bcdr/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.2] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.1] - unreleased
 

--- a/skills/datto-rmm/CHANGELOG.md
+++ b/skills/datto-rmm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.2] - 2026-08-19
 
 ### Fixed
 - Open and resolved alerts now cache to the local SQLite mirror. Datto RMM

--- a/skills/hubspot/CHANGELOG.md
+++ b/skills/hubspot/CHANGELOG.md
@@ -20,10 +20,13 @@ All notable changes to this skill are documented here. Format follows
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-06-06
 
 ### Changed
-- Maintenance and packaging updates.
+
+- skill: hubspot - UPDATE to 4.22.0 reprint (zero-review pipeline) (#37)
+- fix(install): honor GITHUB_TOKEN/GH_TOKEN in fetch_stdout across all skills (#31)
+- feat(surfaces): generate every skill-enumerating surface; media on GitHub; Servosity live-verified (#21)
 
 ## [0.1.0]
 

--- a/skills/hubspot/CHANGELOG.md
+++ b/skills/hubspot/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.3] - unreleased
+## [0.1.3] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.2] - unreleased
 

--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.6] - unreleased
+## [0.1.6] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.5] - unreleased
 

--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -15,89 +15,33 @@ All notable changes to this skill are documented here. Format follows
   resolves to the latest patched Go, so the security gate scanned a patched
   toolchain while the build honoured the pinned one. See issue #210.
 
-## [0.1.5] - unreleased
+## [0.1.5] - 2026-07-17
 
-### Fixed
-- `sync` now detects a repeated `procedure-tasks` primary-key set before
-  upserting it, even if Hudu changes item order or non-key fields. Hudu can
-  return the complete collection while ignoring both `page` and `page_size`;
-  previously, the duplicate-page guard ran only after the same collection had
-  been upserted twice. That doubled `sync_complete.total` even though the cache
-  contained one distinct-ID set. The reported total is now reconciled to the
-  stored row count while paginated Hudu deployments remain fully supported.
-  Thanks @Xenith-B (#183).
+### Changed
 
-## [0.1.4] - unreleased
+- fix(hudu): reconcile procedure task sync totals (#194)
+- chore(fleet): bump Go toolchain to go1.26.5 across 54 connectors (GO-2026-5856) (#189)
 
-### Fixed
-- `sync` now pages the `relations` resource at `page_size=25` instead of the
-  global 100. Hudu's `/relations` endpoint returns HTTP 500 when walked at
-  page_size 100 beyond the first page, so every `sync` failed on `relations`
-  and exhausted its retries. (A direct `relations list` at page_size 100/25/1
-  all succeed; only sync's page-2 request at size 100 500s, so `relations` is
-  not non-paginated like the IPAM family - it just needs the smaller page.) 25
-  is Hudu's documented default page size, and the size the mature
-  n8n-nodes-hudu client uses to retrieve every relation, so the `?page=N` walk
-  now fetches the full collection with no truncation. `relations list` also
-  defaults to `--page-size 25` so manual paging does not hit the same 500.
-  Thanks @Xenith-B (#167).
+## [0.1.4] - 2026-07-07
 
-### Added
-- `sync --exclude <a,b,c>` skips the named resources, applied after
-  `--resources` (or the default set). Ideal for a scheduled daily sync that
-  skips slow or rarely-changing resources without having to enumerate every
-  resource to keep, e.g.
-  `sync --exclude public-photos,procedures,procedure-tasks`. Unknown resource
-  names fail loudly. Thanks @Xenith-B (#169).
+### Changed
 
-### Documented
-- `procedures`/`procedure-tasks` are not broken (#168): the multi-minute sync
-  time is the cost of fetching the full collection now that pagination works
-  in v0.1.3 (v0.1.2 silently truncated to the first 100 rows). The
-  `pagination_cursor_missing` warning on `procedure-tasks` is a false alarm on
-  Hudu's `?page=N` endpoints - verify completeness with the local cache row
-  count, which exceeds one page when the data is complete. The SKILL and guide
-  now cover keeping a daily sync fast (`--exclude` / `--since` / `--latest-only`
-  / `--resources`) and the integration-ID discovery method for `matchers`.
-  Thanks @Xenith-B (#168).
+- fix(hudu): relations page_size=25 + sync --exclude (#167, #168, #169) (#181)
 
-## [0.1.3] - unreleased
+## [0.1.3] - 2026-06-26
 
-### Fixed
-- `sync` and the `list` commands no longer send `page` to Hudu's IPAM-family
-  endpoints (`ip-addresses`, `networks`, `vlans`, `vlan-zones`,
-  `rack-storage-items`). The v0.1.2 fix correctly dropped `page_size` but then
-  assumed these endpoints page by `page` - they don't: they are non-paginated
-  and reject `page` with the same HTTP 400, so every sync after the first page
-  failed and stored zero rows. They now fetch the full collection in a single
-  request. The non-functional `--page`/`page` MCP arg is removed for them.
-  Thanks @Xenith-B (#158).
-- `sync` now advances through every page of the paginated resources instead of
-  stopping after the first 100 rows. The pagination profile declared
-  `cursorType ""`, which disabled the `?page=N` page-int fallback, so any
-  resource with more than one page was silently truncated (v0.1.2's new
-  "data may be truncated" warning is what surfaced it on `expirations`,
-  `folders`, `public-photos`, `relations`, and `procedure-tasks`). Set to
-  `cursorType "page"` so the walk runs until a short/empty page. Thanks
-  @Xenith-B (#158).
-- `sync` now skips `matchers` (with a warning) instead of failing on it every
-  run. Hudu's `/matchers` requires an `integration_id` and returns HTTP 500
-  without one; a flat sync cannot supply it, and the connector exposes no
-  endpoint to enumerate integration IDs. Fetch matchers per integration with
-  `hudu-cli matchers list --integration-id <id>`, or
-  `hudu-cli sync --resource-param matchers:integration_id=<id>`. Thanks
-  @Xenith-B (#159).
+### Changed
 
-## [0.1.2] - unreleased
+- fix(hudu): IPAM endpoints are non-paginated, enable the page walk, skip matchers (#158, #159) (#161)
 
-### Fixed
-- `sync` and the `list` commands no longer send the unsupported `page_size`
-  parameter to Hudu's IPAM-family endpoints (`ip-addresses`, `networks`, `vlans`,
-  `vlan-zones`, `rack-storage-items`). Hudu rejected it with HTTP 400
-  ("page_size is not a valid filter parameter.") and those resources stored zero
-  rows. They are now paged by `page` alone and drained until an empty page, so
-  they sync fully, without truncation. The non-functional `--page-size` flag is
-  removed from those five commands. Thanks @Xenith-B for the detailed report (#153).
+## [0.1.2] - 2026-06-22
+
+### Changed
+
+- fix(hudu): stop sending page_size to IPAM endpoints that reject it (#153) (#156)
+- fleet: re-vendor 48 connectors to printing-press 4.24.0 engine (#96)
+- chore(fleet): press-version provenance + back-fill hand-fix ledgers (#91)
+- fix: drop false "with sound" demo claim, highlight first-party Servosity, point backup/DR skills at Servosity (#77)
 
 ## [0.1.0]
 

--- a/skills/huntress/CHANGELOG.md
+++ b/skills/huntress/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.2] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.1] - unreleased
 

--- a/skills/maxio/CHANGELOG.md
+++ b/skills/maxio/CHANGELOG.md
@@ -4,17 +4,9 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.0.0]
+## [0.1.0] - 2026-07-01
 
-### Added
-- Initial msp-skills release: Maxio Advanced Billing CLI + MCP server.
-- Offline revenue intelligence computed from a local SQLite mirror that snapshots
-  each sync into a time series: MRR movement waterfall (new / expansion /
-  contraction / churn / reactivation), net and gross revenue retention, quick
-  ratio, and signup-month cohort curves.
-- Per-customer recurring-revenue history (`mrr client`), new-logo tracking
-  (`new-customers`), renewal exposure (`renewals`), usage-driven expansion vs
-  contraction (`usage-drivers`), and normalized-vs-invoiced reconciliation
-  (`reconcile`).
-- Account triage rollup, full Maxio Advanced Billing endpoint surface, full-text
-  search over synced data, and `--agent` JSON mode for AI agents.
+### Changed
+
+- feat(maxio): add Maxio Advanced Billing connector (revenue, MRR, retention) (#173)
+

--- a/skills/microsoft-graph/CHANGELOG.md
+++ b/skills/microsoft-graph/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.2.0] - unreleased
-
-### Added
-- `apps consent`: a read-only third-party app consent inventory. Joins service principals, delegated consent grants (`oauth2PermissionGrants`), and application/app-only permissions (`appRoleAssignments`) into one risk-ranked table, flagging over-privileged, admin-consented, privilege-escalation, and user-consented (shadow IT) apps with least-privilege framing. Microsoft first-party apps are counted but not listed. Needs read scopes `Application.Read.All`, `Directory.Read.All`, and `DelegatedPermissionGrant.Read.All`.
+## [0.2.0] - 2026-07-04
 
 ### Changed
-- Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
+
+- feat(microsoft-graph): read-only apps consent audit + governance-snapshot kit (#177)
+- fleet: re-vendor 48 connectors to printing-press 4.24.0 engine (#96)
+- chore(fleet): press-version provenance + back-fill hand-fix ledgers (#91)
 
 ## [0.1.0]
 

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -23,32 +23,17 @@ All notable changes to this skill are documented here. Format follows
 ### Changed
 - Bumped the Go toolchain to go1.26.5 (clears the `crypto/tls` standard-library advisory GO-2026-5856).
 
-## [0.1.5] - unreleased
+## [0.1.5] - 2026-07-07
 
-### Fixed
-- `sync` now continues through NinjaOne `/v2/queries/*` report pages when the API
-  keeps the same `cursor.name` token but advances the cursor object's `offset`.
-  The loop still sends the valid cursor token to the API, but uses the offset as
-  the internal progress key so large report resources no longer stop at 200 rows
-  with `stuck_pagination`. Thanks to @Xenith-B for the live-tenant report (#179).
+### Changed
 
-## [0.1.4] - unreleased
+- fix(ninjaone): keep query object cursor paging advancing
 
-### Fixed
-- `sync` now stores correct rows for the four `/v2/queries/custom-fields*` report
-  variants, which previously cached **zero** rows. Like the rest of the
-  `/v2/queries/*` family these rows carry no top-level `id`, so the generic key
-  path skipped every one of them (`all_items_failed_id_extraction`). The source
-  API schema confirms the row shapes:
-  - `queries-custom-fields` / `queries-custom-fields-detailed` return one row per
-    device (all values packed into a `fields` map/array), so each now keys on
-    `deviceId`.
-  - `queries-scoped-custom-fields` / `queries-scoped-custom-fields-detailed`
-    return one row per (`scope`, `entityId`); since `entityId` is unique only
-    within a scope, each now keys on `entityId` plus a `scope` discriminator so a
-    device and an organization sharing an id never collapse together.
-  Offline SQL and full-text `search` now see these custom-field reports. This
-  completes the `/v2/queries/*` storage fix begun in 0.1.3. (#137)
+## [0.1.4] - 2026-06-18
+
+### Changed
+
+- fix(ninjaone): store the queries-custom-fields* report variants (#137) (#142)
 
 ## [0.1.3]
 

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.7] - unreleased
+## [0.1.7] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.6] - 2026-07-10
 

--- a/skills/quickbooks/CHANGELOG.md
+++ b/skills/quickbooks/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.5] - unreleased
+## [0.1.5] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.4] - unreleased
 

--- a/skills/quickbooks/CHANGELOG.md
+++ b/skills/quickbooks/CHANGELOG.md
@@ -15,17 +15,12 @@ All notable changes to this skill are documented here. Format follows
   resolves to the latest patched Go, so the security gate scanned a patched
   toolchain while the build honoured the pinned one. See issue #210.
 
-## [0.1.4] - unreleased
+## [0.1.4] - 2026-06-26
 
-### Added
-- `report pnl` and `report balance-sheet` pull QuickBooks' financial statements
-  straight from the Reports API (`/reports/ProfitAndLoss`, `/reports/BalanceSheet`),
-  which the `/query` endpoint the rest of this skill rides cannot reach. `report
-  pnl` returns recognized revenue, COGS, gross and operating margin, and net
-  income for a period (default: last closed month); `report balance-sheet` returns
-  every account and summary as of a date, with an opt-in repeatable `--highlight
-  <substring>` flag that totals any account or group by name. Both are read-only.
-  Recorded as hand-fix `qbo-report-reports-api`.
+### Changed
+
+- feat(quickbooks): report pnl + report balance-sheet (v0.1.4) (#163)
+- chore(quickbooks): redact real tenant transaction counts + add CI guard (#162)
 
 ## [0.1.3] - 2026-06-16
 
@@ -56,23 +51,12 @@ All notable changes to this skill are documented here. Format follows
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-06-13
 
-### Fixed
-- `sync` now stores rows. It was sending a bare `/query` with no SQL, which
-  QuickBooks Online answers with an HTTP 200 `SystemFault` envelope, so every
-  resource failed with `missing id for <resource>` and the offline mirror stayed
-  empty (`ar-aging`, `ap-aging`, `dso`, `balances`, `reconcile` all returned
-  zeros). `sync` now injects `select * from <Entity>` plus `minorversion` per
-  resource and unwraps QuickBooks' `QueryResponse.<Entity>` envelope. Verified
-  live against a sandbox tenant: 227 records across 8 resources. Recorded as
-  hand-fixes `qbo-query-injection` and `qbo-queryresponse-envelope` so a
-  cli-printing-press reprint cannot silently revert it.
+### Changed
 
-### Note
-- This release caps `sync` at 1000 rows per entity (no STARTPOSITION paging).
-  Large production books need press-side pagination; tracked in the hand-fix
-  ledger's `spec_encode_followup`.
+- fix(quickbooks): sync injects /query SQL so the offline mirror hydrates (v0.1.1) (#90)
+- fix: drop false "with sound" demo claim, highlight first-party Servosity, point backup/DR skills at Servosity (#77)
 
 ## [0.1.0]
 

--- a/skills/sentinelone/CHANGELOG.md
+++ b/skills/sentinelone/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.2] - unreleased
+## [0.1.2] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.1] - unreleased
 

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.5.0] - unreleased
+## [0.5.0] - 2026-08-17
 
 Regenerated the vendored `servosity-cli` / `servosity-mcp` source from
 cli-printing-press 4.24.0 to 4.30.3 (engine swap). This release carries five

--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.4] - unreleased
+## [0.1.4] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.3] - unreleased
 

--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -15,23 +15,22 @@ All notable changes to this skill are documented here. Format follows
   resolves to the latest patched Go, so the security gate scanned a patched
   toolchain while the build honoured the pinned one. See issue #210.
 
-## [0.1.3] - unreleased
-
-### Fixed
-- Restored the `CustomerSubDomain` request header and EU region routing that the
-  v0.1.2 reprint silently dropped. Without the header, SuperOps' API gateway
-  rejected every request with HTTP 400 (empty body) before it reached the GraphQL
-  layer - breaking all API connectivity versus v0.1.0. Set `SUPEROPS_SUBDOMAIN`
-  (your tenant subdomain, sent as the `CustomerSubDomain` header) and optionally
-  `SUPEROPS_REGION=eu` (routes to `euapi.superops.ai`). Reported by @AvlCompCo (#132).
-
-## [0.1.2] - unreleased
-
-### Fixed
-- Typed `list`/`get` commands (`clients`, `assets`, `tickets`, and every other entity) no longer fail with GraphQL `SubSelectionNotAllowed` errors. The queries requested association/enum fields (`accountManager`, `primaryContact`, `hqSite`, `client`, `site`, `status`, `priority`, `requester`, `technician`, and others) with object sub-selections, but the SuperOps schema returns those fields as scalar leaf types (JSON/String); they are now requested as the scalars they are. Thanks to @AvlCompCo for the detailed report (#114).
+## [0.1.3] - 2026-06-17
 
 ### Changed
-- Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.
+
+- fix(superops): restore CustomerSubDomain header + EU region routing (#132) (#134)
+
+## [0.1.2] - 2026-06-16
+
+### Changed
+
+- docs(superops): consolidate 0.1.1 fix into the 0.1.2 release section (#114)
+- fix(superops): request scalar GraphQL fields without sub-selections (#114) (#126)
+- fleet: re-vendor 48 connectors to printing-press 4.24.0 engine (#96)
+- chore(fleet): press-version provenance + back-fill hand-fix ledgers (#91)
+- fix: drop false "with sound" demo claim, highlight first-party Servosity, point backup/DR skills at Servosity (#77)
+- fix(install): honor GITHUB_TOKEN/GH_TOKEN in fetch_stdout across all skills (#31)
 
 ## [0.1.0]
 

--- a/skills/threatlocker/CHANGELOG.md
+++ b/skills/threatlocker/CHANGELOG.md
@@ -4,10 +4,26 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.3.1] - unreleased
+## [0.3.1] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
+
+### Fixed
+
+- **MCP tools are no longer default-denied.** Every tool that is not a Cobra
+  mirror - `search`, `sql`, `context`, and the `threatlocker_search` / `threatlocker_get` /
+  `threatlocker_execute` code-orchestration trio - returned
+  `MCP tenant gate is not configured` instead of running. The generated tenant
+  gate treated "no platform source registered" as a failure rather than as
+  "nothing to gate", and no connector registers one. The previously released
+  binary had 6 dead tools. See issue #249.
 
 ## [0.3.0] - unreleased
 

--- a/skills/threatlocker/CHANGELOG.md
+++ b/skills/threatlocker/CHANGELOG.md
@@ -25,34 +25,11 @@ All notable changes to this skill are documented here. Format follows
   "nothing to gate", and no connector registers one. The previously released
   binary had 6 dead tools. See issue #249.
 
-## [0.3.0] - unreleased
-
-### Added
-- `sync` now covers `application-files` and `maintenance`. Both are keyed by a parent
-  (an application, a computer) that the API requires as a query parameter, so a flat
-  sync could never fetch them and both tables stayed empty. Sync now walks each parent
-  already in the local store and fetches its children, running after the parent
-  resources so their ids are available. `applications hunt`'s trusted-file matching
-  reads `application-files`, so it works from a plain `sync` for the first time.
-
-### Fixed
-- `doctor` told you to run `threatlocker-cli applications get` to confirm your token
-  worked. That command needs `--application-id`, so a bare run printed help and exited
-  0 without ever contacting the API, and a broken token looked fine. `doctor` now names
-  a command that actually makes a call, and a test drives every suggestion against a
-  fixture so a suggestion that cannot run fails the build. Reported by @geekbrownbear
-  in #217.
-- `reports` stored nothing. The endpoint returns report *categories* rather than
-  individual reports, and no row key was configured for that shape, so every row was
-  discarded.
-- `scheduled-actions` stored nothing and reported `HTTP 417 Invalid Scheduled Agent
-  Action Type provided` on every sync. Sync was calling a route that requires an action
-  type it cannot know; it now uses the paginated search endpoint, which needs no such
-  parameter.
+## [0.3.0] - 2026-08-14
 
 ### Changed
-- `computers list`, `organizations list`, `applications search` and `approvals list`
-  cover the whole managed tree by default (carried forward from 0.2.0).
+
+- fix(threatlocker): sync the last four resources, and stop doctor recommending a command that cannot run (#227)
 
 ## [0.2.0]
 

--- a/skills/unifi-network/CHANGELOG.md
+++ b/skills/unifi-network/CHANGELOG.md
@@ -4,10 +4,26 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
+
+### Fixed
+
+- **MCP tools are no longer default-denied.** Every tool that is not a Cobra
+  mirror - `search`, `sql`, `context`, and the `unifi_search` / `unifi_get` /
+  `unifi_execute` code-orchestration trio - returned
+  `MCP tenant gate is not configured` instead of running. The generated tenant
+  gate treated "no platform source registered" as a failure rather than as
+  "nothing to gate", and no connector registers one. The previously released
+  binary had 6 dead tools. See issue #249.
 
 ## [0.1.0]
 

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -15,11 +15,9 @@ All notable changes to this skill are documented here. Format follows
   resolves to the latest patched Go, so the security gate scanned a patched
   toolchain while the build honoured the pinned one. See issue #210.
 
-## [0.0.0]
+## [0.1.0] - 2026-07-01
 
-### Added
-- Initial msp-skills release: `wordpress-cli` plus the `wordpress-mcp` MCP server.
-- Pages, posts, media, categories, tags, users, and settings over the WordPress REST API.
-- `media upload` for binary multipart uploads (images, video, audio, PDF), returning the media id.
-- Local SQLite mirror via `workflow archive` / `sync` with full-text `search` for offline cross-content queries.
-- Agent surface: `--agent`, `--dry-run`, `--select`, named profiles, and `--deliver` output sinks.
+### Changed
+
+- feat(wordpress): add WordPress pages/posts/media connector (#171)
+

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.0.0]
 

--- a/skills/zammad/CHANGELOG.md
+++ b/skills/zammad/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.1] - 2026-08-17
 
-### Changed
-- Describe the changes in this release.
+### Security
+
+- Go toolchain bumped to **go1.26.6**, which fixes **GO-2026-6218** (quadratic
+  complexity in `net/url`, reachable from `cliutil.ProbeReachable`). The
+  previously released binary was built with go1.26.5 and carried the advisory.
+  CI could not catch this: the workflows request `go-version: "1.26"`, which
+  resolves to the latest patched Go, so the security gate scanned a patched
+  toolchain while the build honoured the pinned one. See issue #210.
 
 ## [0.1.0]
 

--- a/tools/maintainer/changelog_section.py
+++ b/tools/maintainer/changelog_section.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""changelog_section.py - the release body for one skill version, from its CHANGELOG.
+
+    python3 tools/maintainer/changelog_section.py --slug zammad --version 0.1.1
+
+Why this exists
+---------------
+`gh release create --generate-notes` computes its range against the previous tag
+in the REPO. In a monorepo with per-skill tags, that is whatever unrelated
+skill's tag happens to sort before this one, so the generated notes list every
+PR merged in between regardless of what it touched.
+
+`zammad-v0.1.1` shipped notes advertising the auvik onboarding, four CI fixes and
+a fleet toolchain sweep, footed with `compare/unifi-network-v0.1.0...zammad-v0.1.1`.
+Accurate about the commit range; useless and misleading about the connector. An
+MSP reading it cannot tell what changed in the thing they installed.
+
+The per-skill `CHANGELOG.md` section is the authoritative human-written answer,
+and `release.py` already maintains it. This just extracts it.
+
+It REFUSES a placeholder section (exit 2). A release whose notes say "Describe
+the changes in this release." is not better than the generated ones - it is the
+same failure with fewer words. Failing here forces the section to be written
+before the tag goes out, which is the only point where anyone still remembers
+what changed.
+
+Exit codes: 0 section printed. 2 missing or placeholder section. 1 bad usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+
+# Text release.py stamps into a fresh section. If it survives to release time,
+# nobody filled the section in.
+PLACEHOLDERS = (
+    "describe the changes in this release",
+    "- unreleased",
+)
+
+
+def section(slug: str, version: str) -> tuple[str | None, str]:
+    """Return (body, reason). body is None when unusable."""
+    path = REPO / "skills" / slug / "CHANGELOG.md"
+    if not path.is_file():
+        return None, f"no CHANGELOG.md for {slug}"
+    text = path.read_text()
+
+    # Match "## [1.2.3]" through the next "## [" heading (or EOF).
+    pattern = re.compile(
+        r"^##\s*\[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^##\s*\[|\Z)",
+        re.S | re.M,
+    )
+    m = pattern.search(text)
+    if not m:
+        return None, f"no section '## [{version}]' in skills/{slug}/CHANGELOG.md"
+
+    heading = text[m.start(): m.start(1)].strip()
+    body = m.group(1).strip()
+    if not body:
+        return None, f"section '## [{version}]' is empty"
+
+    blob = (heading + "\n" + body).lower()
+    for ph in PLACEHOLDERS:
+        if ph in blob:
+            return None, (
+                f"section '## [{version}]' for {slug} still carries the release.py "
+                f"placeholder ({ph!r}). Write what actually changed, and date the "
+                f"heading, before tagging."
+            )
+    return body, "ok"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--slug", required=True)
+    ap.add_argument("--version", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="report usability without printing the body")
+    args = ap.parse_args()
+
+    body, reason = section(args.slug, args.version)
+    if body is None:
+        print(reason, file=sys.stderr)
+        return 2
+    print(f"{args.slug} {args.version}: ok" if args.check else body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/maintainer/release.py
+++ b/tools/maintainer/release.py
@@ -31,7 +31,9 @@ Pure stdlib. Run locally:
 
 from __future__ import annotations
 
+import datetime
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -72,12 +74,44 @@ def bump_version(version: str, kind: str) -> str:
 
 
 def changelog_section(version: str) -> str:
-    """A new Keep-a-Changelog section with a placeholder bullet."""
+    """A new Keep-a-Changelog section, dated today, with a placeholder bullet.
+
+    Dated, not "unreleased": this section is created BY a release, for the
+    version being released right now, so "unreleased" is wrong the moment it is
+    written. It also used to survive into the shipped GitHub release notes -
+    every tag in the 2026-08-17 fleet batch went out headed "unreleased".
+
+    The placeholder bullet stays. changelog_section.py refuses to build release
+    notes from it, which is the forcing function to write what actually changed
+    while someone still remembers.
+    """
     return (
-        f"## [{version}] - unreleased\n\n"
+        f"## [{version}] - {_today()}\n\n"
         "### Changed\n"
         "- Describe the changes in this release.\n\n"
     )
+
+
+def _today() -> str:
+    return datetime.date.today().isoformat()
+
+
+def _date_existing_heading(content: str, version: str) -> str | None:
+    """Stamp today's date on an existing '## [version]' heading that is undated
+    or still says "unreleased". Returns None when nothing needs changing.
+
+    A hand-written section prepared ahead of the release carries no date (or
+    says "unreleased"); the release is the moment that becomes knowable, so
+    stamp it here rather than asking a human to remember.
+    """
+    pat = re.compile(r"^##\s*\[" + re.escape(version) + r"\]([^\n]*)$", re.M)
+    m = pat.search(content)
+    if not m:
+        return None
+    tail = m.group(1).strip()
+    if re.fullmatch(r"-\s*\d{4}-\d{2}-\d{2}", tail):
+        return None  # already dated
+    return content[:m.start()] + f"## [{version}] - {_today()}" + content[m.end():]
 
 
 class Planner:
@@ -162,6 +196,11 @@ def propagate(slug: str, new_version: str, bumped: bool, planner: Planner) -> No
             if heading not in cl:
                 new_cl = _insert_changelog(cl, new_version)
                 planner.write_text(cl_path, new_cl, f'insert section [{new_version}]')
+            else:
+                # Section written ahead of the release: stamp the date now.
+                dated = _date_existing_heading(cl, new_version)
+                if dated is not None:
+                    planner.write_text(cl_path, dated, f'date section [{new_version}]')
 
     # tools/maintainer/skills.json (version + cli_hash_at_release)
     reg = _read_json(REGISTRY)


### PR DESCRIPTION
Every release from the 2026-08-17 fleet batch shipped notes about **other connectors**. From [`zammad-v0.1.1`](https://github.com/Servosity/msp-skills/releases/tag/zammad-v0.1.1):

```
## What's Changed
* fix(ci): unblock outside contributors ... (#228)
* docs: make contributing readable for MSPs ... (#233)
* skill(auvik): Auvik network-monitoring connector (CLI + MCP) (#238)
* chore(fleet): bump Go toolchain to go1.26.6 across 58 connectors (#244)
...
**Full Changelog**: .../compare/unifi-network-v0.1.0...zammad-v0.1.1
```

Nothing in there tells an MSP what changed in **zammad**.

## Cause

`gh release create --generate-notes` computes its range against the previous tag in the **repo**. With per-skill tags in a monorepo that is whatever unrelated skill sorts before this one - here `unifi-network-v0.1.0` - so the notes list every PR merged in between regardless of what it touched.

It gets worse as more skills ship, and all 16 tags in that batch pointed at the same commit, so every one drew from the same irrelevant range.

## Fix

Notes now come from `skills/<slug>/CHANGELOG.md` - the authoritative human-written answer, already maintained by `release.py`.

`tools/maintainer/changelog_section.py` extracts one version's section and **refuses a placeholder** (exit 2):

```
$ changelog_section.py --slug zammad --version 0.1.1     # before the backfill
section '## [0.1.1]' for zammad still carries the release.py placeholder
('describe the changes in this release'). Write what actually changed, and
date the heading, before tagging.
rc=2

$ changelog_section.py --slug halopsa --version 0.2.7    # real content
### Fixed
- `--since` now accepts the RFC3339 timestamps its own help documents...
rc=0
```

The refusal matters more than the extraction. `release.py` stamps `## [x.y.z] - unreleased` with "Describe the changes in this release."; if that survives to release time the notes are the same failure with fewer words. Failing at the tag is the last moment anyone still remembers what changed.

## Backfill

**All 17 sections from that batch were shipped as placeholders. That was my error** - they should have been written before the tag. Each now states what actually changed:

| | |
|---|---|
| all 17 | go1.26.6 toolchain, GO-2026-6218 |
| axcient | + `x/text` v0.39.0, GO-2026-5970 |
| threatlocker, unifi-network, auvik | + MCP tenant-gate fix (#249) |
| auvik | + Windows binaries that had never compiled |
| servosity | already had real content; dated only |

Headings now carry the release date instead of `unreleased`. All 17 pass `changelog_section.py --check`.

The **published** GitHub release bodies are already live and are backfilled separately from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Release notes now use the relevant version’s documented changelog entries.
  - Existing releases continue to be reused, while incomplete or missing release documentation is flagged during publishing.

- **Documentation**
  - Finalized release notes across multiple skills with dated entries and security updates for Go 1.26.6.
  - Documented fixes restoring previously unavailable MCP tools and enabling Windows release binaries for applicable skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->