### PR TITLE
chore(release): one source of truth for release asset filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,14 +164,26 @@ jobs:
           GOOS: ${{ matrix.target.goos }}
           GOARCH: ${{ matrix.target.goarch }}
           CGO_ENABLED: "0"
+          # SINGLE SOURCE OF TRUTH for asset filenames. These are the FINAL
+          # literal names, computed by registry.asset_map() and embedded in the
+          # matrix by tools/maintainer/release_matrix.py - the same function
+          # tools/maintainer/check_release_contract.py checks the install scripts
+          # against. This workflow no longer rebuilds the "-<goos>-<goarch>"
+          # suffix or the windows ".exe" rule in shell, so it cannot drift away
+          # from the gate that is supposed to police it (before this, the
+          # contract check could pass green while the workflow uploaded
+          # something else entirely).
+          CLI_ASSET: ${{ matrix.skill.assets[format('{0}-{1}', matrix.target.goos, matrix.target.goarch)].cli }}
+          MCP_ASSET: ${{ matrix.skill.assets[format('{0}-{1}', matrix.target.goos, matrix.target.goarch)].mcp }}
         run: |
           set -euo pipefail
           skill="${{ matrix.skill.name }}"
           # Each skill is tagged and released independently
           # (<slug>-v<semver>); a tag builds only its matching skill. The slug
           # is derived generically from the tag, so a new skill needs no edit
-          # here. Asset names match exactly what skills/<skill>/install.sh and
-          # install.ps1 download.
+          # here. Asset names come from the matrix (see CLI_ASSET/MCP_ASSET
+          # above) and are proven equal to what skills/<skill>/install.sh and
+          # install.ps1 download by tools/maintainer/check_release_contract.py.
           tag_skill="${TAG%-v*}"      # halopsa-v0.1.0 -> halopsa
           version="${TAG##*-v}"       # halopsa-v0.1.0 -> 0.1.0
 
@@ -188,11 +200,16 @@ jobs:
           # This matrix row builds only the skill the tag names.
           [ "$skill" = "$tag_skill" ] || { echo "Tag $TAG: skipping $skill (this tag releases $tag_skill)."; exit 0; }
 
-          ext=""
-          [ "$GOOS" = "windows" ] && ext=".exe"
-          suffix="${GOOS}-${GOARCH}${ext}"
-          cli="${{ matrix.skill.cli_bin }}-${suffix}"
-          mcp="${{ matrix.skill.mcp_bin }}-${suffix}"
+          # Asset names come from the matrix (registry.asset_map), never from
+          # string-building here. Fail loudly rather than uploading an empty or
+          # half-formed name if the matrix ever lacks this target's entry.
+          cli="$CLI_ASSET"
+          mcp="$MCP_ASSET"
+          if [ -z "$cli" ] || [ -z "$mcp" ]; then
+            echo "::error::matrix carries no asset names for ${GOOS}-${GOARCH};"
+            echo "::error::regenerate with tools/maintainer/release_matrix.py"
+            exit 1
+          fi
 
           # $version (derived above as ${TAG##*-v}) is stamped into the CLI,
           # matching the prior goreleaser config.

--- a/tools/maintainer/check_pinned_artifacts.py
+++ b/tools/maintainer/check_pinned_artifacts.py
@@ -317,10 +317,11 @@ def expected_assets(slug: str, meta: dict) -> set[str]:
     """The complete asset set a release for this slug ships: the release
     workflow's binaries, their .sha256 sidecars, and the .mcpb bundle."""
     assets: set[str] = set()
-    for binary in (meta["cli_binary"], meta["mcp_binary"]):
-        for t in registry.TARGETS:
-            ext = ".exe" if t["goos"] == "windows" else ""
-            name = f"{binary}-{t['goos']}-{t['goarch']}{ext}"
+    # Names come from registry.asset_map - the same function release_matrix.py
+    # feeds into the build matrix release.yml uploads from - so this gate can
+    # never expect a filename the release does not actually produce.
+    for per_target in registry.asset_map(meta["cli_binary"], meta["mcp_binary"]).values():
+        for name in per_target.values():
             assets.add(name)
             assets.add(name + ".sha256")
     assets.add(f"{meta['mcp_binary']}.mcpb")

