### PR TITLE
fix(halopsa): stop page-walking /Feed, which is a keyset endpoint

### DIFF
--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.11] - unreleased
+
+### Fixed
+- `sync` no longer page-walks `feed`. HaloPSA's `/Feed` is a time-ordered
+  activity stream whose own parameters are `count` for the window size and
+  `newer_than_id`/`older_than_id` for position; it has no page number to
+  honour. The connector sent it the paging trio every other list endpoint
+  gets (`pageinate=true`, `page_size`, an incrementing `page_no`), which the
+  endpoint ignores, so each request returned a window overlapping the last and
+  the walk re-read rows it already had. That is what #264 recorded for `feed`
+  as 100 rows fetched and 62 stored. Nothing was being dropped: `/Feed`
+  identifies its rows with a globally unique id, so the repeats were one row
+  fetched twice and the local mirror collapsed them correctly. `feed` now asks
+  for a single window of `count` rows per sync, which is what an activity-feed
+  mirror wants, and a `--param count=<n>` override still wins. Reported by
+  @Xenith-B (#273).
+- The same walk could fail to terminate. Because the cursor it advances is
+  computed client-side, the sticky-cursor guard never fires, and a full window
+  returned to every request keeps the more-pages heuristic true, so under the
+  default `--max-pages 0` the loop had no way to stop. A tenant whose feed
+  always filled the window would have kept requesting pages until the sync was
+  interrupted. `feed` no longer enters that loop at all.
+
 ## [0.2.10] - 2026-08-20
 
 ### Fixed

--- a/skills/halopsa/cli/internal/cli/feed_walk_test.go
+++ b/skills/halopsa/cli/internal/cli/feed_walk_test.go
@@ -132,3 +132,46 @@ func TestFeedWindowIsUserOverridable(t *testing.T) {
 		t.Errorf("--param count=250 was overridden to %q; user params must win", got)
 	}
 }
+
+// feed declares no temporal filter, so an incremental sync (full=false with a
+// recorded last-sync time) falls through the not-incremental warning path.
+// That path must still produce exactly one unfiltered window rather than
+// re-entering a walk, and the warning it prints must not promise pagination
+// feed no longer does.
+func TestFeedIncrementalSyncStillFetchesOneWindow(t *testing.T) {
+	api := &fakeFeed{total: 60, pageCap: 60}
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	// First pass records a last-synced timestamp.
+	if res := syncResource(context.Background(), api, db, "feed", "", true, 0, false,
+		&syncUserParams{}, nil); res.Err != nil {
+		t.Fatalf("seed sync: %v", res.Err)
+	}
+	// Second pass is incremental: full=false, and the store now has a
+	// last-synced time, so effectiveSince is set and sinceParam is empty.
+	var events strings.Builder
+	res := syncResource(context.Background(), api, db, "feed", "", false, 0, false,
+		&syncUserParams{}, &events)
+	if res.Err != nil {
+		t.Fatalf("incremental sync: %v", res.Err)
+	}
+	if len(api.calls) != 2 {
+		t.Fatalf("two syncs made %d requests, want 2 (one window each)", len(api.calls))
+	}
+	last := api.calls[1]
+	if last["count"] != "100" {
+		t.Errorf("incremental feed sync sent count=%q, want 100", last["count"])
+	}
+	for _, banned := range []string{"page_no", "page_size", "pageinate"} {
+		if _, ok := last[banned]; ok {
+			t.Errorf("incremental feed sync sent %s; feed is not page-walked", banned)
+		}
+	}
+	if out := events.String(); strings.Contains(out, "full pagination") {
+		t.Errorf("warning still promises pagination feed does not do: %s", out)
+	}
+}

