### PR TITLE
fix(datto-rmm): cache open and resolved alerts by alertUid (#258)

### DIFF
--- a/skills/datto-rmm/CHANGELOG.md
+++ b/skills/datto-rmm/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.2] - unreleased
+
+### Fixed
+- Open and resolved alerts now cache to the local SQLite mirror. Datto RMM
+  identifies an alert only by `alertUid`, which the generic primary-key
+  detection did not recognize, so every `sync` consumed alerts and stored none
+  of them - `fleet storms`, alert search, and any offline alert query saw an
+  empty table while live queries kept working. Reported with a full diagnosis by
+  [@zendzipr](https://github.com/zendzipr) ([#258](https://github.com/Servosity/msp-skills/issues/258)).
 
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.

--- a/skills/datto-rmm/cli/internal/cli/sync.go
+++ b/skills/datto-rmm/cli/internal/cli/sync.go
@@ -1524,6 +1524,15 @@ func syncResourcePath(resource string) (string, error) {
 // flat paths.
 var resourceIDFieldOverrides = map[string]string{
 	"activity-logs": "id",
+	// Datto RMM alerts key on `alertUid` and carry no id/uid/uuid/name field,
+	// so every generic fallback misses and the suffix fallback cannot help
+	// either: it probes "<resource>_id"-style keys against the resource name
+	// ("account-alerts-open"), never the "alert" stem, and only by direct
+	// snake_case map lookup. Result before this override: every alert row
+	// failed ID extraction and sync stored 0 of N (#258). The snake_case key
+	// resolves the camelCase JSON field via LookupFieldValue.
+	"account-alerts-open":     "alert_uid",
+	"account-alerts-resolved": "alert_uid",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did

--- a/skills/datto-rmm/cli/internal/cli/sync_alert_id_test.go
+++ b/skills/datto-rmm/cli/internal/cli/sync_alert_id_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import "testing"
+
+// extractID and store.ExtractResourceID are separate implementations reading
+// separate override maps. Divergence between them is itself a silent-drop bug:
+// sync would count an alert as consumed while the store dropped it. #258 fixed
+// both maps; this test fails if a future edit touches only one.
+func TestExtractID_AlertUidOverride(t *testing.T) {
+	obj := map[string]any{
+		"alertUid": "16c466e9-9dfd-4ad1-a9cf-c02ea18eebcd",
+		"priority": "High",
+		"resolved": false,
+	}
+	const want = "16c466e9-9dfd-4ad1-a9cf-c02ea18eebcd"
+	for _, resource := range []string{"account-alerts-open", "account-alerts-resolved"} {
+		if got := extractID(resource, obj); got != want {
+			t.Errorf("extractID(%q) = %q, want %q", resource, got, want)
+		}
+	}
+}
+
+// Both alert resources are in the default sync set, so the override map keys
+// must match the resource names sync actually dispatches — a typo here would
+// silently restore the 0-stored behaviour.
+func TestAlertOverridesMatchSyncResourceNames(t *testing.T) {
+	known := map[string]bool{}
+	for _, name := range knownSyncResourceNames() {
+		known[name] = true
+	}
+	for resource, field := range resourceIDFieldOverrides {
+		if !known[resource] {
+			t.Errorf("override for %q is not a known sync resource", resource)
+		}
+		if field == "" {
+			t.Errorf("override for %q is empty", resource)
+		}
+	}
+	for _, resource := range []string{"account-alerts-open", "account-alerts-resolved"} {
+		if resourceIDFieldOverrides[resource] != "alert_uid" {
+			t.Errorf("missing alert_uid override for %q", resource)
+		}
+	}
+}
+
+func TestExtractID_NonAlertResourcesUnchanged(t *testing.T) {
+	if got := extractID("account-devices", map[string]any{"uid": "dev", "id": "7"}); got != "7" {
+		t.Errorf("account-devices = %q, want 7", got)
+	}
+	if got := extractID("account-users", map[string]any{"alertUid": "leaked"}); got != "" {
+		t.Errorf("alertUid must not leak into the generic list, got %q", got)
+	}
+}

--- a/skills/datto-rmm/cli/internal/store/alert_id_override_test.go
+++ b/skills/datto-rmm/cli/internal/store/alert_id_override_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// alertItem mirrors the shape /v2/account/alerts/{open,resolved} returns: the
+// primary key is the camelCase `alertUid` and there is no id/uid/uuid/name/
+// slug/key/code field anywhere on the object (see internal/types.Alert). Before
+// the resourceIDFieldOverrides entries, every generic fallback missed, the
+// suffix fallback probed "account-alerts-open_id"-style keys that do not exist,
+// and sync consumed N alerts while storing 0 of them (#258).
+const alertItem = `{
+  "alertUid": "16c466e9-9dfd-4ad1-a9cf-c02ea18eebcd",
+  "alertContext": {"@class": "diskusage_ctx"},
+  "priority": "High",
+  "resolved": false,
+  "muted": false,
+  "ticketNumber": "",
+  "timestamp": "1787069191000"
+}`
+
+func TestExtractResourceID_AlertUidOverride(t *testing.T) {
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(alertItem), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	const want = "16c466e9-9dfd-4ad1-a9cf-c02ea18eebcd"
+	for _, resource := range []string{"account-alerts-open", "account-alerts-resolved"} {
+		if got := ExtractResourceID(resource, obj); got != want {
+			t.Errorf("ExtractResourceID(%q) = %q, want %q", resource, got, want)
+		}
+	}
+}
+
+// The snake_case override key must resolve the API's camelCase rendering;
+// this is the only reason a "alert_uid" override can match "alertUid".
+func TestLookupFieldValue_AlertUidCamelCase(t *testing.T) {
+	obj := map[string]any{"alertUid": "abc"}
+	if got := LookupFieldValue(obj, "alert_uid"); got != "abc" {
+		t.Errorf("LookupFieldValue(alert_uid) = %v, want abc", got)
+	}
+}
+
+// A paginated batch must report consumed == stored with zero extraction
+// failures — the exact counter pair the #258 sync_anomaly reported as 250/0.
+func TestUpsertBatch_AlertsStoreEveryRow(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	for _, resource := range []string{"account-alerts-open", "account-alerts-resolved"} {
+		items := make([]json.RawMessage, 0, 25)
+		for i := 0; i < 25; i++ {
+			items = append(items, json.RawMessage(
+				`{"alertUid": "uid-`+resource+`-`+string(rune('a'+i%26))+`", "priority": "High"}`))
+		}
+		stored, extractFailures, err := s.UpsertBatch(resource, items)
+		if err != nil {
+			t.Fatalf("UpsertBatch(%s): %v", resource, err)
+		}
+		if stored != len(items) {
+			t.Errorf("%s: stored = %d, want %d", resource, stored, len(items))
+		}
+		if extractFailures != 0 {
+			t.Errorf("%s: extractFailures = %d, want 0", resource, extractFailures)
+		}
+	}
+}
+
+// The override is scoped to the two alert resources; every other resource must
+// keep resolving through the untouched generic fallback list.
+func TestExtractResourceID_NonAlertResourcesUnchanged(t *testing.T) {
+	cases := []struct {
+		resource string
+		obj      map[string]any
+		want     string
+	}{
+		{"account-devices", map[string]any{"uid": "dev-uid", "id": "7"}, "7"},
+		{"account", map[string]any{"uid": "site-uid", "name": "HQ"}, "site-uid"},
+		{"account-components", map[string]any{"uid": "comp-uid"}, "comp-uid"},
+		{"activity-logs", map[string]any{"id": "log-1", "uid": "ignored"}, "log-1"},
+		// An alert-shaped object under a resource with no override still has
+		// no extractable id — the override must not leak into the generic list.
+		{"account-users", map[string]any{"alertUid": "leaked"}, ""},
+	}
+	for _, c := range cases {
+		if got := ExtractResourceID(c.resource, c.obj); got != c.want {
+			t.Errorf("ExtractResourceID(%q) = %q, want %q", c.resource, got, c.want)
+		}
+	}
+}

--- a/skills/datto-rmm/cli/internal/store/store.go
+++ b/skills/datto-rmm/cli/internal/store/store.go
@@ -2340,6 +2340,15 @@ func (s *Store) UpsertSystem(data json.RawMessage) error {
 // path-item.
 var resourceIDFieldOverrides = map[string]string{
 	"activity-logs": "id",
+	// Datto RMM alerts key on `alertUid` and carry no id/uid/uuid/name field,
+	// so every generic fallback misses and the suffix fallback cannot help
+	// either: it probes "<resource>_id"-style keys against the resource name
+	// ("account-alerts-open"), never the "alert" stem, and only by direct
+	// snake_case map lookup. Result before this override: every alert row
+	// failed ID extraction and sync stored 0 of N (#258). The snake_case key
+	// resolves the camelCase JSON field via LookupFieldValue.
+	"account-alerts-open":     "alert_uid",
+	"account-alerts-resolved": "alert_uid",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did

--- a/skills/datto-rmm/handfixes.json
+++ b/skills/datto-rmm/handfixes.json
@@ -1,0 +1,46 @@
+{
+  "slug": "datto-rmm",
+  "doc": "docs/reprint-survival.md",
+  "_comment": "Connector-specific edits to GENERATED files that a cli-printing-press reprint must NOT clobber. check_handfixes.py asserts every marker below is still present and fails CI if a reprint dropped one.",
+  "handfixes": [
+    {
+      "id": "alert-uid-resource-id-override",
+      "summary": "account-alerts-open / account-alerts-resolved key on `alert_uid` (the API's camelCase `alertUid`) in resourceIDFieldOverrides, in BOTH the sync extractor and the store extractor",
+      "why": "Datto RMM alert objects carry no id/uid/uuid/name/slug/key/code field -- `alertUid` is the only identifier (see internal/types.Alert). Every entry in genericIDFieldFallbacks therefore misses, and suffixIDFieldFallback cannot help either: it derives probes from the RESOURCE name (\"account-alerts-open\" -> \"account-alerts-open_id\"), never the \"alert\" stem, and matches by direct snake_case map lookup so it would never see camelCase `alertUid` regardless. Result before this override: sync consumed every alert and stored zero, emitting sync_anomaly all_items_failed_id_extraction (250/0), leaving local alert search and fleet analytics silently blind. Reported by @zendzipr in #258. The override map is duplicated in internal/cli/sync.go and internal/store/store.go -- both must carry it; fixing only one restores the silent drop.",
+      "status": "active",
+      "spec_encode_followup": "The durable fix is upstream: the press profiler should set IDField from the response-item schema when the item declares exactly one identifier-shaped field (`<stem>Uid`/`<stem>Id`) and no generic id. Filed as a /printing-press-retro item. Until the press emits it, or the Datto spec carries x-resource-id on /v2/account/alerts/{open,resolved}, this ledger entry is what survives a reprint.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "\"account-alerts-open\":     \"alert_uid\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "\"account-alerts-resolved\": \"alert_uid\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"account-alerts-open\":     \"alert_uid\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/store.go",
+          "contains": "\"account-alerts-resolved\": \"alert_uid\"",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/store/alert_id_override_test.go",
+          "contains": "TestUpsertBatch_AlertsStoreEveryRow",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync_alert_id_test.go",
+          "contains": "TestAlertOverridesMatchSyncResourceNames",
+          "min_count": 1
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #258 — reported with a full and accurate diagnosis by @zendzipr.

## The bug

Datto RMM alert objects carry **no** `id`/`uid`/`uuid`/`name`/`slug`/`key`/`code` field. `alertUid` is the only identifier (see `internal/types.Alert`). So:

- every entry in `genericIDFieldFallbacks` missed, and
- `suffixIDFieldFallback` could not help either — it builds its probes from the **resource** name (`account-alerts-open` → `account-alerts-open_id`), never the `alert` stem, and matches by direct snake_case map lookup, so it would never see the camelCase `alertUid` regardless.

The failure was silent data loss. `sync` consumed every alert and stored none of them:

```
warning: 250/250 account-alerts-open items returned but not cached locally
{"event":"sync_anomaly","resource":"account-alerts-open","consumed":250,"stored":0,
 "reason":"all_items_failed_id_extraction"}
```

Live queries kept working, so `fleet storms`, alert search, and every offline alert query saw an empty table with no obvious cause.

## The fix

An `alert_uid` `resourceIDFieldOverrides` entry for both alert resources. The snake_case key resolves the camelCase JSON field through `LookupFieldValue`.

The override map is **duplicated** in the sync extractor (`internal/cli/sync.go`) and the store extractor (`internal/store/store.go`). Both are updated — fixing only one leaves `sync` counting an alert as consumed while the store drops it.

## Evidence

Regression tests were confirmed to **fail before the fix and pass after**:

| | without fix | with fix |
|---|---|---|
| `store.ExtractResourceID` | `""` (both resources) | the alert UUID |
| `UpsertBatch` (25-item batch) | `stored=0, extractFailures=25` | `stored=25, extractFailures=0` |
| `cli.extractID` | `""` (both resources) | the alert UUID |

Coverage matches what the issue asked for: both alert resources extract by `alertUid`; `UpsertBatch` stores a representative alert rather than counting an extraction failure; a paginated batch reports consumed == stored; and non-alert resources still resolve through the untouched generic fallback list (with an explicit assertion that `alertUid` does **not** leak into the global list).

Recorded in `handfixes.json` so a future reprint cannot silently clobber it.

## Security review

- `check_security_gate.py --slug datto-rmm --base origin/main` → **0 P1** (12 pre-existing P2s, none on changed lines)
- Codex adversarial review (read-only, high reasoning) → **PASS, no findings**; independently confirmed against Datto's API documentation that Alert UID is the documented unique identifier, and that rows key on `(resource_type, id)` so open and resolved alerts cannot overwrite one another
- Zero `go.mod`/`go.sum` change — no new dependency surface. The extracted id flows into a parameterized upsert and is never concatenated into SQL.

The reporter proposed a fix in the issue body; it was **not** copied. The fix was derived independently from `internal/types.Alert` and the extraction code on `origin/main`.

## Not fixed here, needs one artifact

`account-users` may have the same shape — the spec type `AuthUser` also carries no `id`/`name` (only `username`/`email`, and `username` is not in the fallback list). The page item type is `json.RawMessage`, so this can't be settled offline, and a wrong override would outrank a real `id` if one exists. Asking the reporter to check the stored count for that resource rather than guessing.

The durable fix belongs upstream: the printing-press profiler should set `IDField` from the response-item schema when the item declares exactly one identifier-shaped field and no generic id. Filing a `/printing-press-retro` item.