### PR TITLE
fix(liongard): compose the ROAR key pair; fix Basic-auth credential-precedence tests (wordpress, resourceguru)

### DIFF
--- a/skills/liongard/CHANGELOG.md
+++ b/skills/liongard/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- **`LIONGARD_ACCESS_KEY_ID` and `LIONGARD_ACCESS_KEY_SECRET` were ignored, so every call went out
+  unauthenticated.** Liongard hands you an Access Key ID and an Access Key Secret and never shows
+  the encoded form the API actually wants, and the README, the SKILL and the guide all tell you to
+  export those two variables. The config loader read neither: it only ever looked for a
+  pre-encoded `LIONGARD_API_KEY`, so an operator who followed the shipped instructions got an empty
+  `X-ROAR-API-KEY` header and a 401 on every command, with nothing in `doctor` naming the cause.
+  The loader composes the pair into base64 of `accessKeyId:accessKeySecret` again, as it did when
+  the connector first shipped; a pre-encoded `LIONGARD_API_KEY` still wins when both are set.
+  Both variables are now declared on all three install channels, so Claude Desktop asks for them
+  and the copy-paste MCP config blocks carry them.
+
 ## [0.1.1] - 2026-08-26
 
 ### Fixed

--- a/skills/liongard/CHANGELOG.md
+++ b/skills/liongard/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable changes to this skill are documented here. Format follows
   The loader composes the pair into base64 of `accessKeyId:accessKeySecret` again, as it did when
   the connector first shipped; a pre-encoded `LIONGARD_API_KEY` still wins when both are set.
   Both variables are now declared on all three install channels, so Claude Desktop asks for them
-  and the copy-paste MCP config blocks carry them.
+  and the copy-paste MCP config blocks carry them. `LIONGARD_API_KEY` is no longer marked required
+  in `manifest.json` or `server.json` either: while it was, the MCPB bundle and the registry
+  install both forced a value into it, and because the pre-encoded key wins the ID/secret pair
+  stayed dead through every official install no matter what the docs said. All three fields now
+  state the one-of contract - set the key or set the pair, never both - and the install pages show
+  the two setups separately instead of one line that sets all three at once.
 
 ## [0.1.1] - 2026-08-26
 

--- a/skills/liongard/README.md
+++ b/skills/liongard/README.md
@@ -145,9 +145,17 @@ LIONGARD_INSTANCE=<your-subdomain> LIONGARD_API_KEY=<value> liongard-cli doctor
   CLI falls back to the placeholder `example.app.liongard.com`, which will not reach
   your data, so always set it. (Advanced: set `LIONGARD_BASE_URL` instead to point
   at a full custom URL.)
-- **`LIONGARD_API_KEY`** (required) is your base64 X-ROAR-API-KEY. Prefer to keep
-  the parts separate? Set `LIONGARD_ACCESS_KEY_ID` and `LIONGARD_ACCESS_KEY_SECRET`
-  and the CLI composes the header for you.
+- **The credential** (required) comes in one of two shapes, and you set exactly one
+  of them. Either `LIONGARD_API_KEY`, your pre-encoded base64 X-ROAR-API-KEY (the
+  line above), or the pair `LIONGARD_ACCESS_KEY_ID` + `LIONGARD_ACCESS_KEY_SECRET`,
+  the two strings Liongard hands you, which the CLI encodes for you:
+
+  ```bash
+  LIONGARD_INSTANCE=<your-subdomain> LIONGARD_ACCESS_KEY_ID=<value> LIONGARD_ACCESS_KEY_SECRET=<value> liongard-cli doctor
+  ```
+
+  Do not set both shapes: `LIONGARD_API_KEY` wins whenever it is non-empty and the
+  ID/secret pair is ignored.
 - **`LIONGARD_ENDPOINTS_API_KEY`** (optional) is only needed for the Liongard
   Endpoints API surface; leave it unset if you do not use it.
 

--- a/skills/liongard/SKILL.md
+++ b/skills/liongard/SKILL.md
@@ -293,7 +293,7 @@ Every system whose patch age crosses the threshold, across all clients.
 
 ## Auth Setup
 
-Liongard issues an Access Key ID and an Access Key Secret per user. The CLI sends them as the X-ROAR-API-KEY header (base64 of `accessKeyId:accessKeySecret`). Set LIONGARD_INSTANCE (your subdomain, e.g. us1), LIONGARD_ACCESS_KEY_ID, and LIONGARD_ACCESS_KEY_SECRET; or set a pre-encoded LIONGARD_API_KEY directly. Run `doctor` to confirm the host and credentials resolve.
+Liongard issues an Access Key ID and an Access Key Secret per user. The CLI sends them as the X-ROAR-API-KEY header (base64 of `accessKeyId:accessKeySecret`). Set LIONGARD_INSTANCE (your subdomain, e.g. us1), LIONGARD_ACCESS_KEY_ID, and LIONGARD_ACCESS_KEY_SECRET; or set a pre-encoded LIONGARD_API_KEY directly. Set one shape or the other, never both: LIONGARD_API_KEY wins whenever it is non-empty and the ID/secret pair is ignored. Run `doctor` to confirm the host and credentials resolve.
 
 Run `liongard-cli doctor` to verify setup.
 