--- a/tools/maintainer/check_release_contract.py
+++ b/tools/maintainer/check_release_contract.py
@@ -2,17 +2,25 @@
 """Assert the install scripts and the release workflow agree on asset names.
 
 This is the gate that guarantees a user's `curl | bash` one-liner resolves to a
-real GitHub Release asset. For every skill it cross-checks three things:
+real GitHub Release asset. For every skill it cross-checks:
 
   1. install.sh CLI_BIN/MCP_BIN  ==  install.ps1 CliBin/McpBin (minus .exe)
-     ==  tools/skills.json cli_binary/mcp_binary.
-  2. The set of asset names the install scripts will DOWNLOAD
-     (CLI_BIN/MCP_BIN x the os/arch each script covers).
-  3. The set of asset names the release workflow will PRODUCE
-     (release_matrix.py: cli_bin/mcp_bin x TARGETS, .exe on windows).
-  ... and asserts set (2) == set (3) exactly.
+     ==  tools/maintainer/skills.json cli_binary/mcp_binary.
+  2. The asset names the install scripts will DOWNLOAD, RENDERED FROM THE
+     SCRIPTS' OWN URL TEMPLATES (install.sh `cli_url=`/`mcp_url=`, install.ps1
+     `$cliUrl`/`$mcpUrl`) with the os/arch each script covers substituted in.
+  3. The asset names the release workflow will PRODUCE - read from the SAME
+     shared source the workflow itself consumes: registry.asset_map(), which
+     release_matrix.py embeds into the build matrix as literal filenames.
+  ... and asserts set (2) == set (3) exactly, per skill.
 
-Run locally:  python3 tools/check_release_contract.py
+Because (3) now comes from the one shared function rather than a second hand-
+written copy of the "-<goos>-<goarch>" + windows ".exe" rule, a workflow that
+disagrees with this gate is no longer possible: both read the same names. What
+the gate still independently proves is that the shipped install scripts - real
+text, parsed here, not a mirror of it - resolve to those exact names.
+
+Run locally:  python3 tools/maintainer/check_release_contract.py
 """
 
 from __future__ import annotations
@@ -42,23 +50,87 @@ def _ps_var(text: str, name: str) -> str | None:
     return m.group(1) if m else None
 
 
-def install_expected_assets(cli_bin: str, mcp_bin: str) -> set[str]:
-    assets = set()
-    for bin_ in (cli_bin, mcp_bin):
-        for os_, arch in SH_TARGETS:
-            assets.add(f"{bin_}-{os_}-{arch}")
-        for os_, arch in PS_TARGETS:
-            assets.add(f"{bin_}-{os_}-{arch}.exe")
-    return assets
+# The asset-name templates the shipped installers actually use. We parse these
+# out of the real script text rather than re-declaring the naming rule, so an
+# edit to an installer's URL line is caught instead of silently agreeing with a
+# copy of itself.
+SH_URL_RE = {
+    "cli": re.compile(r'^cli_url="\$\{RELEASE_BASE\}/(?P<t>[^"]+)"', re.MULTILINE),
+    "mcp": re.compile(r'^mcp_url="\$\{RELEASE_BASE\}/(?P<t>[^"]+)"', re.MULTILINE),
+}
+PS_URL_RE = {
+    "cli": re.compile(r'^\$cliUrl\s*=\s*"\$ReleaseBase/(?P<t>[^"]+)"', re.MULTILINE),
+    "mcp": re.compile(r'^\$mcpUrl\s*=\s*"\$ReleaseBase/(?P<t>[^"]+)"', re.MULTILINE),
+}
+
+
+# Only the variable belonging to THIS kind is substituted, so a cli_url line
+# that mistakenly interpolates ${MCP_BIN} leaves an unresolved "$" and is
+# reported instead of quietly rendering the right-looking name.
+SH_BIN_VAR = {"cli": "${CLI_BIN}", "mcp": "${MCP_BIN}"}
+PS_BIN_VAR = {"cli": "$($CliBin.Replace('.exe',''))",
+              "mcp": "$($McpBin.Replace('.exe',''))"}
+
+
+def _render_sh(template: str, kind: str, binary: str, os_: str, arch: str) -> str:
+    """Render an install.sh URL-tail template for one target."""
+    return (template
+            .replace(SH_BIN_VAR[kind], binary)
+            .replace("${os}", os_)
+            .replace("${arch}", arch))
+
+
+def _render_ps(template: str, kind: str, binary: str, arch: str) -> str:
+    """Render an install.ps1 URL-tail template for one target.
+
+    `$CliBin`/`$McpBin` carry the .exe suffix in PowerShell, and the script
+    strips it with .Replace('.exe','') before appending the target suffix; the
+    `binary` passed here is already the stripped registry name.
+    """
+    return (template
+            .replace(PS_BIN_VAR[kind], binary)
+            .replace("$arch", arch))
+
+
+def install_expected_assets(sh: str, ps: str, cli_bin: str, mcp_bin: str) -> tuple[set[str], list[str]]:
+    """Asset names the installers will fetch, rendered from their own templates.
+
+    Returns (names, problems); a problem is a missing template or one that still
+    has an unresolved variable after substitution.
+    """
+    assets: set[str] = set()
+    problems: list[str] = []
+
+    for kind, binary in (("cli", cli_bin), ("mcp", mcp_bin)):
+        m = SH_URL_RE[kind].search(sh)
+        if not m:
+            problems.append(f"install.sh: no {kind}_url=\"${{RELEASE_BASE}}/...\" line found")
+        else:
+            for os_, arch in SH_TARGETS:
+                name = _render_sh(m.group("t"), kind, binary, os_, arch)
+                if "$" in name:
+                    problems.append(f"install.sh {kind}_url template leaves an unresolved variable: {name!r}")
+                assets.add(name)
+
+        m = PS_URL_RE[kind].search(ps)
+        if not m:
+            problems.append(f"install.ps1: no ${kind}Url = \"$ReleaseBase/...\" line found")
+        else:
+            for _os, arch in PS_TARGETS:
+                name = _render_ps(m.group("t"), kind, binary, arch)
+                if "$" in name:
+                    problems.append(f"install.ps1 ${kind}Url template leaves an unresolved variable: {name!r}")
+                assets.add(name)
+
+    return assets, problems
 
 
 def release_produced_assets(cli_bin: str, mcp_bin: str) -> set[str]:
-    assets = set()
-    for bin_ in (cli_bin, mcp_bin):
-        for t in registry.TARGETS:
-            ext = ".exe" if t["goos"] == "windows" else ""
-            assets.add(f"{bin_}-{t['goos']}-{t['goarch']}{ext}")
-    return assets
+    """Asset names the release will upload - the SAME shared function the build
+    matrix (and therefore release.yml) resolves its upload filenames through."""
+    return {name
+            for per_target in registry.asset_map(cli_bin, mcp_bin).values()
+            for name in per_target.values()}
 
 
 def main() -> int:
@@ -91,7 +163,9 @@ def main() -> int:
                 errors.append(f"{slug}: {label} is {got!r}, expected {want!r} (from skills.json)")
 
         # (2) == (3): the assets installers fetch == the assets release builds.
-        expected = install_expected_assets(reg_cli, reg_mcp)
+        expected, problems = install_expected_assets(sh, ps, reg_cli, reg_mcp)
+        for p in problems:
+            errors.append(f"{slug}: {p}")
         produced = release_produced_assets(reg_cli, reg_mcp)
         missing = expected - produced
         extra = produced - expected

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -29,6 +29,43 @@ TARGETS = [
 ]
 
 
+def target_key(goos: str, goarch: str) -> str:
+    """The stable key naming one build target ("darwin-arm64").
+
+    Used to index the per-target asset map from a GitHub Actions matrix row:
+    `matrix.skill.assets[format('{0}-{1}', matrix.target.goos, matrix.target.goarch)]`.
+    """
+    return f"{goos}-{goarch}"
+
+
+def asset_name(binary: str, goos: str, goarch: str) -> str:
+    """THE one place that turns (binary, goos, goarch) into a release asset filename.
+
+    Every consumer - the release workflow's upload step, the install scripts'
+    download URLs, and the release-contract gate - must resolve names through
+    here (directly, or through the matrix JSON this feeds). Reconstructing the
+    "-<goos>-<goarch>" suffix or the windows ".exe" rule anywhere else is how the
+    workflow silently drifted from the gate that is supposed to police it.
+    """
+    ext = ".exe" if goos == "windows" else ""
+    return f"{binary}-{goos}-{goarch}{ext}"
+
+
+def asset_map(cli_binary: str, mcp_binary: str) -> dict[str, dict[str, str]]:
+    """Literal asset filenames for one skill, keyed by target ("darwin-arm64").
+
+    {"darwin-arm64": {"cli": "halopsa-cli-darwin-arm64",
+                      "mcp": "halopsa-mcp-darwin-arm64"}, ...}
+    """
+    return {
+        target_key(t["goos"], t["goarch"]): {
+            "cli": asset_name(cli_binary, t["goos"], t["goarch"]),
+            "mcp": asset_name(mcp_binary, t["goos"], t["goarch"]),
+        }
+        for t in TARGETS
+    }
+
+
 def load() -> dict:
     return json.loads(REGISTRY.read_text(encoding="utf-8"))
 

