### PR TITLE
fix(release): build notes from the skill's CHANGELOG, not --generate-notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
     needs: [security_gate]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Ensure release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -111,9 +116,30 @@ jobs:
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; reusing it."
-          else
-            gh release create "$TAG" --title "$TAG" --generate-notes
+            exit 0
           fi
+          # Release notes come from the SKILL'S OWN CHANGELOG, never
+          # --generate-notes.
+          #
+          # --generate-notes computes its range against the previous tag in the
+          # REPO. In a monorepo with per-skill tags that is some unrelated
+          # skill's tag, so the notes list every PR merged in between regardless
+          # of what it touched. zammad-v0.1.1 shipped notes advertising the
+          # auvik onboarding and a batch of CI work, footed with
+          # "compare/unifi-network-v0.1.0...zammad-v0.1.1" - accurate about the
+          # range, useless and misleading about the skill.
+          #
+          # The per-skill CHANGELOG section is the authoritative, human-written
+          # answer to "what changed in THIS connector", and release.py already
+          # maintains it.
+          slug="${TAG%-v*}"
+          version="${TAG##*-v}"
+          notes=$(python3 tools/maintainer/changelog_section.py --slug "$slug" --version "$version") || {
+            echo "::error::no usable CHANGELOG section for $slug $version"
+            exit 1
+          }
+          printf '%s\n' "$notes" > /tmp/release-notes.md
+          gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md
 
   build:
     needs: [prepare, create-release, security_gate]


### PR DESCRIPTION
**Split out of #259 because it touches `.github/workflows/release.yml`**, which the security gate protects from self-approval. This is the workflow half only - one step, ~25 lines.

> **Merge order: #259 first.** This step calls `tools/maintainer/changelog_section.py`, which #259 adds.

## The problem

Every release this repo has cut shipped notes about **other connectors**. From [`zammad-v0.1.1`](https://github.com/Servosity/msp-skills/releases/tag/zammad-v0.1.1) as it stood:

```
## What's Changed
* skill(auvik): Auvik network-monitoring connector (CLI + MCP) (#238)
* chore(fleet): bump Go toolchain to go1.26.6 across 58 connectors (#244)
...
**Full Changelog**: .../compare/unifi-network-v0.1.0...zammad-v0.1.1
```

Measured across all 122 published releases: **105 were co-mingled.**

## Cause

`gh release create --generate-notes` computes its range against the previous tag in the **repo**. With per-skill tags in a monorepo that is whatever unrelated skill sorts before this one, so the notes list every PR merged in between regardless of what it touched. Accurate about the commit range; useless to an MSP trying to learn what changed in the thing they installed.

## Change

Notes come from `skills/<slug>/CHANGELOG.md` - the authoritative human-written answer, already maintained by `release.py`. `changelog_section.py` extracts the version's section and **exits 2 on a placeholder**, so a release cannot go out headed "Describe the changes in this release."

`create-release` also gains an explicit `actions/checkout` - it previously ran only `gh` commands and had no working tree.

## Security review notes

For whoever reviews this as CODEOWNERS:

- The step runs on a **tag push**, with the workflow's existing `contents: write`. No new permission.
- `slug` and `version` are derived from `${TAG}` by shell parameter expansion, and `$TAG` is `github.ref_name`. They are passed to `changelog_section.py` as `--slug` / `--version` argv, never interpolated into a shell string.
- `changelog_section.py` reads one file under `skills/<slug>/` and writes nothing.
- Failure mode is fail-closed: no usable section means `exit 1` and no release is created.
- No change to `security_gate`, the build matrix, or artifact upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)