--- a/skills/liongard/cli/internal/config/config.go
+++ b/skills/liongard/cli/internal/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,11 +61,24 @@ func Load(configPath string) (*Config, error) {
 
 	cfg.snapshotFileConfig()
 
-	// Env var overrides
+	// Env var overrides. Liongard's X-ROAR-API-KEY header is the base64 encoding
+	// of "accessKeyId:accessKeySecret". Accept either a pre-encoded value via
+	// LIONGARD_API_KEY (wins), or the two natural credential values via
+	// LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET (composed here).
+	// Liongard hands operators the ID and the secret as separate strings and
+	// never shows the encoded form, so the composed pair is the credential
+	// shape real users actually have; README, SKILL.md, guide.md and
+	// server.json all document it. Dropping this branch (a full reprint
+	// regenerates the single-env-var template) leaves every operator who
+	// followed those docs with an empty X-ROAR-API-KEY and a 401 on every call.
 	if v := os.Getenv("LIONGARD_API_KEY"); v != "" {
 		cfg.LiongardApiKey = v
 		cfg.markEnvOverride("LiongardApiKey")
 		cfg.AuthSource = "env:LIONGARD_API_KEY"
+	} else if id, secret := strings.TrimSpace(os.Getenv("LIONGARD_ACCESS_KEY_ID")), strings.TrimSpace(os.Getenv("LIONGARD_ACCESS_KEY_SECRET")); id != "" && secret != "" {
+		cfg.LiongardApiKey = base64.StdEncoding.EncodeToString([]byte(id + ":" + secret))
+		cfg.markEnvOverride("LiongardApiKey")
+		cfg.AuthSource = "env:LIONGARD_ACCESS_KEY_ID+SECRET"
 	}
 
 	// Label config-file-derived credentials so doctor can distinguish

--- a/skills/liongard/guide.md
+++ b/skills/liongard/guide.md
@@ -121,7 +121,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ## Authentication
 
-Liongard issues an Access Key ID and an Access Key Secret per user. The CLI sends them as the X-ROAR-API-KEY header (base64 of `accessKeyId:accessKeySecret`). Set LIONGARD_INSTANCE (your subdomain, e.g. us1), LIONGARD_ACCESS_KEY_ID, and LIONGARD_ACCESS_KEY_SECRET; or set a pre-encoded LIONGARD_API_KEY directly. Run `doctor` to confirm the host and credentials resolve.
+Liongard issues an Access Key ID and an Access Key Secret per user. The CLI sends them as the X-ROAR-API-KEY header (base64 of `accessKeyId:accessKeySecret`). Set LIONGARD_INSTANCE (your subdomain, e.g. us1), LIONGARD_ACCESS_KEY_ID, and LIONGARD_ACCESS_KEY_SECRET; or set a pre-encoded LIONGARD_API_KEY directly. Set one shape or the other, never both: LIONGARD_API_KEY wins whenever it is non-empty and the ID/secret pair is ignored. Run `doctor` to confirm the host and credentials resolve.
 
 ## Quick Start
 
@@ -494,6 +494,6 @@ If you use agentcookie to sync secrets across machines, this CLI auto-adopts age
 
 ### API-specific
 - **doctor reports the host cannot be resolved**  -  Set LIONGARD_INSTANCE to your subdomain only (e.g. us1), not the full URL; the base becomes https://us1.app.liongard.com/api/v1.
-- **401 Unauthorized on every call**  -  The X-ROAR-API-KEY must be base64 of accessKeyId:accessKeySecret. Set LIONGARD_ACCESS_KEY_ID and LIONGARD_ACCESS_KEY_SECRET and let the CLI encode them, or set a correctly pre-encoded LIONGARD_API_KEY.
+- **401 Unauthorized on every call**  -  The X-ROAR-API-KEY must be base64 of accessKeyId:accessKeySecret. Set LIONGARD_ACCESS_KEY_ID and LIONGARD_ACCESS_KEY_SECRET and let the CLI encode them, or set a correctly pre-encoded LIONGARD_API_KEY - one or the other, never both. A leftover LIONGARD_API_KEY (even a placeholder) wins over the pair, which is the usual cause of a 401 when the ID and secret look right.
 - **drift or stale commands return nothing**  -  Run `sync --full` first; the cross-estate joins read the local store, not the live API.
 - **list commands return a Data wrapper you do not want**  -  The CLI already unwraps the {Data,Pagination,Success} envelope; use --select to project just the fields you need.

--- a/skills/liongard/handfixes.json
+++ b/skills/liongard/handfixes.json
@@ -165,6 +165,61 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "composed-roar-auth-from-id-and-secret",
+   "summary": "config.Load composes LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET into the base64 X-ROAR-API-KEY value when LIONGARD_API_KEY is unset",
+   "why": "Liongard hands an operator two separate strings - an Access Key ID and an Access Key Secret - and never shows the encoded form. The wire header X-ROAR-API-KEY is base64(\"accessKeyId:accessKeySecret\"), so the CLI has to compose it. README.md, SKILL.md, guide.md and server.json all instruct operators to export the two variables. The press template emits a single-env-var loader (one variable per config field) and has no notion of a composed credential, so a reprint or a fleet re-vendor regenerates config.go and drops the composed branch: the 4.24.0 fleet re-vendor (fc7720092) did exactly that, and from then on every operator who followed the shipped docs got an empty auth header and a 401 on every call while the connector's own hand-added test (config_liongard_auth_test.go) failed in CI. The branch is inline in a DO-NOT-EDIT generated file, so this ledger entry is the only thing that makes the next drop loud. Same class as the levelio x-auth-env-vars regression and gradient's composed GRADIENT-TOKEN pair (which survives reprints only because it lives in a novel file).",
+   "status": "active",
+   "spec_encode_followup": "Teach the press composed-credential auth (N env vars -> one derived header value) so the loader is generated, not hand-wired. Until then this recurs on every reprint.",
+   "asserts": [
+    {
+     "file": "cli/internal/config/config.go",
+     "contains": "LIONGARD_ACCESS_KEY_SECRET"
+    },
+    {
+     "file": "cli/internal/config/config.go",
+     "contains": "base64.StdEncoding.EncodeToString([]byte(id + \":\" + secret))"
+    },
+    {
+     "file": "cli/internal/config/config.go",
+     "contains": "env:LIONGARD_ACCESS_KEY_ID+SECRET"
+    },
+    {
+     "file": "cli/internal/config/config_liongard_auth_test.go",
+     "contains": "TestLoad_ComposedRoarAuth"
+    },
+    {
+     "file": "manifest.json",
+     "contains": "\"LIONGARD_ACCESS_KEY_ID\": \"${user_config.liongard_access_key_id}\"",
+     "min_count": 1
+    },
+    {
+     "file": "manifest.json",
+     "contains": "\"LIONGARD_ACCESS_KEY_SECRET\": \"${user_config.liongard_access_key_secret}\"",
+     "min_count": 1
+    },
+    {
+     "file": "server.json",
+     "contains": "\"name\": \"LIONGARD_ACCESS_KEY_ID\"",
+     "min_count": 1
+    },
+    {
+     "file": "server.json",
+     "contains": "\"name\": \"LIONGARD_ACCESS_KEY_SECRET\"",
+     "min_count": 1
+    },
+    {
+     "file": "mcp-install.md",
+     "contains": "\"LIONGARD_ACCESS_KEY_ID\":",
+     "min_count": 3
+    },
+    {
+     "file": "mcp-install.md",
+     "contains": "\"LIONGARD_ACCESS_KEY_SECRET\":",
+     "min_count": 3
+    }
+   ]
   }
  ]
 }

--- a/skills/liongard/manifest.json
+++ b/skills/liongard/manifest.json
@@ -15,6 +15,8 @@
       "command": "${__dirname}/bin/liongard-mcp",
       "args": [],
       "env": {
+        "LIONGARD_ACCESS_KEY_ID": "${user_config.liongard_access_key_id}",
+        "LIONGARD_ACCESS_KEY_SECRET": "${user_config.liongard_access_key_secret}",
         "LIONGARD_API_KEY": "${user_config.liongard_api_key}",
         "LIONGARD_BASE_URL": "${user_config.liongard_base_url}",
         "LIONGARD_INSTANCE": "${user_config.liongard_instance}"
@@ -40,6 +42,20 @@
       "type": "string",
       "title": "Liongard API base URL",
       "description": "Full API base URL. Leave blank: the CLI builds it from LIONGARD_INSTANCE. Set it only to point at a different host.",
+      "required": false
+    },
+    "liongard_access_key_id": {
+      "type": "string",
+      "title": "Liongard Access Key ID",
+      "description": "Liongard Access Key ID. Set it with LIONGARD_ACCESS_KEY_SECRET as an alternative to LIONGARD_API_KEY: the server composes the two into the base64 X-ROAR-API-KEY value. Leave blank if you already have the pre-encoded key.",
+      "sensitive": true,
+      "required": false
+    },
+    "liongard_access_key_secret": {
+      "type": "string",
+      "title": "Liongard Access Key Secret",
+      "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. Leave blank if you set the pre-encoded LIONGARD_API_KEY instead.",
+      "sensitive": true,
       "required": false
     }
   },

