### PR TITLE
fix(servosity): remove stale MCP context endpoints

### DIFF
--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.5.1] - unreleased
+
+### Fixed
+
+- The MCP `context` tool no longer advertises the admin-only `issues archived`
+  and `issues ignored` endpoints that were removed from the reseller-scoped
+  connector. Regression coverage and the hand-fix ledger now protect this
+  generated surface from future reprints (#253, reported by @DamienStevens).
+
 ## [0.5.0] - 2026-08-17
 
 Regenerated the vendored `servosity-cli` / `servosity-mcp` source from

--- a/skills/servosity/cli/internal/mcp/tools.go
+++ b/skills/servosity/cli/internal/mcp/tools.go
@@ -1356,7 +1356,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 			{
 				"name":        "issues",
 				"description": "Manage issues",
-				"endpoints":   []string{"archived", "ignored", "list", "read"},
+				"endpoints":   []string{"list", "read"},
 				"syncable":    true,
 				"searchable":  true,
 			},

--- a/skills/servosity/cli/internal/mcp/tools_test.go
+++ b/skills/servosity/cli/internal/mcp/tools_test.go
@@ -109,6 +109,37 @@ func TestMCPRegisterToolsPreservesTypedSpecialTools(t *testing.T) {
 	}
 }
 
+func TestMCPContextOmitsAdminOnlyIssueEndpoints(t *testing.T) {
+	result, err := handleContext(context.Background(), mcplib.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handleContext returned transport error: %v", err)
+	}
+
+	var payload struct {
+		Resources []struct {
+			Name      string   `json:"name"`
+			Endpoints []string `json:"endpoints"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal([]byte(mcpTextContent(t, result)), &payload); err != nil {
+		t.Fatalf("decode context payload: %v", err)
+	}
+
+	issuesResources := 0
+	for _, resource := range payload.Resources {
+		if resource.Name != "issues" {
+			continue
+		}
+		issuesResources++
+		if len(resource.Endpoints) != 2 || resource.Endpoints[0] != "list" || resource.Endpoints[1] != "read" {
+			t.Fatalf("context issues endpoints = %q, want exactly [list read]", resource.Endpoints)
+		}
+	}
+	if issuesResources != 1 {
+		t.Fatalf("context payload has %d issues resources, want exactly 1", issuesResources)
+	}
+}
+
 func TestMCPSearchMissingStoreIsActionable(t *testing.T) {
 	resetMCPPathEnv(t)
 

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -48,8 +48,8 @@
         },
         {
             "id": "admin-only-issues-endpoints-removed",
-            "summary": "issues archived (/issues/archived/) and issues ignored (/issues/ignored/) are stripped from EVERY surface (CLI, MCP code-orch, sync, store, workflow resource list, declared-surface conformance test) because they are admin-scoped and 403 for the reseller-scoped partner token this connector ships (PR #178)",
-            "why": "These two GET endpoints are generated from the OpenAPI spec and admin-only; the partner SERVOSITY_MSP_TOKEN gets HTTP 403. A naive reprint regenerates them on every surface (the CLI command files, the MCP code-orch endpoint table agents drive via servosity-msp_search/_execute, the sync resource map + store PK map, the workflow sync resource list, and - since press 4.30 - the declared-API-surface conformance test in root_test.go, which fails the build when a declared path has no Cobra command). The de-msp ritual must re-strip all of them; these not_contains asserts fail CI if any surface reintroduced them. Admin functionality lives in Servosity's separate internal admin CLI (admin-token-scoped) instead. See docs/reprint-survival.md.",
+            "summary": "issues archived (/issues/archived/) and issues ignored (/issues/ignored/) are stripped from EVERY surface (CLI, MCP code-orch and context, sync, store, workflow resource list, declared-surface conformance test) because they are admin-scoped and 403 for the reseller-scoped partner token this connector ships (PR #178)",
+            "why": "These two GET endpoints are generated from the OpenAPI spec and admin-only; the partner SERVOSITY_MSP_TOKEN gets HTTP 403. A naive reprint regenerates them on every surface (the CLI command files, the MCP code-orch endpoint table agents drive via servosity-msp_search/_execute, the MCP context taxonomy agents use for discovery, the sync resource map + store PK map, the workflow sync resource list, and - since press 4.30 - the declared-API-surface conformance test in root_test.go, which fails the build when a declared path has no Cobra command). The de-msp ritual must re-strip all of them; these not_contains asserts fail CI if any surface reintroduced them. Admin functionality lives in Servosity's separate internal admin CLI (admin-token-scoped) instead. See docs/reprint-survival.md.",
             "status": "active",
             "pr": 178,
             "asserts": [
@@ -68,6 +68,14 @@
                 {
                     "file": "cli/internal/mcp/code_orch.go",
                     "not_contains": "codeOrchKeywords(\"issues\", \"ignored\""
+                },
+                {
+                    "file": "cli/internal/mcp/tools.go",
+                    "not_contains": "[]string{\"archived\", \"ignored\", \"list\", \"read\"}"
+                },
+                {
+                    "file": "cli/internal/mcp/tools_test.go",
+                    "contains": "func TestMCPContextOmitsAdminOnlyIssueEndpoints("
                 },
                 {
                     "file": "cli/internal/cli/sync.go",


### PR DESCRIPTION
## Summary

- remove the retired admin-only `issues archived` and `issues ignored` endpoints from the Servosity MCP context taxonomy
- add semantic regression coverage for the real context payload
- extend the reprint-survival ledger to protect the generated MCP context surface

Fixes #253.

Reported by @DamienStevens.

## Security and release impact

- Impact B: the MCP context payload changes, while the supported CLI and API behavior remain unchanged
- no credentials, authorization behavior, dependencies, or unrelated connectors changed
- deterministic security gate: PASS (0 P1 findings; five pre-existing P2 scanner findings outside the diff)
- fresh-context adversarial review: no P1/P2 findings
- independent read-only Codex review: no P1/P2 findings

## Verification

- `go test ./internal/mcp`
- `go vet ./...`
- `python3 tools/maintainer/check_handfixes.py --slug servosity`
- `python3 tools/maintainer/check_security_gate.py --slug servosity --base origin/main`
- `tools/maintainer/verify_all.sh servosity`: all code, security, MCP, catalog, release, installer, and plugin gates passed; final status is blocked only by a pre-existing `actionlint` warning in untouched `.github/workflows/mcp-publish.yml`
- `git diff --check`

After merge, this should ship as `servosity-v0.5.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed access to the admin-only archived and ignored issue endpoints.
  * The issues resource now exposes only list and read operations.
  * Added regression coverage to verify the updated endpoint availability.
  * Documented the changes in the upcoming release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->