--- a/tools/maintainer/release_matrix.py
+++ b/tools/maintainer/release_matrix.py
@@ -24,6 +24,14 @@ Each skill entry carries everything the build step needs:
     name, dir, module, cli_cmd, mcp_cmd, cli_bin, mcp_bin
 cmd paths are introspected, so they are correct whether the source is stripped
 (cmd/<slug>-cli) or not (cmd/<slug>-pp-cli).
+
+The FULL matrix (the release.yml shape, i.e. not --skills-only) additionally
+carries `assets`: the FINAL literal asset filenames per target, keyed
+"<goos>-<goarch>", straight from registry.asset_map(). release.yml reads those
+names instead of re-deriving the "-<goos>-<goarch>" suffix and the windows
+".exe" rule in shell, so the workflow and tools/maintainer/check_release_contract.py
+can no longer disagree about what a release asset is called. --skills-only omits
+`assets` - that shape (ci.yml build+vet) has no target axis to key them by.
 """
 
 from __future__ import annotations
@@ -37,24 +45,28 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import registry  # noqa: E402  (local tools/ module)
 
 
-def skill_entries() -> list[dict]:
+def skill_entries(with_assets: bool = True) -> list[dict]:
     entries = []
     for slug, meta in registry.skills().items():
         # markdown-only skills have no vendored cli/ - nothing to build or release.
         if registry.is_markdown_only(slug):
             continue
         cli_cmd, mcp_cmd = registry.cmd_dirs(slug)
-        entries.append(
-            {
-                "name": slug,
-                "dir": f"skills/{slug}/cli",
-                "module": registry.module_path(slug),
-                "cli_cmd": cli_cmd,
-                "mcp_cmd": mcp_cmd,
-                "cli_bin": meta["cli_binary"],
-                "mcp_bin": meta["mcp_binary"],
-            }
-        )
+        entry = {
+            "name": slug,
+            "dir": f"skills/{slug}/cli",
+            "module": registry.module_path(slug),
+            "cli_cmd": cli_cmd,
+            "mcp_cmd": mcp_cmd,
+            "cli_bin": meta["cli_binary"],
+            "mcp_bin": meta["mcp_binary"],
+        }
+        if with_assets:
+            # Final literal filenames, one entry per registry.TARGETS row. The
+            # release workflow uploads exactly these; nothing downstream rebuilds
+            # the suffix or the .exe rule by hand.
+            entry["assets"] = registry.asset_map(meta["cli_binary"], meta["mcp_binary"])
+        entries.append(entry)
     return entries
 
 
@@ -113,7 +125,7 @@ def main(argv: list[str]) -> int:
     if "--changed-only" in argv:
         base_ref = argv[argv.index("--changed-only") + 1]
 
-    entries = skill_entries()
+    entries = skill_entries(with_assets=not skills_only)
 
     if tag:
         # <slug>-v<semver> -> <slug>; unknown slug -> empty matrix (the


### PR DESCRIPTION
## Rebase note (2026-08-26)

Rebased onto `origin/main` at `d178c5dd8` (the day's 8 merged PRs, the bot
regens, and the #291-merge / #301-revert churn). **Clean rebase, zero
conflicts**: no commit on `main` since the old merge-base `45cf76cfe` touched
any of the five files this branch changes, and `git patch-id --stable` is
unchanged across the rebase (`42fc4541...` before and after), so the diff is
byte-for-byte the same change on a new base.

Because `main` moved (tags deleted and re-pointed by the revert wave, then the
65-tag push), the **entire proof suite below was re-run on the rebased tree**.
Two results changed for the better, both called out inline:

1. `check_pinned_artifacts.py` is **no longer red**. It now exits 0 on this
   branch AND on a clean `main` checkout, with byte-identical output.
2. That gate is now wired into `ci.yml` as a **hard** gate (`e73775e52`), so
   this PR's edit to it is CI-live rather than local-only.

Old head `364c68263` was replaced by `6792f6a3b` via `--force-with-lease`.

---

## What

One source of truth for release asset filenames (plan item 5).

`registry.asset_name()` / `registry.asset_map()` is now the only place the
asset-filename rule lives (`<binary>-<goos>-<goarch>`, plus `.exe` on windows).

| File | Change |
| --- | --- |
| `tools/maintainer/registry.py` | New `target_key()`, `asset_name()`, `asset_map()`. `asset_map()` returns `{"darwin-arm64": {"cli": ..., "mcp": ...}, ...}` for one skill. |
| `tools/maintainer/release_matrix.py` | The FULL matrix (release.yml shape) now carries `assets` per skill: the final literal filenames, keyed `<goos>-<goarch>`. `--skills-only` omits them (that shape has no target axis to key them by). |
| `.github/workflows/release.yml` | The build job reads `CLI_ASSET` / `MCP_ASSET` from the matrix instead of rebuilding `ext` / `suffix` / `cli` / `mcp` in shell, and fails loudly if a target's names are missing. |
| `tools/maintainer/check_release_contract.py` | Release side reads the SAME `registry.asset_map()`. Install side now RENDERS the installers' own URL templates, parsed out of `install.sh` / `install.ps1`, instead of mirroring the naming rule. |
| `tools/maintainer/check_pinned_artifacts.py` | A fourth reconstruction site; now reads `registry.asset_map()` too. Byte-identical output (proof below). |

## Why

`release.yml` and `check_release_contract.py` each reconstructed the filename
rule independently. Nothing tied them together, so a workflow edit could change
what a release actually uploads while the gate that is supposed to police it
kept passing green. The gate's own two sides had the same problem: the "install
expects" set was a hand-written copy of the naming rule, so it could agree with
itself while the shipped `install.sh` said something else.

After this change:

- The release side of the gate and the workflow resolve names through the same
  function, so they cannot disagree.
- The install side reads the real shipped script text, so an installer edit is
  caught rather than silently matching a mirror of itself.

## Proof suite, re-run on the rebased tree

| # | Check | Result |
| --- | --- | --- |
| 1 | Byte-identity vs the OLD `release.yml` shell formula, 3 sample slugs x 6 targets | 18/18 rows identical (36 asset names) |
| 1 | Same comparison fleet-wide, 65 skills x 6 targets | 390 rows / **780 asset names, zero mismatches** |
| 1b | `check_pinned_artifacts.expected_assets` old vs new, fleet-wide | 65 skills, **mismatches: NONE** |
| 1c | Negative control: break `registry.asset_name()`, does the comparison fire | yes, mismatches reported AND contract gate fails |
| 1d | Sites in `tools/` + `.github/` still applying the `.exe` rule | **4 on `main` down to 1** (`registry.py:50`) |
| 2 | `check_release_contract.py` fleet-wide | **pass**, exit 0, 65 skills |
| 3 | `check_pinned_artifacts.py --base origin/main --no-network` | **exit 0 on this branch AND on clean `main`, output byte-identical** |
| 4 | `release_matrix.py --tag halopsa-v0.0.0` | valid JSON, exit 0, 1 skill x 6 targets, `assets` present |
| 4 | `release_matrix.py --skills-only` | valid JSON, exit 0, 65 skills, **byte-identical to `origin/main`** |
| 5 | `bash tools/maintainer/ci_guards.sh` | **all 6 guards pass**, exit 0 |
| extra | `actionlint .github/workflows/release.yml` | exit 0 |
| extra | `check_vocabulary.py`, `check_no_todos.py` | exit 0 |
| extra | `git status` on the worktree after every negative control | clean |
| CI | All checks on the rebased head `6792f6a3b`, settled | **68 pass, 1 fail** |
| CI | `prepare`, `guards`, all 65 `build (...)` jobs, CodeRabbit | **pass** (`guards` runs the hard `check_pinned_artifacts` gate this PR edits) |
| CI | `security-gate` | **the 1 fail, by design**, see below |

### (1) Byte-identical to the old `release.yml` string-construction

The "old" column runs the literal shell from `origin/main`
(`.github/workflows/release.yml` lines 191-195: `ext=""` /
`[ "$GOOS" = "windows" ] && ext=".exe"` / `suffix="${GOOS}-${GOARCH}${ext}"` /
`cli="<cli_bin>-${suffix}"` / `mcp="<mcp_bin>-${suffix}"`) in bash, fed
`cli_bin` / `mcp_bin` read from **`origin/main`'s own** `release_matrix.py` in a
separate checkout, so neither side borrows the other's code. The "new" column
reads `assets` out of the branch's `release_matrix.py --tag <slug>-v0.0.0`,
exactly as the workflow now does.

| slug | target | old release.yml (shell) | shared registry.asset_map() | identical |
| --- | --- | --- | --- | --- |
| halopsa | darwin-arm64 | `halopsa-cli-darwin-arm64` + `halopsa-mcp-darwin-arm64` | `halopsa-cli-darwin-arm64` + `halopsa-mcp-darwin-arm64` | yes |
| halopsa | darwin-amd64 | `halopsa-cli-darwin-amd64` + `halopsa-mcp-darwin-amd64` | `halopsa-cli-darwin-amd64` + `halopsa-mcp-darwin-amd64` | yes |
| halopsa | linux-arm64 | `halopsa-cli-linux-arm64` + `halopsa-mcp-linux-arm64` | `halopsa-cli-linux-arm64` + `halopsa-mcp-linux-arm64` | yes |
| halopsa | linux-amd64 | `halopsa-cli-linux-amd64` + `halopsa-mcp-linux-amd64` | `halopsa-cli-linux-amd64` + `halopsa-mcp-linux-amd64` | yes |
| halopsa | windows-amd64 | `halopsa-cli-windows-amd64.exe` + `halopsa-mcp-windows-amd64.exe` | `halopsa-cli-windows-amd64.exe` + `halopsa-mcp-windows-amd64.exe` | yes |
| halopsa | windows-arm64 | `halopsa-cli-windows-arm64.exe` + `halopsa-mcp-windows-arm64.exe` | `halopsa-cli-windows-arm64.exe` + `halopsa-mcp-windows-arm64.exe` | yes |
| ninjaone | darwin-arm64 | `ninjaone-cli-darwin-arm64` + `ninjaone-mcp-darwin-arm64` | `ninjaone-cli-darwin-arm64` + `ninjaone-mcp-darwin-arm64` | yes |
| ninjaone | darwin-amd64 | `ninjaone-cli-darwin-amd64` + `ninjaone-mcp-darwin-amd64` | `ninjaone-cli-darwin-amd64` + `ninjaone-mcp-darwin-amd64` | yes |
| ninjaone | linux-arm64 | `ninjaone-cli-linux-arm64` + `ninjaone-mcp-linux-arm64` | `ninjaone-cli-linux-arm64` + `ninjaone-mcp-linux-arm64` | yes |
| ninjaone | linux-amd64 | `ninjaone-cli-linux-amd64` + `ninjaone-mcp-linux-amd64` | `ninjaone-cli-linux-amd64` + `ninjaone-mcp-linux-amd64` | yes |
| ninjaone | windows-amd64 | `ninjaone-cli-windows-amd64.exe` + `ninjaone-mcp-windows-amd64.exe` | `ninjaone-cli-windows-amd64.exe` + `ninjaone-mcp-windows-amd64.exe` | yes |
| ninjaone | windows-arm64 | `ninjaone-cli-windows-arm64.exe` + `ninjaone-mcp-windows-arm64.exe` | `ninjaone-cli-windows-arm64.exe` + `ninjaone-mcp-windows-arm64.exe` | yes |
| connectwise-control | darwin-arm64 | `connectwise-control-cli-darwin-arm64` + `connectwise-control-mcp-darwin-arm64` | `connectwise-control-cli-darwin-arm64` + `connectwise-control-mcp-darwin-arm64` | yes |
| connectwise-control | darwin-amd64 | `connectwise-control-cli-darwin-amd64` + `connectwise-control-mcp-darwin-amd64` | `connectwise-control-cli-darwin-amd64` + `connectwise-control-mcp-darwin-amd64` | yes |
| connectwise-control | linux-arm64 | `connectwise-control-cli-linux-arm64` + `connectwise-control-mcp-linux-arm64` | `connectwise-control-cli-linux-arm64` + `connectwise-control-mcp-linux-arm64` | yes |
| connectwise-control | linux-amd64 | `connectwise-control-cli-linux-amd64` + `connectwise-control-mcp-linux-amd64` | `connectwise-control-cli-linux-amd64` + `connectwise-control-mcp-linux-amd64` | yes |
| connectwise-control | windows-amd64 | `connectwise-control-cli-windows-amd64.exe` + `connectwise-control-mcp-windows-amd64.exe` | `connectwise-control-cli-windows-amd64.exe` + `connectwise-control-mcp-windows-amd64.exe` | yes |
| connectwise-control | windows-arm64 | `connectwise-control-cli-windows-arm64.exe` + `connectwise-control-mcp-windows-arm64.exe` | `connectwise-control-cli-windows-arm64.exe` + `connectwise-control-mcp-windows-arm64.exe` | yes |

Fleet-wide, same comparison:

```
skills: 65 | old rows: 390 | new rows: 390 | asset names compared: 780
RESULT: byte-identical, zero mismatches
```

And `check_pinned_artifacts.expected_assets` is unchanged fleet-wide, comparing
the branch module against the `origin/main` module in one process:

```
check_pinned_artifacts.expected_assets: checked 65 skills; mismatches: NONE
```

### (1c) The comparison fires when the shared function is wrong

A green comparison only means something if the red case is reachable. Removing
the windows `.exe` rule from `registry.asset_name()` (negative control, then
reverted) breaks BOTH the byte-identity comparison and the contract gate:

```
-afi	windows-amd64	afi-cli-windows-amd64.exe	afi-mcp-windows-amd64.exe
+afi	windows-amd64	afi-cli-windows-amd64	afi-mcp-windows-amd64
...
Release contract check FAILED:
  - abnormal: installers request assets the release won't produce: ['abnormal-cli-windows-amd64.exe', ...]
  - abnormal: release produces assets no installer fetches: ['abnormal-cli-windows-amd64', ...]
```

### (1d) One-source-of-truth receipt: the rule now exists in exactly one place

Grepping `tools/` and `.github/` for anything that applies the windows `.exe`
rule, before and after:

```
origin/main (4 rule-application sites, all independent):
  tools/maintainer/check_pinned_artifacts.py:322   ext = ".exe" if t["goos"] == "windows" else ""
  tools/maintainer/check_release_contract.py:51    assets.add(f"{bin_}-{os_}-{arch}.exe")      # the "install expects" mirror
  tools/maintainer/check_release_contract.py:59    ext = ".exe" if t["goos"] == "windows" else ""
  .github/workflows/release.yml:192                [ "$GOOS" = "windows" ] && ext=".exe"

this branch (1):
  tools/maintainer/registry.py:50                  ext = ".exe" if goos == "windows" else ""
```

Honest remaining site, out of scope: `.github/workflows/mcp-publish.yml:109`
still hardcodes a suffix list. That one is a **deliberate 5-of-6 subset**
(windows/arm64 has no MCPB host, guarded by `EXPECTED_BINARIES: "5"`), so it
cannot simply consume `asset_map()` wholesale. It is unchanged by this PR and
is called out here rather than left implied.

### (2) `check_release_contract.py` passes fleet-wide, and fails on a broken installer

```
$ python3 tools/maintainer/check_release_contract.py
Release contract check passed for 65 skill(s): install scripts and release assets agree.
(exit 0)
```

Negative control A, changing `skills/halopsa/install.sh`'s `cli_url` separator
from `-` to `_`:

```
Release contract check FAILED:
  - halopsa: installers request assets the release won't produce: ['halopsa-cli_darwin_amd64', 'halopsa-cli_darwin_arm64', ...]
  - halopsa: release produces assets no installer fetches: ['halopsa-cli-darwin-amd64', 'halopsa-cli-darwin-arm64', ...]
(exit 1)
```

Negative control B, swapping `$CliBin` for `$McpBin` in
`skills/halopsa/install.ps1`'s `$cliUrl`, a name that would still LOOK
well-formed, is caught by the per-kind variable substitution:

```
Release contract check FAILED:
  - halopsa: install.ps1 $cliUrl template leaves an unresolved variable: "$($McpBin.Replace('.exe',''))-windows-amd64.exe"
  - halopsa: install.ps1 $cliUrl template leaves an unresolved variable: "$($McpBin.Replace('.exe',''))-windows-arm64.exe"
(exit 1)
```

All three negative controls were reverted; `git status --porcelain` is empty
after each, and the gate returns green again.

### (3) `check_pinned_artifacts.py` is now GREEN, on this branch and on `main`

This changed since the original proof. The revert wave plus #302 repointed the
README download links, and `e73775e52` promoted the gate to a hard CI gate.

```
$ python3 tools/maintainer/check_pinned_artifacts.py --base origin/main --no-network
check_pinned_artifacts: OK (192 pinned release URLs across 128 files resolve to a cut tag or an in-flight release)
(exit 0)
```

Run on a clean `origin/main` checkout, the output is **byte-identical** (`diff`
empty, exit 0 both sides), including the four non-fatal NOTE lines for
afi / atera / levelio / ninjaone catalog stamps. So this PR does not change the
gate's verdict in either direction; it only changes where the names come from.

### (4) `release_matrix.py` output

```
$ python3 tools/maintainer/release_matrix.py --tag halopsa-v0.0.0
{
  "skill": [
    {
      "name": "halopsa",
      "dir": "skills/halopsa/cli",
      "module": "halopsa-pp-cli",
      "cli_cmd": "./cmd/halopsa-cli",
      "mcp_cmd": "./cmd/halopsa-mcp",
      "cli_bin": "halopsa-cli",
      "mcp_bin": "halopsa-mcp",
      "assets": {
        "darwin-arm64":  {"cli": "halopsa-cli-darwin-arm64",      "mcp": "halopsa-mcp-darwin-arm64"},
        "darwin-amd64":  {"cli": "halopsa-cli-darwin-amd64",      "mcp": "halopsa-mcp-darwin-amd64"},
        "linux-arm64":   {"cli": "halopsa-cli-linux-arm64",       "mcp": "halopsa-mcp-linux-arm64"},
        "linux-amd64":   {"cli": "halopsa-cli-linux-amd64",       "mcp": "halopsa-mcp-linux-amd64"},
        "windows-amd64": {"cli": "halopsa-cli-windows-amd64.exe", "mcp": "halopsa-mcp-windows-amd64.exe"},
        "windows-arm64": {"cli": "halopsa-cli-windows-arm64.exe", "mcp": "halopsa-mcp-windows-arm64.exe"}
      }
    }
  ],
  "target": [ ...the 6 registry.TARGETS rows, unchanged... ]
}
```

(re-indented for readability; the real output is one line of compact JSON)

`--skills-only` is BYTE-IDENTICAL to `origin/main`, so `ci.yml` is unaffected:

```
$ cmp <(main --skills-only) <(branch --skills-only)
(no output, exit 0)
skills: 65 | target axis present: False | assets present: False
```

Two more `release_matrix.py` paths were exercised, since `main` moved:

- `--skills-only --changed-only origin/main`: exit 0. It returns the FULL 65
  and prints `release_matrix: machinery changed (.github/workflows/release.yml);
  FULL matrix`. That is the pre-existing machinery escape hatch reacting to this
  PR's own workflow edit, not new behavior: the diff touches only context lines
  around `--changed-only`, none of its logic.
- `--tag nosuchskill-v0.0.0`: exit 0, `{"skill": [], "target": [...6 rows...]}`,
  so an unknown tag still yields an empty build set rather than an error.

`actionlint .github/workflows/release.yml` exits 0, which validates the
`matrix.skill.assets[format('{0}-{1}', matrix.target.goos, matrix.target.goarch)]`
expression syntax as well as the YAML. `release.yml` always calls
`release_matrix.py --tag "$TAG"`, so the matrix payload is one skill: 1008 bytes
for `halopsa`, 1255 bytes for the longest slug (`connectwise-automate`), far
under any matrix size limit.

### (5) Repo guards

```
$ bash tools/maintainer/ci_guards.sh
==> 1. No unresolved owner placeholder token anywhere
==> 2. No em-dash in human-authored files
==> 3. No personal filesystem paths in human-authored files
==> 4. No obvious hardcoded secrets in human-authored files
==> 5. No real production-tenant transaction counts in human-authored files
==> 6. No connector selects a Go toolchain below the fleet floor
All CI guards passed.
(exit 0)
```

`check_vocabulary.py` and `check_no_todos.py` also exit 0.

## Expected red check: `security-gate`

`.github/workflows/security-gate.yml` (lines 35-45) hard-fails on a changed-path
match before the gate script ever runs:

```
if printf '%s\n' "$changed" | grep -qE '^(tools/maintainer/check_security_gate\.py|\.semgrep\.yml|\.github/workflows/security-gate\.yml|\.github/workflows/release\.yml|\.github/CODEOWNERS)$'; then
  echo "::error::This PR modifies the security-gate LOGIC. That cannot be self-approved ..."
  exit 1
fi
```

On the rebased head this is exactly what happened: `security-gate` failed in 14
seconds in the `Scope - what did this PR change?` step, with
`##[error]This PR modifies the security-gate LOGIC...`, before the gate script
ran. It is the only red check; the other 68 are green.

`.github/workflows/release.yml` is in that set. The check is **categorical**: it
matches on the changed-path list only, with no author, actor, or label
condition, so **any** PR touching `release.yml` fails `security-gate` regardless
of who opens it. This PR will therefore show `security-gate` red. That is the
designed behavior, not a defect in this change, and no attempt was made to work
around it.

Compliance with the rest of the rule: this PR touches **nothing** in the
security-policy file set, not `check_security_gate.py`, not
`dep_allowlist.json`, not `security_suppressions.json`, not `.semgrep.yml`, not
`security-gate.yml`, not `CODEOWNERS`. `release.yml` is the only path in the
hard-fail list this PR touches. Resolution is a maintainer override decision.

## Deferred

- **`check_release_contract.py` is still not wired into `ci.yml`.** The
  guards-job wiring lands as a follow-up PR; `release/p0-mcp-filesystem` is
  still an open branch that owns `ci.yml` edits. Until then that gate is
  local-run only. Note that `check_pinned_artifacts.py`, which this PR also
  touches, IS wired into `ci.yml` as a hard gate and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