--- a/skills/liongard/manifest.json
+++ b/skills/liongard/manifest.json
@@ -27,9 +27,9 @@
     "liongard_api_key": {
       "type": "string",
       "title": "LIONGARD_API_KEY",
-      "description": "Sets LIONGARD_API_KEY for the Liongard MCP server.",
+      "description": "Pre-encoded X-ROAR-API-KEY: base64 of 'accessKeyId:accessKeySecret'. One of two ways to authenticate - set EITHER this key OR the LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET pair, never both. This key wins when it is set, and the pair is ignored.",
       "sensitive": true,
-      "required": true
+      "required": false
     },
     "liongard_instance": {
       "type": "string",
@@ -47,14 +47,14 @@
     "liongard_access_key_id": {
       "type": "string",
       "title": "Liongard Access Key ID",
-      "description": "Liongard Access Key ID. Set it with LIONGARD_ACCESS_KEY_SECRET as an alternative to LIONGARD_API_KEY: the server composes the two into the base64 X-ROAR-API-KEY value. Leave blank if you already have the pre-encoded key.",
+      "description": "Liongard Access Key ID, the half that pairs with LIONGARD_ACCESS_KEY_SECRET; the server composes the two into the base64 X-ROAR-API-KEY. One of two ways to authenticate - set EITHER this pair OR the pre-encoded LIONGARD_API_KEY, never both. LIONGARD_API_KEY wins when it is set, so leave it blank to use this pair.",
       "sensitive": true,
       "required": false
     },
     "liongard_access_key_secret": {
       "type": "string",
       "title": "Liongard Access Key Secret",
-      "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. Leave blank if you set the pre-encoded LIONGARD_API_KEY instead.",
+      "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. One of two ways to authenticate - set EITHER this pair OR the pre-encoded LIONGARD_API_KEY, never both. LIONGARD_API_KEY wins when it is set, so leave it blank to use this pair.",
       "sensitive": true,
       "required": false
     }

--- a/skills/liongard/mcp-install.md
+++ b/skills/liongard/mcp-install.md
@@ -18,6 +18,24 @@ and `liongard-mcp` on your PATH. `liongard-mcp` is what the agents talk to.
 liongard-mcp --help
 ```
 
+## Two ways to authenticate
+
+Liongard's `X-ROAR-API-KEY` header is base64 of `accessKeyId:accessKeySecret`. Supply
+it **either** way, never both:
+
+- **A - pre-encoded key.** Set `LIONGARD_API_KEY` to the base64 value and leave
+  `LIONGARD_ACCESS_KEY_ID` / `LIONGARD_ACCESS_KEY_SECRET` empty.
+- **B - ID + secret.** Set `LIONGARD_ACCESS_KEY_ID` and `LIONGARD_ACCESS_KEY_SECRET`
+  to the two strings Liongard hands you and leave `LIONGARD_API_KEY` empty; the server
+  encodes them for you.
+
+`LIONGARD_API_KEY` **wins whenever it is non-empty** - including when it still holds a
+placeholder like `<your-liongard_api_key>`. If you are using shape B, clear that field
+in the config blocks below or the ID/secret pair is ignored and every call returns 401.
+
+Every config block below lists all five variables so you can see the full shape. Fill
+in the ones for your chosen shape and leave the others as empty strings.
+
 ---
 
 # Local agents (launch the binary directly)
@@ -112,8 +130,16 @@ web** is remote-only - see the remote section below.)
 All remote agents need `liongard-mcp` reachable as a public **HTTPS** endpoint. Run it
 in HTTP mode with your credentials in the environment:
 
+Pick **one** of the two credential shapes (see [Two ways to authenticate](#two-ways-to-authenticate)):
+
 ```bash
-LIONGARD_ACCESS_KEY_ID=<value> LIONGARD_ACCESS_KEY_SECRET=<value> LIONGARD_API_KEY=<value> LIONGARD_BASE_URL=<value> LIONGARD_INSTANCE=<value> liongard-mcp --transport http --addr :7777
+# A - pre-encoded key. Leave the ID/secret pair unset.
+LIONGARD_API_KEY=<value> LIONGARD_BASE_URL=<value> LIONGARD_INSTANCE=<value> liongard-mcp --transport http --addr :7777
+```
+
+```bash
+# B - ID + secret. Leave LIONGARD_API_KEY unset, or it wins and this pair is ignored.
+LIONGARD_ACCESS_KEY_ID=<value> LIONGARD_ACCESS_KEY_SECRET=<value> LIONGARD_BASE_URL=<value> LIONGARD_INSTANCE=<value> liongard-mcp --transport http --addr :7777
 ```
 
 Then expose `http://localhost:7777` as a public HTTPS URL via a secure tunnel

--- a/skills/liongard/mcp-install.md
+++ b/skills/liongard/mcp-install.md
@@ -37,6 +37,8 @@ Add (or merge with your existing `mcpServers` block):
     "liongard": {
       "command": "liongard-mcp",
       "env": {
+        "LIONGARD_ACCESS_KEY_ID": "",
+        "LIONGARD_ACCESS_KEY_SECRET": "",
         "LIONGARD_API_KEY": "<your-liongard_api_key>",
         "LIONGARD_BASE_URL": "",
         "LIONGARD_INSTANCE": "<your-liongard_instance>"
@@ -64,6 +66,8 @@ Configuration**) and add:
       "type": "stdio",
       "command": "liongard-mcp",
       "env": {
+        "LIONGARD_ACCESS_KEY_ID": "",
+        "LIONGARD_ACCESS_KEY_SECRET": "",
         "LIONGARD_API_KEY": "<your-liongard_api_key>",
         "LIONGARD_BASE_URL": "",
         "LIONGARD_INSTANCE": "<your-liongard_instance>"
@@ -87,6 +91,8 @@ Claude Desktop:
     "liongard": {
       "command": "liongard-mcp",
       "env": {
+        "LIONGARD_ACCESS_KEY_ID": "",
+        "LIONGARD_ACCESS_KEY_SECRET": "",
         "LIONGARD_API_KEY": "<your-liongard_api_key>",
         "LIONGARD_BASE_URL": "",
         "LIONGARD_INSTANCE": "<your-liongard_instance>"
@@ -107,7 +113,7 @@ All remote agents need `liongard-mcp` reachable as a public **HTTPS** endpoint. 
 in HTTP mode with your credentials in the environment:
 
 ```bash
-LIONGARD_API_KEY=<value> LIONGARD_BASE_URL=<value> LIONGARD_INSTANCE=<value> liongard-mcp --transport http --addr :7777
+LIONGARD_ACCESS_KEY_ID=<value> LIONGARD_ACCESS_KEY_SECRET=<value> LIONGARD_API_KEY=<value> LIONGARD_BASE_URL=<value> LIONGARD_INSTANCE=<value> liongard-mcp --transport http --addr :7777
 ```
 
 Then expose `http://localhost:7777` as a public HTTPS URL via a secure tunnel

--- a/skills/liongard/server.json
+++ b/skills/liongard/server.json
@@ -29,6 +29,18 @@
       },
       "environmentVariables": [
         {
+          "name": "LIONGARD_ACCESS_KEY_ID",
+          "description": "Liongard Access Key ID. Set it with LIONGARD_ACCESS_KEY_SECRET as an alternative to LIONGARD_API_KEY: the server composes the two into the base64 X-ROAR-API-KEY value. Leave blank if you already have the pre-encoded key.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "LIONGARD_ACCESS_KEY_SECRET",
+          "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. Leave blank if you set the pre-encoded LIONGARD_API_KEY instead.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
           "name": "LIONGARD_API_KEY",
           "description": "Base64 X-ROAR-API-KEY for the Liongard API (or use LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET).",
           "isRequired": true,

--- a/skills/liongard/server.json
+++ b/skills/liongard/server.json
@@ -30,20 +30,20 @@
       "environmentVariables": [
         {
           "name": "LIONGARD_ACCESS_KEY_ID",
-          "description": "Liongard Access Key ID. Set it with LIONGARD_ACCESS_KEY_SECRET as an alternative to LIONGARD_API_KEY: the server composes the two into the base64 X-ROAR-API-KEY value. Leave blank if you already have the pre-encoded key.",
+          "description": "Liongard Access Key ID, the half that pairs with LIONGARD_ACCESS_KEY_SECRET; the server composes the two into the base64 X-ROAR-API-KEY. One of two ways to authenticate - set EITHER this pair OR the pre-encoded LIONGARD_API_KEY, never both. LIONGARD_API_KEY wins when it is set, so leave it blank to use this pair.",
           "isRequired": false,
           "isSecret": true
         },
         {
           "name": "LIONGARD_ACCESS_KEY_SECRET",
-          "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. Leave blank if you set the pre-encoded LIONGARD_API_KEY instead.",
+          "description": "Liongard Access Key Secret, the other half of LIONGARD_ACCESS_KEY_ID. One of two ways to authenticate - set EITHER this pair OR the pre-encoded LIONGARD_API_KEY, never both. LIONGARD_API_KEY wins when it is set, so leave it blank to use this pair.",
           "isRequired": false,
           "isSecret": true
         },
         {
           "name": "LIONGARD_API_KEY",
-          "description": "Base64 X-ROAR-API-KEY for the Liongard API (or use LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET).",
-          "isRequired": true,
+          "description": "Pre-encoded X-ROAR-API-KEY: base64 of 'accessKeyId:accessKeySecret'. One of two ways to authenticate - set EITHER this key OR the LIONGARD_ACCESS_KEY_ID + LIONGARD_ACCESS_KEY_SECRET pair, never both. This key wins when it is set, and the pair is ignored.",
+          "isRequired": false,
           "isSecret": true
         },
         {

--- a/skills/resourceguru/CHANGELOG.md
+++ b/skills/resourceguru/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- **The credential-precedence tests were skipped, so nothing was watching which secret goes on the
+  wire.** The four tests that pin the order - a saved credentials file beats an old secret left in
+  `config.toml`, a corrupt credentials file falls back to that config and then to the environment,
+  an empty one clears nothing - looked for the raw secret inside the `Authorization` header and set
+  only the email half of this connector's email plus password pair. They were skipped rather than
+  corrected, which left the precedence chain untested. The fixtures now supply both halves and the
+  assertion decodes the header, so all four run and were checked to fail when the order is broken.
+  Runtime behaviour is unchanged.
+
 ## [0.1.1] - 2026-08-26
 
 ### Fixed

--- a/skills/resourceguru/cli/internal/cliutil/credentials_test.go
+++ b/skills/resourceguru/cli/internal/cliutil/credentials_test.go
@@ -5,6 +5,7 @@ package cliutil_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io"
 	"os"
 	"path/filepath"
@@ -45,16 +46,14 @@ func resetCredentialEnv(t *testing.T) (home, configPath string) {
 }
 
 func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
-	// Skipped for HTTP Basic auth: these are bearer-style credential-precedence tests that assert the RAW secret appears in AuthHeader(). Basic auth base64-encodes email:password, and the fixtures only populate the email var, so AuthHeader() correctly returns "" / an encoded value the raw-substring check can never match. The runtime AuthHeader is correct; the generated tests are mis-emitted for a Basic-auth CLI. (Generator bug — filed for retro.)
-	t.Skip("bearer-style credential test incompatible with HTTP Basic two-var auth")
 	_, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialPairTOML("legacy-secret")), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
-	if err := cliutil.SaveCredentials(testCredentials("data-secret")); err != nil {
+	if err := cliutil.SaveCredentials(testCredentialPair("data-secret")); err != nil {
 		t.Fatalf("SaveCredentials() error = %v", err)
 	}
 
@@ -63,19 +62,15 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "data-secret")
-	if got := cfg.AuthHeader(); !strings.Contains(got, "data-secret") || strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want credentials-file value and not legacy value", got)
-	}
+	assertAuthHeaderCarries(t, cfg, "data-secret", "legacy-secret")
 }
 
 func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
-	// Skipped for HTTP Basic auth: these are bearer-style credential-precedence tests that assert the RAW secret appears in AuthHeader(). Basic auth base64-encodes email:password, and the fixtures only populate the email var, so AuthHeader() correctly returns "" / an encoded value the raw-substring check can never match. The runtime AuthHeader is correct; the generated tests are mis-emitted for a Basic-auth CLI. (Generator bug — filed for retro.)
-	t.Skip("bearer-style credential test incompatible with HTTP Basic two-var auth")
 	home, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialPairTOML("legacy-secret")), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "resourceguru-cli", "credentials.toml")
@@ -92,19 +87,16 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 			t.Fatalf("Load() error = %v", err)
 		}
 		assertConfigCredential(t, cfg, "legacy-secret")
-		if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
-			t.Fatalf("AuthHeader() = %q, want legacy credential", got)
-		}
+		assertAuthHeaderCarries(t, cfg, "legacy-secret")
 	})
 	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
 		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
 	}
 }
 func TestCorruptCredentialsFallsBackToEnvCredential(t *testing.T) {
-	// Skipped for HTTP Basic auth: these are bearer-style credential-precedence tests that assert the RAW secret appears in AuthHeader(). Basic auth base64-encodes email:password, and the fixtures only populate the email var, so AuthHeader() correctly returns "" / an encoded value the raw-substring check can never match. The runtime AuthHeader is correct; the generated tests are mis-emitted for a Basic-auth CLI. (Generator bug — filed for retro.)
-	t.Skip("bearer-style credential test incompatible with HTTP Basic two-var auth")
 	home, _ := resetCredentialEnv(t)
 	t.Setenv("RESOURCEGURU_EMAIL", "env-secret")
+	t.Setenv("RESOURCEGURU_PASSWORD", "env-secret-password")
 	credentialsPath := filepath.Join(home, ".local", "share", "resourceguru-cli", "credentials.toml")
 	if err := os.MkdirAll(filepath.Dir(credentialsPath), 0o700); err != nil {
 		t.Fatalf("mkdir credentials dir: %v", err)
@@ -118,9 +110,7 @@ func TestCorruptCredentialsFallsBackToEnvCredential(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Load() error = %v", err)
 		}
-		if got := cfg.AuthHeader(); !strings.Contains(got, "env-secret") {
-			t.Fatalf("AuthHeader() = %q, want env credential", got)
-		}
+		assertAuthHeaderCarries(t, cfg, "env-secret")
 	})
 	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
 		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
