### PR TITLE
fix(autotask): seed the required filter on the first page of a POST-query sync

### DIFF
--- a/skills/autotask/CHANGELOG.md
+++ b/skills/autotask/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
-## [0.1.1] - unreleased
+## [0.1.2] - unreleased
+
+### Fixed
+- `sync` no longer fails on the first page of every POST-query resource. Autotask
+  requires a filter on `query` endpoints and rejected the filterless first request
+  with HTTP 500 `Value cannot be null. Parameter name: filters`, so companies,
+  contacts, tickets, projects and the other 39 POST resources never synced a single
+  row. The first page now carries the same `id`-walk condition every later page
+  already sent. Reported by @zendzipr in
+  [#257](https://github.com/Servosity/msp-skills/issues/257).
+- `--param` / `--resource-param` overrides for array and comma-separated body
+  fields (`filter`, `includeFields`) are now sent as JSON arrays instead of the
+  literal string, matching what the `query` commands have always done.
 
 ### Changed
 - Regenerated on the printing-press 4.24.0 engine: more reliable fleet sync, corrected pagination across large result sets, robust numeric-ID handling, and dependency security updates. Same commands and workflows, sturdier local mirror.

--- a/skills/autotask/cli/internal/cli/sync.go
+++ b/skills/autotask/cli/internal/cli/sync.go
@@ -968,10 +968,8 @@ func syncFetch(ctx context.Context, c interface {
 		return c.Get(ctx, path, params)
 	}
 	queryParams, body := splitSyncPostParams(resource, params)
-	if cursor != "" {
-		if err := appendIDWalkFilter(body, idWalk, cursor); err != nil {
-			return nil, err
-		}
+	if err := appendIDWalkFilter(body, idWalk, cursor); err != nil {
+		return nil, err
 	}
 	data, _, err := c.PostQueryWithParams(ctx, path, queryParams, body)
 	return data, err
@@ -981,9 +979,43 @@ func appendIDWalkFilter(body map[string]any, config idWalkConfig, cursor string)
 	if config.filterParam == "" || config.idField == "" {
 		return nil
 	}
-	filters, ok := coerceIDWalkFilters(body[config.filterParam])
+	raw, supplied := body[config.filterParam]
+	filters, ok := coerceIDWalkFilters(raw)
 	if !ok {
 		return fmt.Errorf("invalid id-walk filter %q: expected a JSON array", config.filterParam)
+	}
+	// Supplied but empty (`[]`, `null`, "", whitespace) is a caller error, not
+	// a licence to seed. An empty condition list matches no records, so quietly
+	// substituting the seed would turn an explicit request into a whole-tenant
+	// sync. The seed exists for the caller who supplied nothing at all.
+	if supplied && len(filters) == 0 {
+		return fmt.Errorf("empty id-walk filter %q: an empty condition list matches no records; omit the parameter to sync every record", config.filterParam)
+	}
+	if cursor == "" {
+		// First page. APIs whose query endpoint requires a filter reject a
+		// filterless body outright — Autotask answers HTTP 500 "Value cannot
+		// be null. Parameter name: filters" — so page 1 needs a seed with the
+		// same shape every later page already sends.
+		//
+		// An empty array is NOT a valid seed: the API matches records against
+		// the filter conditions, so zero conditions matches zero records and a
+		// sync that should have walked the whole entity silently reports 0 rows
+		// instead of erroring. Seeding the walk's own field keeps page 1
+		// all-inclusive (ids are positive) and consistent with the `gt cursor`
+		// condition used from page 2 on.
+		if len(filters) > 0 {
+			// Caller supplied conditions; leave them alone, but write back the
+			// coerced value so a --param override that arrived as a JSON string
+			// reaches the wire as a real array.
+			body[config.filterParam] = filters
+			return nil
+		}
+		body[config.filterParam] = []any{map[string]any{
+			"field": config.idField,
+			"op":    "gte",
+			"value": int64(0),
+		}}
+		return nil
 	}
 	body[config.filterParam] = append(filters, map[string]any{
 		"field": config.idField,
@@ -1015,7 +1047,10 @@ func coerceIDWalkFilters(value any) ([]any, bool) {
 		}
 		return nil, false
 	}
-	return nil, true
+	// Any other shape (object, number, bool) is a caller error, not "no
+	// filter". Reporting it as absent would let the first-page seed replace a
+	// caller's intended restriction and sync the entire tenant, so fail closed.
+	return nil, false
 }
 
 func coerceIDWalkValue(cursor string) any {
@@ -1044,7 +1079,34 @@ func splitSyncPostParams(resource string, params map[string]string) (map[string]
 			queryParams[key] = value
 		}
 	}
+	ensureIDWalkKeyField(resource, body, bodyParamWireNames)
 	return queryParams, body
+}
+
+// ensureIDWalkKeyField keeps the walk's key column in a field-restricted
+// request. `--param includeFields=companyName` otherwise returns rows with no
+// id: the store cannot key them and the walk stops after one page with an
+// id_walk_cursor_missing warning. Autotask additionally requires the id field
+// in a restricted-field query that matches more than 500 records.
+func ensureIDWalkKeyField(resource string, body map[string]any, wireNames map[string]string) {
+	config, usesIDWalk := syncResourceIDWalkConfig(resource)
+	if !usesIDWalk || config.idField == "" {
+		return
+	}
+	key := wireNames["includeFields"]
+	if key == "" {
+		key = "includeFields"
+	}
+	fields, ok := body[key].([]string)
+	if !ok || len(fields) == 0 {
+		return
+	}
+	for _, field := range fields {
+		if strings.EqualFold(field, config.idField) {
+			return
+		}
+	}
+	body[key] = append(append([]string(nil), fields...), config.idField)
 }
 
 func syncResourceMethod(resource string) string {
@@ -1681,6 +1743,16 @@ func coerceSyncBodyParam(value string, typ string) any {
 		if parsed, err := strconv.ParseBool(value); err == nil {
 			return parsed
 		}
+	case "array", "json_array":
+		// Mirrors the generated query command, which json.Unmarshals the same
+		// body field. Without this a --param/--resource-param override reaches
+		// the wire as the string "[...]" instead of a JSON array.
+		var parsed any
+		if err := json.Unmarshal([]byte(value), &parsed); err == nil {
+			return parsed
+		}
+	case "string_csv_array":
+		return cliutil.SplitCSV(value)
 	}
 	return value
 }

--- a/skills/autotask/cli/internal/cli/sync_post_filter_test.go
+++ b/skills/autotask/cli/internal/cli/sync_post_filter_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Damien Stevens and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// recordingPostClient captures the last body handed to a POST query so the
+// tests below can assert the exact wire shape.
+type recordingPostClient struct{ lastBody any }
+
+func (c *recordingPostClient) Get(context.Context, string, map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(`[]`), nil
+}
+
+func (c *recordingPostClient) PostWithParams(_ context.Context, _ string, _ map[string]string, body any) (json.RawMessage, int, error) {
+	c.lastBody = body
+	return json.RawMessage(`[]`), 200, nil
+}
+
+func (c *recordingPostClient) PostQueryWithParams(_ context.Context, _ string, _ map[string]string, body any) (json.RawMessage, int, error) {
+	c.lastBody = body
+	return json.RawMessage(`[]`), 200, nil
+}
+
+func fetchBody(t *testing.T, resource string, params map[string]string, cursor string) string {
+	t.Helper()
+	idWalk, ok := syncResourceIDWalkConfig(resource)
+	if !ok {
+		t.Fatalf("%s declares no id-walk config", resource)
+	}
+	c := &recordingPostClient{}
+	if _, err := syncFetch(context.Background(), c, resource, "/"+resource+"/query", params, idWalk, cursor); err != nil {
+		t.Fatalf("syncFetch(%s, cursor=%q): %v", resource, cursor, err)
+	}
+	encoded, err := json.Marshal(c.lastBody)
+	if err != nil {
+		t.Fatalf("marshaling captured body: %v", err)
+	}
+	return string(encoded)
+}
+
+// The Autotask query endpoint rejects a filterless body with HTTP 500
+// "Value cannot be null. Parameter name: filters" (issue #257). The first
+// page must carry the id-walk's own condition, not an empty array — an empty
+// condition list matches zero records and turns the failure silent.
+func TestSyncPostFirstPageSeedsIDWalkFilter(t *testing.T) {
+	got := fetchBody(t, "companies", map[string]string{"maxRecords": "100"}, "")
+	want := `{"filter":[{"field":"id","op":"gte","value":0}],"maxRecords":100}`
+	if got != want {
+		t.Errorf("first-page body = %s, want %s", got, want)
+	}
+}
+
+func TestSyncPostLaterPagesWalkFromCursor(t *testing.T) {
+	got := fetchBody(t, "companies", map[string]string{"maxRecords": "100"}, "42")
+	want := `{"filter":[{"field":"id","op":"gt","value":42}],"maxRecords":100}`
+	if got != want {
+		t.Errorf("second-page body = %s, want %s", got, want)
+	}
+}
+
+// A caller-supplied filter must survive as JSON (not the literal string
+// "[...]"), and must not be overwritten by the first-page seed.
+func TestSyncPostCoercesCallerSuppliedArrayFilter(t *testing.T) {
+	params := map[string]string{
+		"maxRecords": "100",
+		"filter":     `[{"field":"companyName","op":"beginsWith","value":"A"}]`,
+	}
+	got := fetchBody(t, "companies", params, "")
+	want := `{"filter":[{"field":"companyName","op":"beginsWith","value":"A"}],"maxRecords":100}`
+	if got != want {
+		t.Errorf("caller-filter body = %s, want %s", got, want)
+	}
+}
+
+// A supplied-but-empty filter is rejected rather than silently replaced by the
+// seed: an empty condition list matches no records, so substituting the seed
+// would turn the caller's explicit request into a whole-tenant sync.
+func TestSyncPostRejectsSuppliedEmptyFilter(t *testing.T) {
+	for _, value := range []string{"[]", "null", "", "   ", `"[]"`} {
+		idWalk, _ := syncResourceIDWalkConfig("companies")
+		c := &recordingPostClient{}
+		params := map[string]string{"maxRecords": "100", "filter": value}
+		if _, err := syncFetch(context.Background(), c, "companies", "/companies/query", params, idWalk, ""); err == nil {
+			t.Errorf("filter=%q: want an error, got body %v", value, c.lastBody)
+		}
+	}
+}
+
+func TestCoerceSyncBodyParamDecodesArraysAndCSV(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		typ   string
+		want  string
+	}{
+		{"json array", `[{"field":"id","op":"gte","value":0}]`, "array", `[{"field":"id","op":"gte","value":0}]`},
+		{"empty json array", `[]`, "array", `[]`},
+		{"csv array", "id,companyName", "string_csv_array", `["id","companyName"]`},
+		{"unparseable array falls back to string", "not json", "array", `"not json"`},
+		{"int untouched", "100", "int", `100`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(coerceSyncBodyParam(tc.value, tc.typ))
+			if err != nil {
+				t.Fatalf("marshaling coerced value: %v", err)
+			}
+			if string(encoded) != tc.want {
+				t.Errorf("coerceSyncBodyParam(%q, %q) = %s, want %s", tc.value, tc.typ, encoded, tc.want)
+			}
+		})
+	}
+}
+
+// Every POST sync resource walks by id and declares an array `filter`, so the
+// seed must apply to all of them, not just companies.
+func TestEveryPostSyncResourceSeedsAFilter(t *testing.T) {
+	for _, resource := range []string{"companies", "contacts", "tickets", "projects", "time-entries"} {
+		got := fetchBody(t, resource, map[string]string{"maxRecords": "100"}, "")
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+			t.Fatalf("%s: %v", resource, err)
+		}
+		filters, ok := decoded["filter"].([]any)
+		if !ok || len(filters) == 0 {
+			t.Errorf("%s first-page body has no filter conditions: %s", resource, got)
+		}
+	}
+}
+
+// A filter that is not a JSON array must be rejected, never treated as absent.
+// Treating it as absent would let the first-page seed silently replace the
+// caller's restriction and sync the whole tenant.
+func TestSyncPostRejectsNonArrayFilter(t *testing.T) {
+	for _, value := range []string{
+		`{"field":"companyName","op":"beginsWith","value":"A"}`,
+		`5`,
+		`true`,
+		`"not json`,
+	} {
+		idWalk, ok := syncResourceIDWalkConfig("companies")
+		if !ok {
+			t.Fatal("companies declares no id-walk config")
+		}
+		params := map[string]string{"maxRecords": "100", "filter": value}
+		c := &recordingPostClient{}
+		_, err := syncFetch(context.Background(), c, "companies", "/companies/query", params, idWalk, "")
+		if err == nil {
+			t.Errorf("filter=%s: want an error, got body %v", value, c.lastBody)
+		}
+	}
+}
+
+// A field-restricted sync must still request the walk's key column, or the
+// walk cannot advance past page 1.
+func TestSyncPostKeepsIDFieldInIncludeFields(t *testing.T) {
+	got := fetchBody(t, "companies", map[string]string{"maxRecords": "100", "includeFields": "companyName,phone"}, "")
+	want := `{"filter":[{"field":"id","op":"gte","value":0}],"includeFields":["companyName","phone","id"],"maxRecords":100}`
+	if got != want {
+		t.Errorf("restricted-field body = %s, want %s", got, want)
+	}
+}
+
+func TestSyncPostDoesNotDuplicateIDField(t *testing.T) {
+	got := fetchBody(t, "companies", map[string]string{"maxRecords": "100", "includeFields": "id,companyName"}, "")
+	want := `{"filter":[{"field":"id","op":"gte","value":0}],"includeFields":["id","companyName"],"maxRecords":100}`
+	if got != want {
+		t.Errorf("already-keyed body = %s, want %s", got, want)
+	}
+}

