### PR TITLE
fix(halopsa,ninjaone): doctor stops sending operators to a command that does not exist

### DIFF
--- a/skills/halopsa/cli/internal/cli/doctor.go
+++ b/skills/halopsa/cli/internal/cli/doctor.go
@@ -100,7 +100,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				header := cfg.AuthHeader()
 				if header == "" {
 					report["auth"] = "not configured"
-					report["auth_hint"] = "Run 'halopsa-cli auth setup' for credential setup steps."
+					// This CLI ships auth login, logout and status. There is no
+					// `auth setup` subcommand, and `auth` answers an
+					// unrecognised subcommand by printing its own help and
+					// exiting 0, so following the old hint looked like it
+					// worked while leaving auth unconfigured.
+					report["auth_hint"] = "Set HALOPSA_TENANT, HALOPSA_DOMAIN, HALOPSA_CLIENT_ID and HALOPSA_CLIENT_SECRET, then run 'halopsa-cli auth login' to mint a token."
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -444,6 +444,24 @@
           "min_count": 1
         }
       ]
+    },
+    {
+      "id": "doctor-auth-hint-names-a-real-command",
+      "summary": "doctor's auth_hint points at `auth login` and the required environment variables instead of a nonexistent `auth setup` subcommand",
+      "why": "This CLI defines auth login, logout and status. There is no `auth setup`, yet doctor's auth_hint told operators to run it. The hint fires exactly when cfg.AuthHeader() is empty, which is the one moment someone reads doctor for guidance: fresh install, rotated secret, new machine, expired token. Worse, `auth` answers an unrecognised subcommand by printing its own help and exiting 0, so there is no 'unknown command' error and no non-zero exit to signal the advice was wrong. Reproduced live against an empty config: doctor reported auth 'not configured' with the auth_setup hint, running the suggested command exited 0 and printed help, and a second doctor still reported 'not configured'. These CLIs are agent-first with typed exit codes, so an agent doing setup reads exit 0 as success and moves on unauthenticated. This skill emits no auth_instructions field, so auth_hint is the only setup guidance doctor gives. The replacement names the real command and the variables auth login reads.",
+      "status": "active",
+      "spec_encode_followup": "Emit the auth hint from the set of subcommands the connector actually generates rather than a fixed string. Four other skills carry the same dead hint (appdirect, crowdstrike, ninjaone, immybot), while blumira and datto-rmm do define `auth setup`, which is why the string was templated in the first place.",
+      "asserts": [
+        {
+          "file": "cli/internal/cli/doctor.go",
+          "not_contains": "halopsa-cli auth setup"
+        },
+        {
+          "file": "cli/internal/cli/doctor.go",
+          "contains": "halopsa-cli auth login",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }

--- a/skills/ninjaone/cli/internal/cli/doctor.go
+++ b/skills/ninjaone/cli/internal/cli/doctor.go
@@ -173,7 +173,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				header := cfg.AuthHeader()
 				if header == "" {
 					report["auth"] = "not configured"
-					report["auth_hint"] = "Run 'ninjaone-cli auth setup' for credential setup steps."
+					// This CLI ships auth login, logout and status. There is no
+					// `auth setup` subcommand, and `auth` answers an
+					// unrecognised subcommand by printing its own help and
+					// exiting 0, so following the old hint looked like it
+					// worked while leaving auth unconfigured.
+					report["auth_hint"] = "Set NINJAONE_CLIENT_ID and NINJAONE_CLIENT_SECRET (plus NINJAONE_OAUTH_SCOPE if your instance needs a scope), then run 'ninjaone-cli auth login' to mint a token."
 				} else {
 					authConfigured = true
 					report["auth"] = "configured"

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -201,6 +201,17 @@
         {"file": "cli/internal/config/config.go", "contains": "markers now survive a save; only MarkCredentialsExplicit clears them.", "min_count": 1},
         {"file": "cli/internal/config/config.go", "not_contains": "delete(c.envOverrides, \"ClientID\")\n\tdelete(c.envOverrides, \"ClientSecret\")\n\tdelete(c.envOverrides, \"AccessToken\")"}
       ]
+    },
+    {
+      "id": "doctor-auth-hint-names-a-real-command",
+      "summary": "doctor's auth_hint points at `auth login` and the required environment variables instead of a nonexistent `auth setup` subcommand",
+      "why": "This CLI defines auth login, logout and status. There is no `auth setup`, yet doctor's auth_hint told operators to run it. The hint fires exactly when cfg.AuthHeader() is empty, which is the one moment someone reads doctor for guidance: fresh install, rotated secret, new machine, expired token. Worse, `auth` answers an unrecognised subcommand by printing its own help and exiting 0, so there is no 'unknown command' error and no non-zero exit to signal the advice was wrong. Reproduced live against an empty config: doctor reported auth 'not configured' with the old hint, running the suggested command exited 0 and printed help, and a second doctor still reported 'not configured'. These CLIs are agent-first with typed exit codes, so an agent doing setup reads exit 0 as success and moves on unauthenticated. This skill emits no auth_instructions field, so auth_hint is the only setup guidance doctor gives. The replacement names the real command and the variables auth login reads, including the optional scope override some instances require.",
+      "status": "active",
+      "spec_encode_followup": "Emit the auth hint from the set of subcommands the connector actually generates rather than a fixed string. Three other skills carry the same dead hint (appdirect, crowdstrike, halopsa), while blumira and datto-rmm do define `auth setup`, which is why the string was templated in the first place.",
+      "asserts": [
+        {"file": "cli/internal/cli/doctor.go", "not_contains": "ninjaone-cli auth setup"},
+        {"file": "cli/internal/cli/doctor.go", "contains": "ninjaone-cli auth login", "min_count": 1}
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Pull request

## What this changes

`halopsa-cli` and `ninjaone-cli` told operators to run `<cli> auth setup` when
authentication was not configured. Neither defines that subcommand.

## What kind of change is it?

- [x] A **fix** to a connector or skill that already exists

## Did you run it against a real tenant?

Yes, both. I used `--config` pointed at an empty temp file so live credentials
were never touched, which is also the state the hint is written for.

    halopsa-cli  doctor       auth "not configured", hint says run auth setup
    halopsa-cli  auth setup   exit=0, prints the auth help
    halopsa-cli  doctor       auth "not configured"     (nothing happened)

    ninjaone-cli doctor       auth "not configured", hint says run auth setup
    ninjaone-cli auth setup   exit=0, prints the auth help
    ninjaone-cli doctor       auth "not configured"     (nothing happened)

Then rebuilt both CLIs from this change and re-ran doctor against the same
empty config to confirm the new hints appear.

### Why this is worse than a typo

`auth` answers an unrecognised subcommand by printing its own help and exiting
0. A control confirms the shape:

    halopsa-cli auth definitelynotacommand   exit=0, same help output

So there is no "unknown command" error and no non-zero exit anywhere in the
journey. The operator follows doctor's advice, sees a success code, and is no
closer to configured credentials. These are agent-first CLIs with typed exit
codes and an `--agent` mode, so an agent performing setup reads exit 0 as
success and moves on unauthenticated.

The hint also fires exactly when it matters. The trigger in both is
`cfg.AuthHeader() == ""`, so it appears only when there is no usable
credential: fresh install, rotated secret, new machine, expired token. Neither
skill emits an `auth_instructions` field, so `auth_hint` is the only setup
guidance their doctor gives.

### What the hint says now

Both name the real command and the variables `auth login` actually reads, taken
from each login command's own flag defaults rather than composed:

    halopsa   Set HALOPSA_TENANT, HALOPSA_DOMAIN, HALOPSA_CLIENT_ID and
              HALOPSA_CLIENT_SECRET, then run 'halopsa-cli auth login'
    ninjaone  Set NINJAONE_CLIENT_ID and NINJAONE_CLIENT_SECRET (plus
              NINJAONE_OAUTH_SCOPE if your instance needs a scope), then run
              'ninjaone-cli auth login'

## Anything you could not do from your side?

Five skills emit this hint while defining no such command: `appdirect`,
`crowdstrike`, `halopsa`, `immybot`, `ninjaone`. `blumira` and `datto-rmm` do
define `auth setup`, which is presumably why the string was templated.

This PR fixes only halopsa and ninjaone, the two I can verify against live
instances. immybot is fixed in #276. **appdirect and crowdstrike are filed as an
issue rather than patched here**, because I have no instance of either and an
unverified fix is worth less to you than a clear report. The change is
mechanical if a maintainer wants to take it, but someone should confirm each
CLI's real auth flow before writing its replacement text, which is the part I
could not do.

## Anything that looks like our bug?

The durable fix belongs in the press: emit the auth hint from the set of
subcommands the connector actually generates, rather than a fixed string. Two
of the seven skills carrying it do define `auth setup`, so a template that
assumed it was universal is the likely origin. Recorded in both ledger entries'
`spec_encode_followup`.

## Checks

`doctor.go` is generated in both skills, so each gains a `handfixes.json` entry
with a banned anti-pattern on the old string. Both ledger files were edited as
raw text splices rather than re-serialised, so both diffs are pure additions
with zero removed lines.

    go build ./...        clean for both
    check_handfixes.py    PASS

Commit is signed off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication guidance in the diagnostic command to show the required environment variables.
  * Replaced the obsolete `auth setup` instruction with the supported `auth login` workflow for HaloPSA and NinjaOne.

* **Tests**
  * Added checks to ensure authentication guidance remains accurate and references valid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->