@@ -128,13 +118,11 @@ func TestCorruptCredentialsFallsBackToEnvCredential(t *testing.T) {
 }
 
 func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
-	// Skipped for HTTP Basic auth: these are bearer-style credential-precedence tests that assert the RAW secret appears in AuthHeader(). Basic auth base64-encodes email:password, and the fixtures only populate the email var, so AuthHeader() correctly returns "" / an encoded value the raw-substring check can never match. The runtime AuthHeader is correct; the generated tests are mis-emitted for a Basic-auth CLI. (Generator bug — filed for retro.)
-	t.Skip("bearer-style credential test incompatible with HTTP Basic two-var auth")
 	home, configPath := resetCredentialEnv(t)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialTOML("legacy-secret")), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("base_url = \"https://legacy.example\"\n"+legacyCredentialPairTOML("legacy-secret")), 0o600); err != nil {
 		t.Fatalf("write legacy config: %v", err)
 	}
 	credentialsPath := filepath.Join(home, ".local", "share", "resourceguru-cli", "credentials.toml")
@@ -150,9 +138,7 @@ func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "legacy-secret")
-	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want legacy credential", got)
-	}
+	assertAuthHeaderCarries(t, cfg, "legacy-secret")
 }
 
 func TestAuthWriteMigratesLegacyConfigToCredentialsOnly(t *testing.T) {
@@ -365,6 +351,61 @@ func assertConfigCredential(t *testing.T, cfg *config.Config, want string) {
 
 func configCredentialValue(cfg *config.Config) string {
 	return cfg.ResourceguruEmail
+}
+
+// testCredentialPair builds a credentials-file fixture carrying BOTH halves of
+// the HTTP Basic pair. AuthHeader() short-circuits to "" when either half is
+// empty, so a single-value fixture cannot exercise the precedence chain all
+// the way to the wire header.
+func testCredentialPair(token string) *cliutil.Credentials {
+	creds := &cliutil.Credentials{}
+	setCredentialValue(creds, token)
+	creds.ResourceguruPassword = token + "-password"
+	return creds
+}
+
+// legacyCredentialPairTOML is legacyCredentialTOML for the Basic pair: the
+// legacy config fixture needs a password alongside the email for the same
+// reason.
+func legacyCredentialPairTOML(token string) string {
+	return legacyCredentialTOML(token) + "password = \"" + token + "-password\"\n"
+}
+
+// authHeaderPayload returns the credential material an Authorization header
+// actually carries. This connector authenticates with the HTTP Basic scheme,
+// so AuthHeader() returns "Basic " + base64("<email>:<password>") and a plain
+// substring check for the credential can never match - decode first, then
+// assert. A header in any other shape (bearer, raw api-key) carries the
+// credential verbatim and passes through unchanged, so the same helper works
+// whichever scheme the connector uses.
+func authHeaderPayload(t *testing.T, header string) string {
+	t.Helper()
+	rest, ok := strings.CutPrefix(header, "Basic ")
+	if !ok {
+		return header
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(rest))
+	if err != nil {
+		t.Fatalf("AuthHeader() = %q, Basic payload is not valid base64: %v", header, err)
+	}
+	return string(decoded)
+}
+
+// assertAuthHeaderCarries asserts the outgoing Authorization header is built
+// from the credential the precedence chain was supposed to pick (want), and
+// carries none of the credentials it was supposed to lose to (notWant).
+func assertAuthHeaderCarries(t *testing.T, cfg *config.Config, want string, notWant ...string) {
+	t.Helper()
+	header := cfg.AuthHeader()
+	payload := authHeaderPayload(t, header)
+	if !strings.Contains(payload, want) {
+		t.Fatalf("AuthHeader() = %q (credential payload %q), want it to carry %q", header, payload, want)
+	}
+	for _, forbidden := range notWant {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("AuthHeader() = %q (credential payload %q), must not carry %q", header, payload, forbidden)
+		}
+	}
 }
 
 func assertCredentialsValue(t *testing.T, creds *cliutil.Credentials, want string) {

--- a/skills/resourceguru/handfixes.json
+++ b/skills/resourceguru/handfixes.json
@@ -141,6 +141,31 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "credential-precedence-tests-decode-basic-header",
+   "summary": "the four credentials-precedence tests run for real (fixtures populate both halves of the Basic pair, and the header is decoded before asserting) instead of being t.Skip-ed",
+   "why": "The generated credentials-precedence tests assert the RAW secret appears in cfg.AuthHeader(). This connector authenticates with HTTP Basic over an email + password pair, so AuthHeader() returns \"Basic \" + base64(\"<email>:<password>\") and short-circuits to \"\" when either half is empty - the bearer-shaped fixtures set only the email. The tests were previously t.Skip-ed with that diagnosis, which is correct about the cause but leaves the connector with ZERO coverage of the credential precedence chain (credentials file beats legacy config, corrupt credentials fall back to legacy then env, an empty credentials file does not clear legacy) - the exact chain that decides which secret goes on the wire. The fixtures now populate both halves and the assertion decodes the header, so the tests assert what they were written to assert. Verified to fail when precedence is broken, not merely to pass. Same defect class as wordpress.",
+   "status": "active",
+   "spec_encode_followup": "Make the press emit scheme-aware credential-precedence tests (two-var Basic fixtures, decode before asserting) so Basic-auth connectors are not born skipped or red.",
+   "asserts": [
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "func authHeaderPayload("
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "func assertAuthHeaderCarries("
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "func testCredentialPair("
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "not_contains": "t.Skip(\"bearer-style credential test incompatible"
+    }
+   ]
   }
  ]
 }

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- **The credential-precedence tests could never pass, so nothing was watching which secret goes on
+  the wire.** The four tests that pin the order - a saved credentials file beats an old secret left
+  in `config.toml`, a corrupt credentials file falls back to that config and then to the
+  environment, an empty one clears nothing - looked for the raw secret inside the `Authorization`
+  header. This connector uses HTTP Basic, so the header carries the secret base64-encoded and the
+  check could never match, whatever the code did. The tests now decode the header first and assert
+  which credential it was built from. Runtime behaviour is unchanged: the precedence order was
+  always correct, and is now actually verified.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/wordpress/cli/internal/cliutil/credentials_test.go
+++ b/skills/wordpress/cli/internal/cliutil/credentials_test.go
@@ -5,6 +5,7 @@ package cliutil_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io"
 	"os"
 	"path/filepath"
