### PR TITLE
chore(ci): gate pinned release URLs for real, now that the backlog is cleared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,12 @@ jobs:
         # fetch-depth: 0, so every tag is local and no network call is made.
         env:
           BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        # WARN for the first landing only. main carries a real backlog this gate
-        # exists to surface - 62 pins across 31 connectors whose releases were
-        # never cut - and those are cleared by the tag push that follows this
-        # merge, not by a code change. Gating before the backlog is cleared would
-        # block the commit that fixes it. Same posture as check_cli_claims.py and
-        # check_env_schema.py above.
-        # NOTE(calibration): drop --warn once the 31 tags are cut and this reads 0.
-        run: python3 tools/maintainer/check_pinned_artifacts.py --base "$BASE" --no-network --warn
+        # Hard gate. The backlog this shipped in warn mode for - 62 pins across
+        # 31 connectors whose releases were never cut - was cleared by the
+        # 65-tag push on 2026-08-26. All 192 pinned release URLs across 128
+        # files now resolve, verified by HTTP HEAD against every one of them, so
+        # any new finding here is a new defect and should block.
+        run: python3 tools/maintainer/check_pinned_artifacts.py --base "$BASE" --no-network
 
       - name: No TODO / placeholder markers in skill prose
         run: python3 tools/maintainer/check_no_todos.py

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -76,9 +76,10 @@ if run python3 tools/maintainer/check_registry_state.py;  then pass "registry st
 if run python3 tools/maintainer/check_skill_contract.py;  then pass "skill contract";      else fail "skill contract";      fi
 if run python3 tools/maintainer/check_md_links.py;        then pass "markdown links";      else fail "markdown links";      fi
 if run python3 tools/maintainer/check_release_contract.py; then pass "release contract";   else fail "release contract";    fi
-# WARN until the 31 never-cut release tags are pushed; see ci.yml.
-# NOTE(calibration): restore fail() once the backlog reads 0.
-if run_show python3 tools/maintainer/check_pinned_artifacts.py --strict --warn; then pass "pinned release artifacts (warn)"; else warn "pinned release artifacts reported findings"; fi
+# Hard gate again: the never-cut-release backlog was cleared by the 2026-08-26
+# tag push, so a finding here is a new defect. --strict also promotes a stale
+# generated pin to a failure; the fix for that is `build-catalog.py`.
+if run_show python3 tools/maintainer/check_pinned_artifacts.py --strict; then pass "pinned release artifacts"; else fail "pinned release artifacts"; fi
 if run python3 tools/maintainer/check_social_assets.py;   then pass "social assets";       else fail "social assets";       fi
 if run python3 tools/maintainer/check_no_todos.py;        then pass "no TODO markers";     else fail "no TODO markers";     fi
 if run python3 tools/maintainer/check_vocabulary.py;      then pass "vocabulary contract"; else fail "vocabulary contract"; fi


### PR DESCRIPTION
Follow-up to #286, which shipped `check_pinned_artifacts.py` in warn mode.

`main` carried 62 broken pins across the 31 connectors whose releases had never been cut. Those are cleared by a tag push, not a code change, so gating on them would have blocked the commit that fixed them.

The 65-tag release cleared the backlog. Verified against real GitHub rather than against `git tag`:

```
distinct pinned download URLs on main: 65   ->  Counter({200: 65})
root README release-tag links:         65   ->  Counter({200: 65})
check_pinned_artifacts (hard, offline)      ->  OK (192 pinned release URLs across 128 files) exit 0
check_pinned_artifacts (hard, network)      ->  OK, asset-level, exit 0
all 65 releases                             ->  25 assets each, .mcpb present on every one
```

So a finding here is now a new defect, and it should block.

Refs #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened release validation so stale or invalid artifact pins now block CI and verification.
  * Updated validation guidance to reflect that generated pin issues are treated as defects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->