--- a/skills/autotask/handfixes.json
+++ b/skills/autotask/handfixes.json
@@ -57,6 +57,19 @@
       "asserts": [
         {"file": "cli/internal/cli/novel_shared.go", "contains": "math.MaxInt32", "min_count": 1}
       ]
+    },
+    {
+      "id": "sync-post-query-requires-seeded-filter",
+      "summary": "POST-query sync seeds the id-walk filter on the FIRST page (`id gte 0`) and coerces array/CSV body params, so page 1 is never sent filterless",
+      "why": "Autotask's query endpoints require a filter: a filterless body answers HTTP 500 \"Value cannot be null. Parameter name: filters\", so every POST sync resource failed on its first page and synced nothing (issue #257). The press emits syncResourceStaticBody entries only for body fields carrying an OpenAPI `default`, and Autotask's `filter` declares none, so the generated static body is empty and appendIDWalkFilter ran only once a cursor already existed. The seed is the walk's own `id gte 0` condition, NOT an empty array: Autotask matches records against the filter conditions, so `filter: []` returns HTTP 200 with zero rows and turns a loud failure into a silent empty sync. coerceSyncBodyParam also gained the array/string_csv_array cases the generated query commands already had, so a --param override reaches the wire as JSON instead of the literal string \"[...]\".",
+      "status": "active",
+      "spec_encode_followup": "Press should seed the id-walk filter param on the first page of any POST-query sync whose body declares a required filter array (or emit a static body for required array params with no default), and coerceSyncBodyParam should decode array/string_csv_array the way the generated query commands do (filed via printing-press-retro).",
+      "asserts": [
+        {"file": "cli/internal/cli/sync.go", "contains": "\"op\":    \"gte\"", "min_count": 1},
+        {"file": "cli/internal/cli/sync.go", "contains": "case \"string_csv_array\":", "min_count": 1},
+        {"file": "cli/internal/cli/sync.go", "contains": "empty id-walk filter", "min_count": 1},
+        {"file": "cli/internal/cli/sync_post_filter_test.go", "contains": "TestSyncPostFirstPageSeedsIDWalkFilter", "min_count": 1}
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #257. Reported by @zendzipr.

## The bug

Autotask's `query` endpoints require a filter. The generated sync sent the **first** page with no filter at all, so every POST resource — companies, contacts, tickets, projects and 39 more — failed immediately with `HTTP 500 Value cannot be null. Parameter name: filters` and synced nothing.

Reproduced offline against trusted `main`, no tenant needed:

| | body sent |
| --- | --- |
| page 1 (before) | `{"maxRecords":100}` — no filter |
| page 2 | `{"filter":[{"field":"id","op":"gt","value":42}],"maxRecords":100}` |

`appendIDWalkFilter` only ran once a cursor existed. The press emits `syncResourceStaticBody` entries only for body fields declaring an OpenAPI `default`, and Autotask's `filter` declares none — so the generated static body was empty.

## The fix

Page 1 now carries the walk's own condition, `id gte 0` — the same shape every later page already sent.

**This is deliberately not the `filter: []` proposed in the issue.** Autotask matches records against the filter conditions, so an empty condition list returns `HTTP 200` with zero rows. That would trade a loud failure for a silent empty sync — the worse failure mode. The reporter's own verification receipt (`"total": 0`) is consistent with that reading.

Three further fixes came out of adversarial review of this change:

- `coerceSyncBodyParam` decodes `array` and `string_csv_array` body params the way the generated query commands always have, so a `--param`/`--resource-param` override reaches the wire as JSON rather than the literal string `"[...]"`.
- The seed applies **only** when the caller supplied no filter. A supplied filter that is empty or not a JSON array is now a hard error rather than being silently replaced by the seed — which would have widened an explicit caller restriction into a whole-tenant sync.
- A field-restricted sync keeps the walk's id column, which the walk needs to advance past page 1.

## Verification

- 9 new regression tests in `sync_post_filter_test.go` covering the seed, the walk, caller-supplied filters, every rejection shape, and `includeFields`.
- `go build` / `go vet` / `go test ./...` green across all packages.
- `check_security_gate.py --slug autotask --base origin/main`: **0 P1** (12 P2, all pre-existing in untouched files).
- 4 adversarial Codex passes, converged to 0 P1. Three P1s and one P2 it raised are fixed in this PR.
- Hand-fix ledger updated with a 6th entry so a future reprint cannot silently drop this.

Scope is one connector and one issue: no CI, auth, dependency, or cross-connector changes (`go.mod`/`go.sum` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)