@@ -60,9 +61,7 @@ func TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "data-secret")
-	if got := cfg.AuthHeader(); !strings.Contains(got, "data-secret") || strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want credentials-file value and not legacy value", got)
-	}
+	assertAuthHeaderCarries(t, cfg, "data-secret", "legacy-secret")
 }
 
 func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
@@ -87,9 +86,7 @@ func TestCorruptCredentialsFallsBackToLegacyConfig(t *testing.T) {
 			t.Fatalf("Load() error = %v", err)
 		}
 		assertConfigCredential(t, cfg, "legacy-secret")
-		if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
-			t.Fatalf("AuthHeader() = %q, want legacy credential", got)
-		}
+		assertAuthHeaderCarries(t, cfg, "legacy-secret")
 	})
 	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
 		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
@@ -111,9 +108,7 @@ func TestCorruptCredentialsFallsBackToEnvCredential(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Load() error = %v", err)
 		}
-		if got := cfg.AuthHeader(); !strings.Contains(got, "env-secret") {
-			t.Fatalf("AuthHeader() = %q, want env credential", got)
-		}
+		assertAuthHeaderCarries(t, cfg, "env-secret")
 	})
 	if !strings.Contains(stderr, credentialsPath) || !strings.Contains(stderr, "parse") {
 		t.Fatalf("stderr %q does not mention corrupt credentials path and parse action", stderr)
@@ -141,9 +136,7 @@ func TestEmptyCredentialsFileDoesNotClearLegacyConfig(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 	assertConfigCredential(t, cfg, "legacy-secret")
-	if got := cfg.AuthHeader(); !strings.Contains(got, "legacy-secret") {
-		t.Fatalf("AuthHeader() = %q, want legacy credential", got)
-	}
+	assertAuthHeaderCarries(t, cfg, "legacy-secret")
 }
 
 func TestAuthWriteMigratesLegacyConfigToCredentialsOnly(t *testing.T) {
@@ -356,6 +349,43 @@ func assertConfigCredential(t *testing.T, cfg *config.Config, want string) {
 
 func configCredentialValue(cfg *config.Config) string {
 	return cfg.WordpressBasicAuth
+}
+
+// authHeaderPayload returns the credential material an Authorization header
+// actually carries. This connector authenticates with the HTTP Basic scheme,
+// so AuthHeader() returns "Basic " + base64("<credential>:") and a plain
+// substring check for the credential can never match - decode first, then
+// assert. A header in any other shape (bearer, raw api-key) carries the
+// credential verbatim and passes through unchanged, so the same helper works
+// whichever scheme the connector uses.
+func authHeaderPayload(t *testing.T, header string) string {
+	t.Helper()
+	rest, ok := strings.CutPrefix(header, "Basic ")
+	if !ok {
+		return header
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(rest))
+	if err != nil {
+		t.Fatalf("AuthHeader() = %q, Basic payload is not valid base64: %v", header, err)
+	}
+	return string(decoded)
+}
+
+// assertAuthHeaderCarries asserts the outgoing Authorization header is built
+// from the credential the precedence chain was supposed to pick (want), and
+// carries none of the credentials it was supposed to lose to (notWant).
+func assertAuthHeaderCarries(t *testing.T, cfg *config.Config, want string, notWant ...string) {
+	t.Helper()
+	header := cfg.AuthHeader()
+	payload := authHeaderPayload(t, header)
+	if !strings.Contains(payload, want) {
+		t.Fatalf("AuthHeader() = %q (credential payload %q), want it to carry %q", header, payload, want)
+	}
+	for _, forbidden := range notWant {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("AuthHeader() = %q (credential payload %q), must not carry %q", header, payload, forbidden)
+		}
+	}
 }
 
 func assertCredentialsValue(t *testing.T, creds *cliutil.Credentials, want string) {

--- a/skills/wordpress/handfixes.json
+++ b/skills/wordpress/handfixes.json
@@ -126,6 +126,31 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "credential-precedence-tests-decode-basic-header",
+   "summary": "the credentials-precedence tests decode the Basic Authorization header before asserting which secret it carries, instead of grepping the raw secret out of base64",
+   "why": "The generated credentials-precedence tests (credentials file beats legacy config, corrupt credentials fall back to legacy, corrupt falls back to env, an empty credentials file does not clear legacy) were emitted in a bearer-style shape: they assert the RAW secret appears in cfg.AuthHeader(). This connector authenticates with HTTP Basic, so AuthHeader() returns \"Basic \" + base64(\"<credential>:\") and the substring check can never match - all four tests failed from the day the connector landed even though the precedence chain is correct. The two wrong resolutions are deleting the assertions and t.Skip-ing the tests (what resourceguru did, which drops the precedence coverage entirely); the right one is to decode the header and assert on the credential payload, which is strictly stronger than the original because it also names the payload in the failure message. A reprint re-emits the bearer-shaped test file and re-breaks it.",
+   "status": "active",
+   "spec_encode_followup": "Make the press emit scheme-aware credential-precedence tests (decode Basic before asserting) so Basic-auth connectors are not born red. Until then this recurs on every reprint.",
+   "asserts": [
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "func authHeaderPayload("
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "func assertAuthHeaderCarries("
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "contains": "assertAuthHeaderCarries(t, cfg, \"data-secret\", \"legacy-secret\")"
+    },
+    {
+     "file": "cli/internal/cliutil/credentials_test.go",
+     "not_contains": "t.Skip(\"bearer-style credential test incompatible"
+    }
+   ]
   }
  ]
 }


