### PR TITLE
chore(release): pin the security scanners and drop the persisted credential

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Reads the repo to compute a matrix; never pushes. No git-usable
+          # credential is left in .git/config for anything this job runs.
+          persist-credentials: false
       - name: Compute build matrix
         id: gen
         env:
@@ -50,19 +54,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # This job downloads and executes third-party scanners. It never
+          # pushes, so it must not leave a git-usable repository credential in
+          # .git/config where a compromised scanner could read it.
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.26"
       - name: Install scanners (best-effort install; the gate fails CLOSED if a required one is missing)
+        env:
+          # PINNED, not @latest. These four tools are fetched and then EXECUTED
+          # inside a job that carries contents:write, so a compromised (or merely
+          # re-cut) upstream release would run with this repository's release
+          # credential. @latest also makes the gate's verdict non-reproducible:
+          # the same tag re-run a week later scans with different rules.
+          # Each pin below is the version @latest resolved to on 2026-08-26, so
+          # this change pins current behavior rather than altering it.
+          # To bump: change the version here, re-run the gate, land as a reviewed PR.
+          GOSEC_VERSION: "v2.29.0"
+          GOVULNCHECK_VERSION: "v1.7.0"
+          # osv-scanner v2 lives at a different module path
+          # (github.com/google/osv-scanner/v2); v1.9.2 is the newest on this v1
+          # path and is what @latest resolved to here.
+          OSV_SCANNER_VERSION: "v1.9.2"
+          SEMGREP_VERSION: "1.174.0"
         run: |
           set -uo pipefail
-          go install github.com/securego/gosec/v2/cmd/gosec@latest || true
-          go install golang.org/x/vuln/cmd/govulncheck@latest || true
+          go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}" || true
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}" || true
           # osv-scanner is a REQUIRED scanner for the gate; it was previously absent at
           # release time, so the release never ran osv at all. Install it for parity.
-          go install github.com/google/osv-scanner/cmd/osv-scanner@latest || true
-          python3 -m pip install --quiet semgrep || true
+          go install "github.com/google/osv-scanner/cmd/osv-scanner@${OSV_SCANNER_VERSION}" || true
+          python3 -m pip install --quiet "semgrep==${SEMGREP_VERSION}" || true
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Pre-warm scanner caches for the tagged connector
         env:
@@ -107,6 +132,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The release is created through `gh` with GH_TOKEN; git itself is
+          # only read from here.
+          persist-credentials: false
 
       - name: Ensure release exists
         env:
@@ -151,6 +179,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Assets are uploaded through `gh` with GH_TOKEN; this job never
+          # pushes with git.
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Raised by an independent Codex security pass over the repo. Split out of #289 because `security-gate.yml` hard-fails any PR touching `release.yml` - by design, since the gate runs the PR's own copy, so gate-logic changes cannot be self-approved. **This PR needs a CODEOWNERS review; the red security-gate check is the intended behaviour, not a defect.**

## The problem

`release.yml` fires on a tag push with `contents: write`. It then installs four third-party scanners and executes them:

```
go install github.com/securego/gosec/v2/cmd/gosec@latest
go install golang.org/x/vuln/cmd/govulncheck@latest
go install github.com/google/osv-scanner/cmd/osv-scanner@latest
python3 -m pip install --quiet semgrep          # unversioned
```

Two consequences:

1. **Supply chain.** A compromised - or merely re-cut - upstream release executes alongside a persisted repository credential that can modify tags and releases.
2. **The gate's verdict is not reproducible.** The same tag re-run a week later scans with different rules, so "the security gate passed" does not describe a fixed thing.

## The change

Each version below is what `@latest` resolved to on 2026-08-26, so this **pins current behaviour rather than altering it** - the gate should return exactly what it returned on the last release.

`persist-credentials: false` on all four checkouts. None of the four jobs pushes with git: `prepare` computes a matrix, `security_gate` scans, and `create-release` / `build` both write through `gh` with `GH_TOKEN`, never through a git-usable credential in `.git/config`. This also brings `release.yml` in line with `mcp-publish.yml`, which already sets it.

To bump a scanner later: change the version, re-run the gate, land as a reviewed PR - which is the point.

## Not done

Codex's fuller recommendation is to split the job graph so scanning runs under `contents: read` and a separate job consumes the result and does the release writes. That is a structural change to the release path and is left for a maintainer to decide. Pinning is the contained fix and removes the immediate exposure.

`security-gate.yml` still installs the same four scanners at `@latest` (lines 67-70). Out of scope here, since this PR is deliberately scoped to `release.yml`, but it is the obvious follow-up.