--- a/skills/halopsa/cli/internal/cli/feed_walk_test.go
+++ b/skills/halopsa/cli/internal/cli/feed_walk_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"halopsa-pp-cli/internal/store"
+)
+
+// fakeFeed stands in for HaloPSA's /Feed: a time-ordered activity stream that
+// knows nothing about page_no. It records every request the sync loop makes so
+// the walk itself can be asserted, and deliberately ignores paging parameters
+// exactly as the real endpoint would, returning the newest window every time.
+type fakeFeed struct {
+	calls   []map[string]string
+	total   int
+	pageCap int // rows returned per call; 0 means "all of them"
+}
+
+func (f *fakeFeed) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	copied := map[string]string{}
+	for k, v := range params {
+		copied[k] = v
+	}
+	f.calls = append(f.calls, copied)
+
+	n := f.total
+	if f.pageCap > 0 && f.pageCap < n {
+		n = f.pageCap
+	}
+	rows := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		// Descending ids, newest first, as an activity feed returns them.
+		rows = append(rows, fmt.Sprintf(
+			`{"id":%d,"datetime":"2026-04-16T16:13:52.903","entitytype":1,"outcome":"KB Viewed"}`,
+			5600-i))
+	}
+	return json.RawMessage("[" + strings.Join(rows, ",") + "]"), nil
+}
+
+func (f *fakeFeed) RateLimit() float64 { return 0 }
+
+func syncFeed(t *testing.T, api *fakeFeed, maxPages int) (syncResult, *store.Store) {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	res := syncResource(context.Background(), api, db, "feed", "", true, maxPages, false,
+		&syncUserParams{}, nil)
+	if res.Err != nil {
+		t.Fatalf("sync feed: %v", res.Err)
+	}
+	return res, db
+}
+
+// The reported defect: /Feed was walked by page number, so the sync spent a
+// request per page re-reading a window it already had (#273).
+func TestFeedIsFetchedInOneWindow(t *testing.T) {
+	api := &fakeFeed{total: 100, pageCap: 100}
+	res, db := syncFeed(t, api, 0)
+
+	if len(api.calls) != 1 {
+		t.Fatalf("feed made %d requests, want exactly 1 (it is not page-walkable)", len(api.calls))
+	}
+	sent := api.calls[0]
+	for _, banned := range []string{"page_no", "page_size", "pageinate"} {
+		if v, ok := sent[banned]; ok {
+			t.Errorf("feed was sent %s=%q; /Feed has no such parameter", banned, v)
+		}
+	}
+	if sent["count"] != "100" {
+		t.Errorf("feed was sent count=%q, want the window size 100", sent["count"])
+	}
+	if res.Count != 100 {
+		t.Errorf("feed stored %d rows, want 100", res.Count)
+	}
+	var stored int
+	if err := db.DB().QueryRow(`SELECT count(*) FROM resources WHERE resource_type = 'feed'`).Scan(&stored); err != nil {
+		t.Fatalf("counting feed rows: %v", err)
+	}
+	if stored != 100 {
+		t.Errorf("resources holds %d feed rows, want 100", stored)
+	}
+}
+
+// Re-syncing must refresh the newest window rather than accumulate copies: the
+// rows carry a globally unique id, so the mirror collapses a re-fetch.
+func TestFeedResyncIsIdempotent(t *testing.T) {
+	api := &fakeFeed{total: 40, pageCap: 40}
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	for i := 0; i < 3; i++ {
+		if res := syncResource(context.Background(), api, db, "feed", "", true, 0, false,
+			&syncUserParams{}, nil); res.Err != nil {
+			t.Fatalf("sync %d: %v", i, res.Err)
+		}
+	}
+	if len(api.calls) != 3 {
+		t.Fatalf("three syncs made %d requests, want 3", len(api.calls))
+	}
+	var stored int
+	if err := db.DB().QueryRow(`SELECT count(*) FROM resources WHERE resource_type = 'feed'`).Scan(&stored); err != nil {
+		t.Fatalf("counting feed rows: %v", err)
+	}
+	if stored != 40 {
+		t.Errorf("three syncs of the same 40 rows stored %d; a re-fetch must collapse, not accumulate", stored)
+	}
+}
+
+// --param must still win, so an operator who wants a wider window can ask.
+func TestFeedWindowIsUserOverridable(t *testing.T) {
+	api := &fakeFeed{total: 10, pageCap: 10}
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+	up := &syncUserParams{flatGlobal: map[string]string{"count": "250"}}
+	if res := syncResource(context.Background(), api, db, "feed", "", true, 0, false, up, nil); res.Err != nil {
+		t.Fatalf("sync: %v", res.Err)
+	}
+	if got := api.calls[0]["count"]; got != "250" {
+		t.Errorf("--param count=250 was overridden to %q; user params must win", got)
+	}
+}