### PR DESCRIPTION
Two unrelated auth/config failures from the fleet audit at `origin/main`, diagnosed independently. One is a real user-visible defect (code wrong), the other is a stale test assumption (test wrong). Both are proved in the failing direction as well as the passing one.

## 1. liongard - CODE was wrong (user-visible: every env-var install authenticated with an empty header)

**Failure:** `internal/config` `TestLoad_ComposedRoarAuth` - `AuthHeader() = ""`, want `base64("abc-id:shh-secret")`.

**Diagnosis.** Liongard's `X-ROAR-API-KEY` header is `base64("accessKeyId:accessKeySecret")`. Liongard hands an operator the two strings separately and never shows the encoded form, so the CLI has to compose it - and `README.md`, `SKILL.md`, `guide.md` and `server.json` all instruct operators to export `LIONGARD_ACCESS_KEY_ID` + `LIONGARD_ACCESS_KEY_SECRET`. `config.Load` read **neither variable anywhere in the binary** (`grep` for either name hit only the docs, the test, and nothing in Go). Anyone who followed the shipped instructions sent an empty `X-ROAR-API-KEY` and got a 401 on every call, with `doctor` unable to name the cause. This is not a test-only failure.

**Regression origin.** The composed branch shipped with the connector in #58 and was dropped by the 4.24.0 fleet re-vendor (`fc7720092`), which regenerates `config.go` from the press's single-env-var template (one variable per config field, no notion of a composed credential). Same class as the levelio `x-auth-env-vars` regression.

**Fix.** Restore the branch in `config.Load`: `LIONGARD_API_KEY` still wins when set; otherwise the trimmed ID + secret pair composes to base64 and `AuthSource` becomes `env:LIONGARD_ACCESS_KEY_ID+SECRET`. The derived value is marked as an env override (`markEnvOverride`), matching the sibling branch, so a later config save cannot persist an env-derived secret to disk.

**Install channels.** With the binary reading two new variables, `check_env_schema.py` correctly failed: an undeclared variable is one Claude Desktop never prompts for. Both are now declared on all three channels - `manifest.json` `server.mcp_config.env` + `user_config` (`sensitive: true`, `required: false`), `server.json` `environmentVariables`, and every `mcp-install.md` env block plus the remote launch line. See the review-fix section below: the pre-encoded key had to become optional too, or the pair stayed unreachable through those same channels.

