### PR TITLE
security(ci): a pushed tag could execute code; pass the slug as argv

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -49,7 +49,9 @@ jobs:
           # The tag must actually contain "-v" (so slug/version both parsed) and
           # the semver portion must look like N.N.N.
           if [ "$tag" != "$skill" ] && printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            if python3 -c "import json,sys; reg=json.load(open('tools/maintainer/skills.json')); sys.exit(0 if '$skill' in reg.get('skills',{}) else 1)"; then
+            # argv, never program text - see release.yml and
+            # tools/maintainer/is_registered_slug.py.
+            if python3 tools/maintainer/is_registered_slug.py --slug "$skill"; then
               proceed=true
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,9 @@ jobs:
           # Guard: the derived slug must exist in skills.json, else skip. This
           # keeps an arbitrary "*-v*.*.*" tag from trying to build a nonexistent
           # skill. The whole release run no-ops cleanly for an unknown slug.
-          if ! python3 -c "import json,sys; reg=json.load(open('tools/maintainer/skills.json')); sys.exit(0 if '$tag_skill' in reg.get('skills',{}) else 1)"; then
+          # argv, never program text: $tag_skill comes from the pushed tag, so
+          # interpolating it into a `python3 -c` string let a tag execute code.
+          if ! python3 tools/maintainer/is_registered_slug.py --slug "$tag_skill"; then
             echo "Tag $TAG: derived slug '$tag_skill' is not in skills.json; skipping."
             exit 0
           fi

--- a/tools/maintainer/is_registered_slug.py
+++ b/tools/maintainer/is_registered_slug.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""is_registered_slug.py - exit 0 if the slug is a registered skill, else 1.
+
+    python3 tools/maintainer/is_registered_slug.py --slug halopsa
+
+Why this exists as a script rather than a `python3 -c` one-liner
+----------------------------------------------------------------
+Both release.yml and mcp-publish.yml used to interpolate a TAG-DERIVED shell
+variable straight into a Python program text:
+
+    python3 -c "... sys.exit(0 if '$slug' in reg.get('skills',{}) else 1)"
+
+`$slug` comes from `${TAG%-v*}` where TAG is `github.ref_name`, so anyone able
+to push a tag controlled the contents of a Python string literal. A single quote
+in the slug closes the literal and the rest is executed:
+
+    git tag "'or(__import__(\\"os\\").popen(\\"id\\").read())or'-v1.0.0"
+
+That runs arbitrary code as the workflow token, which holds `contents: write`.
+Confirmed exploitable before this change.
+
+Passing the value as **argv** removes the class entirely: the slug is data to a
+fixed program, never program text. The `*-v*` tag ruleset restricted this to
+admins, so it was gated rather than open - but a ruleset is configuration, and
+configuration changes. This does not depend on it.
+
+The charset check is defence in depth, not the fix: the fix is argv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+REGISTRY = REPO / "tools" / "maintainer" / "skills.json"
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--slug", required=True)
+    args = ap.parse_args()
+
+    if not SLUG_RE.match(args.slug):
+        print(f"slug {args.slug!r} is not a valid skill slug", file=sys.stderr)
+        return 1
+    try:
+        reg = json.loads(REGISTRY.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"cannot read {REGISTRY}: {exc}", file=sys.stderr)
+        return 1
+    return 0 if args.slug in (reg.get("skills") or {}) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Found by the Codex security review of #262. **The defect is on `main` today and is not introduced by that PR** - #262's own new step was already immune, because it passes slug and version as argv.

## The defect

`release.yml` and `mcp-publish.yml` interpolated a tag-derived shell variable directly into Python **program text**:

```bash
python3 -c "import json,sys; reg=json.load(open('tools/maintainer/skills.json')); sys.exit(0 if '$tag_skill' in reg.get('skills',{}) else 1)"
```

`$tag_skill` is `${TAG%-v*}` where `TAG` is `github.ref_name`. Whoever pushes the tag controls the contents of a Python string literal; a single quote closes it and the rest executes as the workflow token, which holds `contents: write`.

## Reproduced

Isolated sandbox, against the exact old expression:

```
tag:      'or(__import__("os").popen("echo pwned > /tmp/PWNED").read())or'-v1.0.0
derived:  'or(__import__("os").popen("echo pwned > /tmp/PWNED").read())or'

old form -> /tmp/PWNED created    VULNERABLE
new form -> exit 1, nothing ran   inert
```

## Fix

Both call sites now use `tools/maintainer/is_registered_slug.py --slug "$slug"`, so the value arrives as **argv** - data to a fixed program, never program text. That removes the class rather than escaping around it.

A `^[a-z0-9][a-z0-9-]*$` charset check is included, but it is defence in depth. **argv is the fix.**

## Severity

Mitigated in practice: the `release-tags (*-v*)` ruleset has a `creation` rule whose only bypass is an admin `RepositoryRole`, so pushing a matching tag already required admin - and an admin has broader power regardless.

That is a mitigation, not a reason to leave it. A ruleset is configuration, configuration changes, and this code should not depend on it to be safe.

## Note for review

This touches `release.yml` and `mcp-publish.yml`, so the security gate will fail by design and cannot be self-approved. It also partly overlaps #251 (validate slug grammar centrally in `registry.py`) - this fixes the two dangerous call sites now; #251 remains the broader cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)