### PR TITLE
chore: issue chooser + bug-report form for the contribution funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Sorry it broke. The two fields that get this fixed fastest are the exact command (or question) you ran and the exact error text - paste both verbatim, even if they look obvious. Redact tenant names, hostnames, keys, and tokens before you post.
+        Sorry it broke. The field that gets this fixed fastest is the exact command (or question) you ran - paste it verbatim, even if it looks obvious. If there was error text, paste that verbatim too. If there was not - it hung, returned nothing, or answered wrong - describe what came back instead. Redact tenant names, hostnames, keys, and tokens before you post.
 
   - type: dropdown
     id: skill
@@ -131,11 +131,9 @@ body:
   - type: textarea
     id: error
     attributes:
-      label: Exact error output
-      description: Paste the full output, including any stack trace or HTTP status. Redact tenant names, hostnames, keys, and tokens first. This box renders as code, so no backticks needed.
+      label: What you saw (exact error output if any)
+      description: If there was error text, paste it verbatim - the full output, including any stack trace or HTTP status. If there was no error - it hung, returned nothing, or gave a wrong answer - describe what came back instead and what you expected. Redact tenant names, hostnames, keys, and tokens first. This box renders as code, so no backticks needed.
       render: shell
-    validations:
-      required: true
 
   - type: dropdown
     id: ever_worked

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,156 @@
+# NOTE: the "Which skill" dropdown options are GENERATED from tools/skills.json
+# by tools/maintainer/build-catalog.py (every connector, slug-sorted, plus
+# "other / not listed") - the same generator that owns it-works.yml's dropdown.
+# Do NOT edit the options by hand - register the skill and run
+# `python3 tools/maintainer/build-catalog.py`. A hand-maintained slug list
+# drifts the moment a connector ships, and a reporter forced into "other" costs
+# a triage round-trip to find out which connector actually broke.
+name: "🐞 Report: something broke"
+description: A Skill or MCP server errored, hung, returned nothing, or gave a wrong answer. Tell us exactly what you ran and exactly what came back.
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Sorry it broke. The two fields that get this fixed fastest are the exact command (or question) you ran and the exact error text - paste both verbatim, even if they look obvious. Redact tenant names, hostnames, keys, and tokens before you post.
+
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Which skill
+      description: The Skill / MCP server that broke.
+      options:
+        - abnormal
+        - acronis
+        - action1
+        - afi
+        - appdirect
+        - atera
+        - autotask
+        - auvik
+        - avanan
+        - aws-billing
+        - axcient
+        - betterstack
+        - blumira
+        - cipp
+        - connectwise-automate
+        - connectwise-control
+        - connectwise-manage
+        - cork
+        - cove
+        - crowdstrike
+        - datto-bcdr
+        - datto-rmm
+        - domotz
+        - gradient
+        - halopsa
+        - hubspot
+        - hudu
+        - huntress
+        - immybot
+        - itglue
+        - kaseya-bms
+        - knowbe4
+        - levelio
+        - liongard
+        - maxio
+        - microsoft-graph
+        - mspbots
+        - n-central
+        - nerdio
+        - ninjaone
+        - pagerduty
+        - pandadoc
+        - pax8
+        - pipedrive
+        - proofpoint
+        - quickbooks
+        - resourceguru
+        - rewst
+        - rocketcyber
+        - rootly
+        - runzero
+        - salesbuildr
+        - sentinelone
+        - servosity
+        - sherweb
+        - skykick
+        - superops
+        - syncro
+        - tactical-rmm
+        - threatlocker
+        - unifi-network
+        - veeam
+        - wordpress
+        - xero
+        - zammad
+        - other / not listed
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: Where you ran it.
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Which AI agent did you use?
+      description: The AI client you ran it from. Pick "other" if you ran the CLI directly in a terminal.
+      options:
+        - Claude Code
+        - Claude Desktop
+        - ChatGPT
+        - Codex CLI
+        - Copilot
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Exact command or question you ran
+      description: Paste it verbatim. If you asked your agent in plain English, paste the question exactly as you typed it.
+      placeholder: |
+        e.g. halopsa tickets list --status open --limit 50
+        or  "Which clients have HaloPSA tickets breaching SLA in the next 4 hours?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Exact error output
+      description: Paste the full output, including any stack trace or HTTP status. Redact tenant names, hostnames, keys, and tokens first. This box renders as code, so no backticks needed.
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ever_worked
+    attributes:
+      label: Did it ever work?
+      description: Tells us whether we are looking at a regression or a first-run setup problem.
+      options:
+        - "No - it has never worked for me"
+        - "Yes - it worked before and then broke"
+        - "Not sure / first time trying it"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Want a hand live?** Bring it to a [Build Session](https://compoundingteams.com/build-sessions) - free, weekly, Thursdays. We debug real tenants on the call. Recordings and discussion live in the [community](https://ai-accelerator-233a51.circle.so/join).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,9 +13,9 @@ contact_links:
     about: Discussion and Build Session recordings.
 
   - name: Request a connector or send an it-works receipt without a GitHub account
-    url: mailto:hello@servosity.com
-    about: Email hello@servosity.com - plain text is fine. Tell us what to build, or tell us a Skill worked against your real tenant. A web form is coming.
+    url: https://msp-skills.compoundingteams.com/verified/
+    about: This page gives you a plain-email option - no account needed. Tell us what to build, or tell us a Skill worked against your real tenant. Plain text is fine.
 
   - name: Report a security issue privately
-    url: mailto:security@servosity.com
-    about: Email security@servosity.com instead of opening a public issue.
+    url: https://github.com/Servosity/msp-skills/blob/main/SECURITY.md
+    about: Email security@servosity.com instead of opening a public issue - this page has the details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,21 @@
+# The issue chooser's contribution funnel. Blank issues stay ON so an MSP who
+# does not fit a form is never turned away; these links catch the cases where
+# GitHub is the wrong surface entirely (live help, community, no-account
+# requests, private security reports).
+blank_issues_enabled: true
+contact_links:
+  - name: Build Sessions
+    url: https://compoundingteams.com/build-sessions
+    about: Co-build a connector live and ask questions. Free, weekly, Thursdays.
+
+  - name: Community
+    url: https://ai-accelerator-233a51.circle.so/join
+    about: Discussion and Build Session recordings.
+
+  - name: Request a connector or send an it-works receipt without a GitHub account
+    url: https://msp-skills.compoundingteams.com/requesting-a-skill/
+    about: No GitHub account, no terminal. Tell us what to build, or tell us a Skill worked against your real tenant.
+
+  - name: Report a security issue privately
+    url: mailto:security@servosity.com
+    about: Email security@servosity.com instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,8 +13,8 @@ contact_links:
     about: Discussion and Build Session recordings.
 
   - name: Request a connector or send an it-works receipt without a GitHub account
-    url: https://msp-skills.compoundingteams.com/requesting-a-skill/
-    about: No GitHub account, no terminal. Tell us what to build, or tell us a Skill worked against your real tenant.
+    url: mailto:hello@servosity.com
+    about: Email hello@servosity.com - plain text is fine. Tell us what to build, or tell us a Skill worked against your real tenant. A web form is coming.
 
   - name: Report a security issue privately
     url: mailto:security@servosity.com

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -95,3 +95,5 @@ body:
       value: |
         ---
         **What happens next:** we comment within a few days - usually "already on the roadmap," "needs more votes (share with one MSP friend)," or "bring it to next Thursday's Build Session." [RSVP](https://compoundingteams.com/build-sessions).
+
+        **Want a hand live?** Bring it to a [Build Session](https://compoundingteams.com/build-sessions) - free, weekly, Thursdays. We co-build connectors against real tenants on the call. Recordings and discussion live in the [community](https://ai-accelerator-233a51.circle.so/join).

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -12,6 +12,9 @@ This script is the single regenerator. One run refreshes:
     sync_skill_readme_mcpb for why the registry version is the wrong source)
   - docs/skills/<slug>.md via render_docs_page (so a live-verified flip or a
     page.json edit re-renders the site page in the same pass)
+  - the "Which skill" dropdown in every issue form that has one
+    (.github/ISSUE_TEMPLATE/it-works.yml, bug-report.yml), so a reporter can
+    always pick the exact connector instead of being forced into "other"
 
 CI runs it on every PR that touches `skills/` and fails if any committed
 derived file drifts from what this script would produce.
@@ -39,6 +42,11 @@ README = ROOT / "README.md"
 CATALOG = ROOT / "catalog.json"
 DOCS_CATALOG = ROOT / "docs" / "_data" / "catalog.json"
 IT_WORKS_FORM = ROOT / ".github" / "ISSUE_TEMPLATE" / "it-works.yml"
+BUG_REPORT_FORM = ROOT / ".github" / "ISSUE_TEMPLATE" / "bug-report.yml"
+# Every issue form carrying an `id: skill` connector picker. One generator owns
+# them all, so a newly registered connector can never be selectable in one form
+# and missing from another.
+CONNECTOR_FORMS = (IT_WORKS_FORM, BUG_REPORT_FORM)
 
 # Owner/repo and per-skill metadata are the single source of truth in
 # tools/skills.json (loaded via registry). Every install URL is built from
@@ -236,19 +244,24 @@ def replace_block(content: str, marker_start: str, marker_end: str, block: str) 
     return pattern.sub(rf"\1\n{block}\n\3", content)
 
 
-# The "Which skill" dropdown in the it-works issue form. Anchored on the FIRST
-# `options:` block (the `id: skill` dropdown precedes `id: agent` in the file)
-# up to its `validations:`. We rewrite the option LIST in place - same line
-# shape that already ships (`        - <slug>`) - rather than fencing with
-# YAML comments inside the sequence, which the GitHub form parser is fussier
-# about and which we cannot validate locally (no PyYAML in CI's catalog job).
+# The "Which skill" dropdown in an issue form. Anchored on `id: skill`
+# specifically, NOT on the first `options:` block in the file: with two forms
+# now sharing this generator, an anchor that just took the first options block
+# would silently overwrite the WRONG dropdown (e.g. bug-report's `os` list)
+# the moment someone reordered the fields, and would exit 0 while doing it.
+# Anchoring on the field id makes that case a loud failure instead. We rewrite
+# the option LIST in place - same line shape that already ships
+# (`        - <slug>`) - rather than fencing with YAML comments inside the
+# sequence, which the GitHub form parser is fussier about and which we cannot
+# validate locally (no PyYAML in CI's catalog job).
 _FORM_OPTIONS_RE = re.compile(
-    r"(      options:\n)(?:        - .*\n)+?(    validations:\n)"
+    r"(    id: skill\n    attributes:\n(?:      \S.*\n)*?      options:\n)"
+    r"(?:        - .*\n)+?(    validations:\n)"
 )
 
 
-def render_it_works_form(content: str, skills: list[dict]) -> str:
-    """Regenerate the it-works form's skill dropdown from the registry: every
+def render_connector_dropdown(content: str, skills: list[dict], form: Path) -> str:
+    """Regenerate an issue form's skill dropdown from the registry: every
     connector (markdown-only meta excluded), slug-sorted, plus the
     "other / not listed" escape hatch. Returns the new file content."""
     connectors = sorted(s["name"] for s in skills if not s.get("markdown_only"))
@@ -259,9 +272,10 @@ def render_it_works_form(content: str, skills: list[dict]) -> str:
     if n != 1:
         raise SystemExit(
             f"build-catalog: could not find the skill dropdown options block in "
-            f"{IT_WORKS_FORM.relative_to(ROOT)} (expected `      options:` followed "
-            f"by `        - ...` lines and `    validations:`). The form structure "
-            f"changed; update _FORM_OPTIONS_RE."
+            f"{form.relative_to(ROOT)} (expected an `    id: skill` dropdown whose "
+            f"`      options:` is followed by `        - ...` lines and "
+            f"`    validations:`). The form structure changed; update "
+            f"_FORM_OPTIONS_RE."
         )
     return new_content
 
@@ -614,13 +628,17 @@ def main() -> int:
     for w in mcpb_warnings:
         print(f"build-catalog: WARN {w}")
 
-    # Regenerate the it-works issue form's skill dropdown so a reporter can pick
-    # the exact connector (not be forced into "other"); the catalog.yml drift
-    # gate keeps it in lockstep with the registry. Skipped gracefully if the
-    # form is absent (e.g. a partial checkout).
-    if IT_WORKS_FORM.exists():
-        form = IT_WORKS_FORM.read_text(encoding="utf-8")
-        IT_WORKS_FORM.write_text(render_it_works_form(form, skills), encoding="utf-8")
+    # Regenerate each connector-picking issue form's skill dropdown (it-works,
+    # bug-report) so a reporter can pick the exact connector (not be forced into
+    # "other"); the catalog.yml drift gate keeps them in lockstep with the
+    # registry. Each is skipped gracefully if absent (e.g. a partial checkout).
+    for form_path in CONNECTOR_FORMS:
+        if not form_path.exists():
+            continue
+        form = form_path.read_text(encoding="utf-8")
+        form_path.write_text(
+            render_connector_dropdown(form, skills, form_path), encoding="utf-8"
+        )
 
     # Re-render every connector's docs page in the same pass, so a registry
     # change (live-verified flip, display rename) or a page.json edit shows up


### PR DESCRIPTION
## What

Adds the missing front door to the contribution funnel: an issue chooser (`config.yml`) and a structured bug-report form, and puts the connector dropdown in the bug form under the same generator that already owns it-works.yml's.

| File | Change |
| --- | --- |
| `.github/ISSUE_TEMPLATE/config.yml` | **new** - the chooser: blank issues ON, four contact links |
| `.github/ISSUE_TEMPLATE/bug-report.yml` | **new** - structured bug form (`[Bug] `, labels `bug` + `triage`) |
| `.github/ISSUE_TEMPLATE/skill-request.yml` | Build Sessions + community footer links |
| `tools/maintainer/build-catalog.py` | generator now owns the connector dropdown in **both** forms; anchor hardened |

## Why

The repo had two issue forms (skill-request, it-works) and no chooser config. A broken connector therefore arrived as a blank issue with no connector slug, no OS, no agent, and usually no error text - every one of those cost a triage round-trip before work could start. There was also no surface at all pointing an MSP at live help, the community, the no-GitHub-account path, or private security reporting.

### The chooser

Blank issues stay **on**: an MSP who does not fit a form must never be turned away. The four contact links catch the cases where GitHub is the wrong surface entirely:

- **Build Sessions** -> `https://compoundingteams.com/build-sessions` (co-build a connector live and ask questions)
- **Community** -> Circle (discussion and Build Session recordings)
- **Request a connector or send an it-works receipt without a GitHub account** -> `https://msp-skills.compoundingteams.com/verified/` (the page publishes the `hello@servosity.com` plain-email path)
- **Report a security issue privately** -> `https://github.com/Servosity/msp-skills/blob/main/SECURITY.md` (the `about` text names `security@servosity.com`)

All four urls are `https`, which GitHub's config schema requires - see the schema fix below.

### The bug form

Connector, OS, and agent as dropdowns; the exact command as a required textarea and what you saw as an optional one that renders as code and prompts for redaction of tenant names, hostnames, keys, and tokens; a "did it ever work?" dropdown that separates a regression from a first-run setup problem. Footer points at Build Sessions and the community.

### The generator change

The task allowed either extending the generator or falling back to a plain input field. Extending it was cheap and strictly better, so the connector dropdown is generated in the same style as it-works.yml's, from `tools/skills.json`. A hand-maintained slug list drifts the moment a connector ships, and a reporter forced into "other" costs exactly the triage round-trip this form exists to remove.

**The anchor was also hardened while it was being generalized.** `_FORM_OPTIONS_RE` used to take the *first* `options:` block in the file. With two forms sharing the generator, that would have silently rewritten the **wrong** dropdown (bug-report's `os` list) if anyone reordered the fields - and exited 0 while doing it. I reproduced exactly that before changing it. It now anchors on `id: skill`, so the same case is a loud failure naming the form.

## Adversarial review fixes (second commit)

Two findings from review, both corrected on the branch:

1. **The no-account link was a false promise.** The label reads "without a GitHub account", but the URL pointed at `https://msp-skills.compoundingteams.com/requesting-a-skill/`, and that page walks the reader straight into a GitHub issue form. It now points at `https://msp-skills.compoundingteams.com/verified/` - the page that publishes the no-account plain-email receipt path - and the `about` text says plain email is fine and no account is needed. (This started life as a `mailto:` link; see the schema fix below for why it could not stay one.)
2. **"Exact error output" was required, and should not be.** The form's own description names hangs, empty results, and wrong answers as in-scope bugs, and none of those produce error text. A reporter with a silent hang had to invent something to clear the field. The box is now optional and titled **"What you saw (exact error output if any)"**, with guidance to paste output verbatim if there is any and otherwise describe the wrong or empty result. The intro blurb was reworded to match, so the form no longer asks for two verbatim pastes it cannot always get.

## Review fix: `contact_links` must be `https`, not `mailto`

Adversarial review caught a real defect, verified against GitHub's published issue-template config schema: `contact_links[].url` is constrained to `^https?://`. The two `mailto:` entries this PR introduced would make GitHub reject or ignore `config.yml` outright - taking the whole chooser with it, `blank_issues_enabled` included. The links would not merely have failed to render; the config would not have loaded.

Both are now `https`, and neither loses its email path:

- **No-account link** -> `https://msp-skills.compoundingteams.com/verified/`, the page that publishes the `hello@servosity.com` plain-email route. The `about` text says the page gives you a plain-email option, no account needed.
- **Private security link** -> `https://github.com/Servosity/msp-skills/blob/main/SECURITY.md`, the rendered policy. The `about` text still names `security@servosity.com` so the address is visible on the chooser itself, without a click.

Validated: `yaml.safe_load` parses the file, and an assertion confirms **all four** `contact_links` urls start with `https://` (the two pre-existing links were already compliant; they were checked, not assumed).

## Verification

Proven in all three directions, not just the happy path:

1. **Clean run is idempotent** - `build-catalog.py` leaves both forms byte-identical.
2. **A drifted option list is restored exactly** - mangled bug-report's dropdown down to 2 stale slugs, regenerated, `diff` clean against the pre-mangle file.
3. **A missing `id: skill` dropdown exits 1** with a message naming the form (this was the silent-wrong case before the hardening).

Also run and passing:

- `yaml.safe_load` on all four templates (config, bug-report, skill-request, it-works), asserting the parsed shape: title prefixes, labels, field ids, `render: shell` on the what-you-saw box, and that the it-works and bug-report skill dropdowns are **identical** (66 options each).
- `bash tools/maintainer/ci_guards.sh`
- `python3 tools/maintainer/check_vocabulary.py`
- `python3 tools/maintainer/check_no_todos.py`
- `python3 tools/maintainer/check_md_links.py`

`it-works.yml` was **not** hand-edited. It is regenerated byte-identical by the generator under the new anchor.

## Deferred / notes

- **The generated issue forms are not yet in `catalog.yml`'s drift / auto-commit scope, and that is deliberate for this PR.** `build-catalog.py` now writes the skill dropdown into `bug-report.yml` as well as `it-works.yml`, so both belong in the workflow's watched paths and in what the main-branch job auto-commits. Adding them means editing `.github/workflows/catalog.yml`, which is owned by the in-flight `release/p0-mcp-filesystem` branch - touching it here would collide. This is the same pre-existing gap `it-works.yml` has always had (it is generated today and is not in that scope either), so this PR does not widen the exposure, it inherits it. The follow-up lands post-p0.
- **Pre-existing derived-file drift, deliberately not included.** Running `build-catalog.py` on a clean `origin/main` checkout (no changes of mine, tags freshly fetched) rewrites the version-pinned `.mcpb` link in **37** `skills/*/README.md` files - newer release tags exist than the links committed on main. I reverted all 37: they are unrelated to this change and the main-branch auto-commit in `catalog.yml` clears them on the next push. Flagging it because `catalog.yml`'s PR drift gate triggers on `tools/maintainer/build-catalog.py`, so **that check may go red on this PR for a reason this PR did not cause** - it is reproducible on a clean checkout of main with zero changes applied.
- Per instructions, `README.md`, `.github/workflows/ci.yml`, and `.github/workflows/catalog.yml` were not touched (owned by the in-flight `release/p0-mcp-filesystem` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided bug-report form for Skill and MCP server failures, including environment details, troubleshooting guidance, and secure redaction reminders.
  * Added issue chooser links for build sessions, community discussions, connector requests, verification receipts, and private security reports.
  * Added Build Session information to skill requests, including co-building and community resources.

* **Chores**
  * Improved automatic maintenance of connector selections across relevant issue forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->