**Reprint survival.** A new `handfixes.json` entry asserts the composed branch, the base64 expression, the `AuthSource` label, the test's presence, and all six install-channel declarations. Nothing was guarding this before, which is why the re-vendor dropped it silently.

## 2. wordpress - TEST was wrong (precedence behaviour is correct)

**Failures:** `internal/cliutil` x4 - `TestCredentialsFileWinsWhenLegacyConfigAlsoHasSecrets`, `TestCorruptCredentialsFallsBackToLegacyConfig`, `TestCorruptCredentialsFallsBackToEnvCredential`, `TestEmptyCredentialsFileDoesNotClearLegacyConfig`.

**Diagnosis.** Precedence did not regress. Read the failure output: `AuthHeader() = "Basic bGVnYWN5LXNlY3JldDo="` is `base64("legacy-secret:")` - the *correct* credential, correctly encoded. Three of the four tests reached their header assertion only *after* `assertConfigCredential` passed, so the chain (credentials file wins; corrupt falls back to legacy, then env; an empty file clears nothing) resolved to exactly the right value in every case. The generated tests are bearer-shaped: they `strings.Contains` the raw secret against the header. This connector uses HTTP Basic, so the header is `"Basic " + base64("<credential>:")` and the substring check can never match, whatever the code does. `config.go` and `credentials_test.go` both landed in #171 and neither has changed since - these tests have never passed.

**Fix (not a weakening).** The assertions now decode the Basic payload and assert which credential the header was built from, plus which credential it must *not* carry. Strictly stronger than the original: the failure message names the decoded payload. Verified both directions - disabling the credentials-file branch fails the precedence assertion, and building the header from a different secret fails the new header assertion (`AuthHeader() = "Basic d3Jvbmctc2VjcmV0Og==" (credential payload "wrong-secret:"), want it to carry "data-secret"`). No runtime code changed.

## Pattern sweep (all 65 connectors)

**Pattern A - composed multi-env auth.** `go test ./internal/config/...` across all 65 connectors: liongard was the only failure; everything else is green. Statically, 27 connectors read two or more credential env vars, but only four *combine* several values into one credential, and the other three are healthy and structurally safer than liongard was:

| connector | composed credential | where the wiring lives | state |
| --- | --- | --- | --- |
| liongard | base64(id:secret) -> `X-ROAR-API-KEY` | inline in generated `config.go`, no ledger guard | **was broken, fixed here** |
| gradient | base64(vendor:partner) -> `GRADIENT-TOKEN` | novel file `gradient_keys.go` + its own test | healthy |
| datto-bcdr | base64(public:secret) -> Basic | native two-field Basic in the 4.24 template | healthy |
| avanan / autotask / datto-rmm | signed handshake / zone lookup / OAuth | novel files (`avanan_config.go`, `zone.go`, `datto_oauth.go`) | healthy |

The differentiator is placement: hand-wiring inside a regenerated file with no `handfixes.json` assert is the only shape a re-vendor can delete in silence. liongard was the sole instance; it now has the guard.

Adjacent findings from the same sweep, **not fixed here** (different defect class - doc/name drift, not composed auth, and each needs its own connector-scoped verification):
- `acronis`: docs and `governance.md` tell operators to export `ACRONIS_CYBER_PROTECT_BEARER_AUTH`; the binary reads `ACRONIS_BEARER_AUTH`.
- `action1`: `README.md` / `SKILL.md` / `governance.md` still instruct `ACTION1_REGION`, which its own `handfixes.json` records as a phantom already removed from the manifest and `server.json`.
- Also doc-only, unverified against each vendor: `autotask` (`AUTOTASK_PSA_API_INTEGRATION_CODE`, `AUTOTASK_ZONE_URL`), `domotz` (`DOMOTZ_PUBLIC_API_KEY`), `resourceguru` (`RESOURCEGURU_ACCOUNT`), `liongard` (`LIONGARD_ENDPOINTS_API_KEY`, a second auth scheme the 4.24 spec dropped). `abnormal` and `aws-billing` matches are false positives (a filter value; SDK-read AWS vars).

**Pattern B - credentials-file precedence tests.** Eight connectors carry the bearer-shaped `strings.Contains(AuthHeader(), secret)` assertion. Seven are harmless because their `AuthHeader()` returns the credential verbatim (avanan, cork, immybot, servosity, threatlocker, unifi-network, zammad - all pass). The one other connector whose `AuthHeader()` base64-encodes is **resourceguru**, which hit this exact defect and resolved it by `t.Skip`-ing all four tests. That is the weaker resolution: it leaves the connector with zero coverage of the chain that decides which secret goes on the wire. Since this PR establishes the correct resolution, resourceguru is fixed the same way - its Basic pair is email + password and `AuthHeader()` short-circuits on an empty half, so the fixtures now populate both halves, the header is decoded before asserting, and the skips are gone. Verified failing-direction too (disabling the credentials-file branch fails it). No runtime code changed there either.

## Proof

- `go build ./...`, `go vet ./...`, `gofmt -l` clean and `go test -count=1 ./...` fully green for liongard, wordpress and resourceguru.
- `go test -count=1 ./internal/config/...` green across all 65 connectors.
- `bash tools/maintainer/ci_guards.sh`, `check_handfixes.py` (65 skills), `check_env_schema.py`, `check_skill_contract.py`, `check_md_links.py`, `check_mcp_registry.py`, `check_no_todos.py`, `check_vocabulary.py`, `check_doctor_truth.py --slug liongard`, `check_mcp_gate.py --slug liongard`, `check_dco.sh` all pass.
- `handfixes.json` + an `## Unreleased` CHANGELOG entry added for each of the three touched slugs.
- `build-catalog.py` regenerates ~35 unrelated `skills/*/README.md` `.mcpb` links (tag-derived drift already present on `main`); that churn was reverted and is not in this PR.

## Review fix (2026-08-26) - the pair was still unreachable through every official install

Adversarial review caught that restoring the loader branch was necessary but not sufficient. `manifest.json` marked `liongard_api_key` `required: true` and `server.json` marked `LIONGARD_API_KEY` `isRequired: true`, while the two new fields were optional. The MCPB bundle and the MCP Registry install therefore both *forced* a value into the pre-encoded key - and because the loader gives that key precedence, `LIONGARD_ACCESS_KEY_ID` + `LIONGARD_ACCESS_KEY_SECRET` were inert through every supported install channel regardless of what the docs said. `mcp-install.md`'s remote launch line had the same shape, setting all three variables on one line, which made the pair dead there too.

**What changed** (`75ed3dae`, minimal hunks - `manifest.json` / `server.json` are also touched by the in-flight p0 branch for this slug, so a rebase is expected):