--- a/skills/halopsa/cli/internal/cli/sync.go
+++ b/skills/halopsa/cli/internal/cli/sync.go
@@ -536,6 +536,11 @@ func syncResource(ctx context.Context, c interface {
 		if effectiveSince != "" {
 			params[sinceParam] = effectiveSince
 		}
+		// Hand-wired: a resource whose endpoint takes its own size parameter
+		// instead of the generic paging trio. See resourceFixedParams.
+		for k, v := range resourceFixedParams[resource] {
+			params[k] = v
+		}
 		// Apply user-supplied --param / --resource-param overrides last so they
 		// win over spec-derived defaults (e.g. forcing mine=true on a list
 		// endpoint whose OpenAPI spec marks the filter optional).
@@ -864,6 +869,33 @@ func syncResource(ctx context.Context, c interface {
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
 }
 
+// resourceFixedParams carries query parameters a resource always needs but
+// that the generic paging machinery cannot supply.
+//
+// HAND-FIX (handfixes.json: feed-is-not-page-walkable). determinePaginationDefaults
+// describes ONE contract for the whole connector - pageinate=true plus a
+// page_size and an incrementing page_no - because that is what Halo's list
+// endpoints honour. /Feed is not one of those. It is a time-ordered activity
+// stream whose own parameters are `count` for the window size and
+// `newer_than_id`/`older_than_id` for position, and page numbers are the wrong
+// shape for it twice over: Halo has no page_no to honour there, and paging a
+// live stream by ordinal re-reads rows anyway, because new events arrive
+// between requests and shift the ones already seen across the page boundary.
+//
+// That is what #273 reported as 100 rows fetched and 62 stored. Nothing was
+// dropped: /Feed identifies rows with a globally unique id, so the repeats were
+// one row fetched twice and the local mirror collapsed them correctly. The
+// defect was the walk, which spent a request per page re-reading a window it
+// already had. feed is therefore no longer page-walked at all (see
+// resourceSupportsPagination) and asks for one window of `count` rows per sync,
+// which is what an activity-feed mirror wants: the newest entries, refreshed.
+//
+// A user who wants a different window still wins, because --param is applied
+// after this map.
+var resourceFixedParams = map[string]map[string]string{
+	"feed": {"count": "100"},
+}
+
 // paginationDefaults holds the resolved pagination parameter names and page size.
 type paginationDefaults struct {
 	cursorParam string
@@ -957,8 +989,6 @@ func resourceSupportsPagination(resource string) bool {
 	case "email-address-book":
 		return true
 	case "external-link":
-		return true
-	case "feed":
 		return true
 	case "incomingemail":
 		return true

--- a/skills/halopsa/cli/internal/cli/sync.go
+++ b/skills/halopsa/cli/internal/cli/sync.go
@@ -468,13 +468,13 @@ func syncResource(ctx context.Context, c interface {
 		effectiveSince = lastSynced.Format(time.RFC3339)
 	}
 	// Resources whose list endpoint declares no temporal-filter parameter
-	// fall back to plain pagination — sending a synthetic since=... would
+	// fall back to an unfiltered sync — sending a synthetic since=... would
 	// reach the API as an unknown query param and (for strict APIs like
 	// Notion) fail the whole resource with a 400. Warn once per resource
 	// when the user expected incremental behavior.
 	if effectiveSince != "" && sinceParam == "" {
 		if humanFriendly {
-			fmt.Fprintf(os.Stderr, "  %s: incremental sync ignored (endpoint declares no temporal filter; falling back to full pagination)\n", resource)
+			fmt.Fprintf(os.Stderr, "  %s: incremental sync ignored (endpoint declares no temporal filter; falling back to an unfiltered sync)\n", resource)
 		} else {
 			fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"resource_not_incremental","message":"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource"}`+"\n", resource)
 		}

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -415,6 +415,35 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "feed-is-not-page-walkable",
+      "summary": "feed is excluded from the page-number walk and asks for one window via count, because /Feed is a keyset activity stream with no page_no (issue #273)",
+      "why": "determinePaginationDefaults describes ONE paging contract for the whole connector - pageinate=true plus page_size and an incrementing page_no - because that is what Halo's list endpoints honour (#203). /Feed is not one of those: it is a time-ordered activity stream whose own parameters are count for the window size and newer_than_id/older_than_id for position. Page numbers are the wrong shape for it twice over. Halo has no page_no to honour there, and paging a live stream by ordinal re-reads rows regardless, because new events arrive between requests and shift the ones already seen across the page boundary. Reported in #264 as feed fetching 100 rows and storing 62, which looked like the parent-scoped-id family the rest of that issue was about but is not: /Feed identifies rows with a globally unique id, so the repeats were one row fetched twice and the mirror collapsed them correctly. The defect was the walk, not the key, which is why feed is deliberately absent from resourceParentKeyColumns and a regression test pins it there - adding a parent key would have converted honest dedup into duplicate rows. A second, worse failure rides along: the page-int cursor is computed client-side, so the sticky-cursor guard cannot fire, and a full window returned to every request keeps pageLooksFull true, leaving the loop with no termination condition under the default --max-pages 0. A fixture that always fills the window reproduces a non-terminating walk. Excluding feed from resourceSupportsPagination removes both problems, and resourceFixedParams supplies the count the endpoint actually takes, applied before user --param so an operator can still widen the window. NOT extended to the other endpoints that expose count rather than page numbers (address, crmnote, version-info-*): /Actions also documents no page_no yet demonstrably honours it, so Halo's parameter lists are not evidence of what it ignores, and depaginating a resource that currently walks correctly would truncate it. Those need a live tenant to settle.",
+      "status": "active",
+      "spec_encode_followup": "Teach cli-printing-press that one paging contract per API is not always right: an endpoint exposing keyset parameters (newer_than/older_than plus a count) alongside the API's normal page parameters needs its own contract, and the generic page-int fallback should not advance a client-side cursor on an endpoint that never returns one. The unbounded case is the sharper ask: a walk whose cursor the client invents has no natural termination when the API keeps answering with a full page.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "var resourceFixedParams = map[string]map[string]string{",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/sync.go",
+          "contains": "\"feed\": {\"count\": \"100\"}",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/feed_walk_test.go",
+          "contains": "TestFeedIsFetchedInOneWindow",
+          "min_count": 1
+        },
+        {
+          "file": "cli/internal/cli/feed_walk_test.go",
+          "contains": "TestFeedWindowIsUserOverridable",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #273, which was split out of #264 because it is a different defect from the parent-scoped-id family reported alongside it.

## The defect

`/Feed` is a time-ordered activity stream. Its own parameters are `count` for the window size and `newer_than_id`/`older_than_id` for position — it has no page number to honour. The connector sent it the paging trio every other list endpoint gets (`pageinate=true`, `page_size`, an incrementing `page_no`), which the endpoint ignores, so each request answered with a window overlapping the last and the walk re-read rows it already had.

That is what #264 recorded for `feed` as **100 fetched, 62 stored**.

## It was never row loss

`/Feed` identifies its rows with a **globally unique** `id`, so the repeats were one row fetched twice and the local mirror collapsed them correctly. `feed` is therefore deliberately absent from `resourceParentKeyColumns`, and `TestFeedIsNotParentScoped` (added in `v0.2.10`) pins it there — adding a parent key, as the "same defect class" framing invited, would have converted honest dedup into **duplicate rows**.

## The part I did not see until I built the fixture

The page-int cursor is computed **client-side**, so the sticky-cursor guard cannot fire on it, and a full window returned to every request keeps `pageLooksFull` true. Under the default `--max-pages 0` the loop therefore had **no termination condition at all**.

A fixture that always fills the window reproduces a walk that never ends — my first unbounded run of it hung until I killed it. Bounded to five pages, the walk is unambiguous:

```
request 1: page_no="1" page_size="100" pageinate="true" count=""
request 2: page_no="2" page_size="100" pageinate="true" count=""
request 3: page_no="3" page_size="100" pageinate="true" count=""
request 4: page_no="4" page_size="100" pageinate="true" count=""
request 5: page_no="5" page_size="100" pageinate="true" count=""
fetched/upserted reported=100   distinct rows stored=100
```

Five requests, same rows every time. On @Xenith-B's tenant the walk evidently did terminate (their sync completed), so the observed symptom was the overlap; the non-termination is the latent worst case for a tenant whose feed always fills the window. I have stated it that way rather than claiming they hit it.

## The fix

`feed` is excluded from `resourceSupportsPagination`, so it makes exactly one request per sync, and a small `resourceFixedParams` map supplies the `count` the endpoint actually takes. That is what an activity-feed mirror wants: the newest window, refreshed each sync. The map is applied **before** `userParams.applyTo`, so `--param count=250` still wins.

This gives up the *possibility* of deep feed history. That possibility was illusory — the previous walk returned an unstable overlapping sample, not reliable history. Real history depth needs keyset paging via `older_than_id`, which drags in four separate special cases (per-resource pagination contract, keyset advancement, a walk ceiling since `--max-pages` defaults to unlimited and a feed is unbounded on a rate-limited API, and cursor-persistence suppression — the saved cursor would otherwise march the walk further back every sync and never pick up new activity). That deserves its own design pass, not a patch release.

## Deliberately not extended

The other endpoints exposing `count` rather than page numbers — `address`, `crmnote`, `version-info-*` — are **unchanged**. `/Actions` documents no `page_no` either yet demonstrably honours it (#203), so Halo's parameter lists are not evidence of what it ignores, and depaginating a resource that currently walks correctly would truncate it. Settling those needs a live tenant.

## Verification

- New tests drive the **real sync loop** through its client interface (`syncResource` takes the client as an interface) against a fake `/Feed`, so the walk itself is asserted — request count, exact params sent, rows stored, re-sync idempotency, and `--param` override.
- Run against the un-fixed code they fail; the unbounded variant does not terminate.
- Full `go test ./...` green; `go vet` clean; `gofmt` clean.
- `verify_all.sh`: 0 failures.
- `check_security_gate.py --slug halopsa --base origin/main`: **0 P1**, 13 P2, all pre-existing generated-code `G104` plus one transitive advisory.
- `ci_guards.sh` passed; `check_handfixes.py` PASS, 13 entries.

`sync.go` is generated; the edit is recorded in `handfixes.json` with an upstream `spec_encode_followup` — one paging contract per API is not always right, and a walk whose cursor the client invents has no natural termination when the API keeps answering with a full page.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feed synchronization by fetching a single activity window instead of using unsupported page-based pagination.
  - Prevented repeated records and non-terminating synchronization loops.
  - Preserved user-provided item count overrides while applying a default window size.

- **Documentation**
  - Added release notes and regression coverage describing the corrected feed synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->