### PR TITLE
chore(release): immybot-v0.1.0

### DIFF
--- a/skills/immybot/CHANGELOG.md
+++ b/skills/immybot/CHANGELOG.md
@@ -1,4 +1,44 @@
 # Changelog
 
-This file is maintained by printing-press-library release automation. Do not hand-edit release sections in normal PRs.
+All notable changes to this skill are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[semantic versioning](https://semver.org/).
 
+## [0.1.0] - 2026-08-22
+
+### Added
+- Initial msp-skills release of the ImmyBot connector: `immybot-cli` and the
+  `immybot-mcp` MCP server, covering the ImmyBot API (computers, tenants,
+  software, target assignments, maintenance sessions and actions, scripts,
+  schedules, provider and RMM links, persons, roles, and access).
+- Offline SQLite mirror with `sync` and full-text `search`, so cross-tenant
+  questions answer from local data instead of one API call per tenant.
+- Cross-tenant views the console does not offer: `session-triage` (groups a
+  maintenance window's failures by root cause), `version-spread` (one software
+  title ranked across every tenant with a real semver comparator),
+  `assignment-explain` (which deployment rule actually won on a given machine,
+  and which are shadowed), `fleet-diff` (what changed between two syncs, from
+  history the API does not retain), `deployment-health`, `onboarding-stalled`,
+  `computer-dossier`, `drift`, `psa-reconcile`, and `script-blast-radius`.
+
+### Fixed
+- `auth login` no longer persists an env-supplied client secret to disk:
+  `SaveTokens` keeps the ClientID/ClientSecret env-override markers, so the
+  guards added in #268 actually hold.
+- `sync` mirrors every computer. `GET /api/v1/computers` exposes no cursor,
+  page, skip or offset, so `pageSize` is a ceiling rather than a page size and
+  the profiler's spec default of 25 silently truncated the resource that the
+  offline commands join on most.
+- Three parameter-required lookup endpoints are out of the default sync walk
+  (they returned HTTP 400 on every run) and remain reachable via `--resources`.
+- Staleness reports `never_synced` separately instead of reading a zero
+  watermark as a 292-year-old mirror.
+- `doctor` reports the instance subdomain as its own check, and every auth
+  hint - in `doctor`, `auth status`, `auth login --help`, the runtime error
+  paths, and the MCP tool layer - names the four required `IMMYBOT_*`
+  variables and points at `auth login` rather than an `auth setup` subcommand
+  this CLI does not define.
+
+Connector contributed by [@geekbrownbear](https://github.com/geekbrownbear)
+(PR [#276](https://github.com/servosity/msp-skills/pull/276)), live-verified
+against a production ImmyBot tenant.

--- a/tools/maintainer/skills.json
+++ b/tools/maintainer/skills.json
@@ -709,10 +709,10 @@
       "category": "RMM",
       "display_name": "ImmyBot",
       "tagline": "Triage a night of failed maintenance by root cause, and rank one title across every tenant.",
-      "cli_hash": "sha256:48ba104dacc229c9154c0e8da3000b16f366d48bcd1441462b2a23a1049a64a5",
+      "cli_hash": "sha256:f7a3c20983dede2bc9e2ecabf292b8e5205c25509e53cb63f719dfc0b9eca7aa",
       "template_version": 3,
       "version": "0.1.0",
-      "cli_hash_at_release": null,
+      "cli_hash_at_release": "sha256:f7a3c20983dede2bc9e2ecabf292b8e5205c25509e53cb63f719dfc0b9eca7aa",
       "has_video": false,
       "install_auth_hint": "Then register an app in Microsoft Entra ID, add the Enterprise Application object ID as an admin person in ImmyBot (Show More > People > New > AD External ID), set `IMMYBOT_SUBDOMAIN`, `IMMYBOT_TENANT_ID`, `IMMYBOT_CLIENT_ID` and `IMMYBOT_CLIENT_SECRET`, then run `immybot-cli doctor` to confirm it works",
       "live_verified": {


### PR DESCRIPTION
First release of the ImmyBot connector contributed by @geekbrownbear in #276.

- `cli_hash` restamped: maintainer fixes to `auth.go`, `mcp/tools.go` and `agent_context.go` landed after the last stamp, so the recorded hash no longer matched the tree.
- `cli_hash_at_release` stamped via `release.py` (never-released slug, so 0.1.0 is the first release with no bump).
- CHANGELOG 0.1.0 section hand-authored and dated: `release.py` only writes a section when bumping.

Tag `immybot-v0.1.0` follows once this is green and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvPuMj1ThvaiELSR1hzM24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.1.0, covering the initial connector, offline data mirror, cross-tenant views, authentication and synchronization improvements, staleness reporting, and troubleshooting guidance.
  * Added contributor and pull request attribution.

* **Chores**
  * Updated skill release metadata to reflect the current CLI version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->