- `manifest.json` `liongard_api_key.required` and `server.json` `LIONGARD_API_KEY.isRequired` are now `false`. `LIONGARD_INSTANCE` stays required; it is not a credential and both shapes need it.
- All three credential fields state the one-of contract in their descriptions, on both channels: set EITHER the pre-encoded key OR the ID + secret pair, never both, and the key wins when both are present.
- `mcp-install.md` gains a **Two ways to authenticate** section and splits the remote launch line into two mutually exclusive examples (A: key only; B: pair only). It calls out the trap that `LIONGARD_API_KEY` wins whenever it is non-empty - *including* when it still holds the literal `<your-liongard_api_key>` placeholder from the copy-paste config blocks, which is the likely 401 for anyone choosing shape B. The three local-agent JSON blocks still list all five variables (`check_env_schema.py` asserts each block declares exactly the manifest set), with prose telling the operator to fill in one shape and leave the other empty.
- `README.md`, `SKILL.md` and `guide.md` no longer call `LIONGARD_API_KEY` "required"; each states the one-of contract and the precedence, and the guide's 401 entry now names a leftover key as the usual cause when the ID and secret look correct.

**Runtime message when an installer supplies neither** (asked for in review; reported, not changed - `doctor.go` / `doctor_verdict.go` are owned by another branch). Measured against the built binary with no credential in the environment and no config file:

```
"auth": "not configured"
"auth_hint": "Set your API key with: export LIONGARD_API_KEY=\"your-token-here\""
"env_vars": "ERROR missing required: LIONGARD_API_KEY"
"credentials": "ERROR not verified: ..."
```

So the missing-credential case is loud and `--fail-on` trips on it. Two observations for whoever owns `doctor`, neither introduced here:

1. `auth_hint` names only `LIONGARD_API_KEY`. Now that the key is optional and the pair is a first-class shape, the hint should offer both. The `env_vars` line has the same single-variable framing; `doctor.go` already has an unused `authEnvOptionalNames` / `authEnvOptionalSatisfied` path that emits `INFO set one of: A or B`, which is the right shape for this connector.
2. With the pair set and `LIONGARD_INSTANCE` correct, `doctor` reports `base_url` as the unresolved template `https://{instance}.app.liongard.com/api/v1` and advises "set `LIONGARD_BASE_URL`". `{instance}` is substituted from `cfg.TemplateVars` at request time, so this is a doctor display/verdict issue, not a broken base URL - but the advice points at the wrong knob (`LIONGARD_INSTANCE` is the documented one).

With the pair set, `doctor` does report it correctly: `auth: configured`, `auth_source: env:LIONGARD_ACCESS_KEY_ID+SECRET`, `env_vars: OK credentials available from env:LIONGARD_ACCESS_KEY_ID+SECRET`.

**Gates re-run on the amended tree:** `ci_guards.sh`, `check_env_schema.py --slug liongard`, `check_mcp_registry.py --slug liongard`, `check_skill_contract.py --slug liongard`, `check_handfixes.py --slug liongard`, `check_cli_claims.py --slug liongard`, `check_doctor_truth.py --slug liongard`, `check_aeo.py --slug liongard`, `check_marketplace_sync.py`, `check_md_links.py`, `check_no_todos.py`, `check_vocabulary.py` - all pass. `go build ./...`, `go vet ./...`, `go test ./...` clean for liongard. (`check_surface_coverage.py` reports a missing `footer-releases` marker pair in `skills/liongard/README.md`; that is pre-existing on the branch tip and unrelated - it reproduces on the unmodified tree.)

## Rebased 2026-08-26 over the #291-merge / #301-revert churn on `main`

This branch was cut on top of `45cf76cf`, which sat **after** #291 (`release/p0-mcp-filesystem`) merged, so it inherited the release stamps that wave applied - liongard `0.1.2`, resourceguru `0.1.2`, wordpress `0.1.3`. `main` then **reverted** #291 (#301, `18f3d0a2`) and repointed the skill-README download links (#302, `053d5c65`), putting those three connectors back at liongard `0.1.1`, resourceguru `0.1.1`, wordpress `0.1.2`. The branch and `main` therefore disagreed about released history, which is what produced the conflicts.

Rebased onto `9068ba69`. Resolution, file by file:

| file | conflict | resolution |
| --- | --- | --- |
| `skills/liongard/CHANGELOG.md` | branch carried `## Unreleased` stacked on a `## [0.1.2]` section that `main` no longer has | kept `## Unreleased` verbatim; dropped the reverted `## [0.1.2]` section and re-anchored on `main`'s `## [0.1.1]` |
| `skills/resourceguru/CHANGELOG.md` | same shape | kept `## Unreleased`; dropped the reverted `## [0.1.2]`; re-anchored on `## [0.1.1]` |
| `skills/wordpress/CHANGELOG.md` | same shape | kept `## Unreleased`; dropped the reverted `## [0.1.3]`; re-anchored on `## [0.1.2]` |
| `skills/liongard/manifest.json` | branch's new `user_config` fields plus a `0.1.2` version stamp against `main`'s `0.1.1` | resolved field by field: `version` stays `main`'s `0.1.1`; only this PR's semantic changes re-applied (the two `LIONGARD_ACCESS_KEY_*` entries in `server.mcp_config.env`, the two new `user_config` prompts, the `liongard_api_key.required: false` flip, and the one-of descriptions on all three credential fields) |
| `skills/liongard/server.json` | same shape | `version`, the packages `version`, and the pinned `.mcpb` identifier all stay at `main`'s `0.1.1`; only the two new `environmentVariables` entries, the `LIONGARD_API_KEY.isRequired: false` flip, and the one-of descriptions were re-applied |

**No released section was deleted that `main` still carries, and none that `main` dropped was resurrected.** Nothing in this PR re-stamps a version: `.claude-plugin/plugin.json`, `manifest.json` and `server.json` are all left on `main`'s post-revert `0.1.1`, so re-releasing these connectors stays the release owner's call.

Receipt that the rebase moved nothing but that anchor: diffing the pre-rebase change-set (`45cf76cf..75ed3dae`) against the post-rebase one (`origin/main..f05729d0`), ignoring `index` lines, the **only** difference is three context lines - the released heading directly beneath each new `## Unreleased` block, now `0.1.1` / `0.1.1` / `0.1.2` instead of the reverted `0.1.2` / `0.1.2` / `0.1.3`. Every other byte of the 15-file, +348/-47 change-set is identical.

### Gates re-run on the rebased tree

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` clean for **liongard**, **wordpress** and **resourceguru**.
- `bash tools/maintainer/ci_guards.sh` - pass.
- `check_env_schema.py --base origin/main` (fleet) and `--slug liongard|wordpress|resourceguru` - pass.
- `check_handfixes.py --slug liongard|wordpress|resourceguru` and `--changed --base origin/main` - pass.
- `check_skill_contract.py`, `check_md_links.py`, `check_mcp_registry.py`, `check_no_todos.py`, `check_vocabulary.py`, `check_aeo.py`, `check_marketplace_sync.py`, `check_release_contract.py`, `check_registry_state.py`, `check_media_block.py`, `check_surface_coverage.py`, `check_cli_claims.py`, `check_doctor_truth.py`, `check_mcp_gate.py`, `check_security_gate.py` (0 P0/P1), `check_dco.sh` - pass.
- `check_pinned_artifacts.py --base origin/main --no-network` - **pass** on the current base. It was failing on `main` itself earlier in the rebase (`skills/auvik/README.md` pinned `auvik-v0.2.2`, a tag that was never cut - reproduced byte-identically on a pristine `299d3cb0` checkout, so not from this PR); the catalog bot's `9068ba69` repointed that pin and the gate is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