## Rebase onto main (2026-08-26)

Rebased from `e817cbfd9` onto `3904ca93d` to pick up #294 (`6792f6a3b`, "one source of truth for release asset filenames"), which rewrote the `build` job so it consumes literal asset names from the `release_matrix.py` output instead of reconstructing the `-<goos>-<goarch>` suffix in shell.

**No conflict.** The two changesets touch disjoint regions of `release.yml`:

| PR | Region touched |
| --- | --- |
| #294 | `build` job `env:` block and the shell body that derives `cli` / `mcp` (now lines 199-243) |
| #290 | the four `actions/checkout` steps (lines 37, 61, 137, 185) and the `security_gate` scanner-install `env:` block (lines 67-90) |

#290's closest hunk is the `build` job's checkout at line 185; #294's nearest edit starts at line 199. The rebase applied cleanly and the post-rebase diff against `main` is 36 insertions / 4 deletions, byte-for-byte the same change as before the rebase. Both intents survive, confirmed by grep on the rebased file:

- #294 present: `CLI_ASSET` / `MCP_ASSET` at 208-209, `cli="$CLI_ASSET"` at 238, the empty-name guard at 240-243.
- #290 present: `persist-credentials: false` at 37 / 61 / 137 / 185, the four `*_VERSION` pins at 76-82, all four installs interpolating them at 85-90.

## Verification on the rebased tree

**Every pin resolves, and each equals what `@latest` returns today:**

| Tool | Pinned | Upstream `@latest` | Published |
| --- | --- | --- | --- |
| gosec | `v2.29.0` | `v2.29.0` | 2026-08-25 |
| govulncheck | `v1.7.0` | `v1.7.0` | 2026-08-13 |
| osv-scanner (v1 path) | `v1.9.2` | `v1.9.2` | 2024-12-19 |
| semgrep | `1.174.0` | `1.175.0` | 2026-08-20 |

Go pins spot-checked against the module proxy, for example:

```
$ curl -s https://proxy.golang.org/github.com/securego/gosec/v2/@v/v2.29.0.info
{"Version":"v2.29.0","Time":"2026-08-25T08:37:38Z","Origin":{"VCS":"git",
 "URL":"https://github.com/securego/gosec","Hash":"deb54465fea23d19a77f037e11e6589021f8501d",
 "Ref":"refs/tags/v2.29.0"}}
```

Two notes on the table. The `osv-scanner` comment in the workflow checks out: `github.com/google/osv-scanner/@latest` really is `v1.9.2`, and v2 really does live at a separate module path (`github.com/google/osv-scanner/v2/@latest` is `v2.5.1`), so the v1 pin is the newest release on the path the workflow uses. The semgrep pin looks one behind only because `1.175.0` was uploaded to PyPI at 2026-08-26T17:11Z, after this commit was authored at 13:56Z; `1.174.0` (2026-08-20) was genuinely `@latest` at the time, so the "pins current behaviour" claim holds.

**The persisted credential is gone and nothing needs it.** All four `actions/checkout@v4` steps in the workflow now set `persist-credentials: false`, and the workflow contains no `git push`, `git tag`, `git commit`, `git config ... credential`, `extraheader`, `GIT_ASKPASS`, `x-access-token`, `submodules:`, `ssh-key:` or `token:` usage. The only writes are `gh release create` and `gh release upload`, both authenticated by `GH_TOKEN` rather than by the git credential helper.

**Gates:**

```
$ actionlint .github/workflows/release.yml      # exit 0, no output
$ actionlint                                    # exit 0, all workflows
$ bash tools/maintainer/ci_guards.sh            # All CI guards passed. (exit 0)
```

Also run green on the rebased tree, including the two checks #294 rewrote:

```
check_release_contract    PASS
check_pinned_artifacts    PASS
check_skill_contract      PASS
check_md_links            PASS
check_no_todos            PASS
check_vocabulary          PASS
check_aeo                 PASS
check_video_assets        PASS
check_mcp_registry        PASS
```

Behavioural verification is still the next tag push: the gate should reach the same verdict it reached on the last one.

**Correction to an earlier draft of this description:** it listed `github.com/anchore/grype/cmd/grype@latest` as the third scanner. That was wrong. `release.yml` has never installed grype; the third tool is `osv-scanner`, which is what the diff actually pins. The code block above is corrected.

Refs #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation security by preventing workflows from retaining authentication credentials.
  * Standardized security scanning tools to use fixed, verified versions.
  * Added the required vulnerability scanner to release checks for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
