### PR TITLE
docs(verified): receipts are mostly external now - stop claiming first-party only

### DIFF
--- a/docs/verified.md
+++ b/docs/verified.md
@@ -14,7 +14,7 @@ Every connector passes four mechanical gates before it ships - build, command-su
 
 {% include proof-strip.html %}
 
-> **An honest note.** Today's live verifications are first-party - **Servosity (maintainer)** confirmed them against our own tenants. That's a real receipt, but it isn't yet a receipt from *you*. External MSP receipts are exactly what this wall wants. If you run any connector against your tenant and it works, [tell us below](#receipt) and your name goes on the wall.
+> **Where these receipts come from.** Most of the live verifications below came from outside Servosity: independent MSPs who ran a connector against their own production tenant and told us it worked. Every badge names who confirmed it and links the receipt where there is one, so you can weigh each one yourself. The badges that read **Servosity (maintainer)** are first-party - our own tenants, labeled as such on purpose, because a receipt from us is not the same as a receipt from another MSP. If you run any connector against your tenant and it works, [tell us below](#receipt) and your name goes on the wall next to theirs.
 
 {% assign verified = site.data.catalog.connectors | where: "verification", "live-verified" %}
 {% assign awaiting = site.data.catalog.connectors | where_exp: "c", "c.verification != 'live-verified'" %}

--- a/docs/verified.md
+++ b/docs/verified.md
@@ -14,7 +14,7 @@ Every connector passes four mechanical gates before it ships - build, command-su
 
 {% include proof-strip.html %}
 
-> **Where these receipts come from.** Most of the live verifications below came from outside Servosity: independent MSPs who ran a connector against their own production tenant and told us it worked. Every badge names who confirmed it and links the receipt where there is one, so you can weigh each one yourself. The badges that read **Servosity (maintainer)** are first-party - our own tenants, labeled as such on purpose, because a receipt from us is not the same as a receipt from another MSP. If you run any connector against your tenant and it works, [tell us below](#receipt) and your name goes on the wall next to theirs.
+> **Where these receipts come from.** Most of the live verifications below came from outside Servosity: independent MSPs who ran a connector against their own production tenant and told us it worked. Every badge carries the source of the receipt behind it: most name the reporting MSP and link the receipt itself, and a receipt that reached us without a name is credited to the channel it arrived on rather than to a person. The badges that read **Servosity (maintainer)** are first-party - our own tenants, labeled as such on purpose, because a receipt from us is not the same as a receipt from another MSP. If you run any connector against your tenant and it works, [tell us below](#receipt) and your name goes on the wall next to theirs.
 
 {% assign verified = site.data.catalog.connectors | where: "verification", "live-verified" %}
 {% assign awaiting = site.data.catalog.connectors | where_exp: "c", "c.verification != 'live-verified'" %}


### PR DESCRIPTION
## The problem

`docs/verified.md` carried an "An honest note" callout claiming:

> Today's live verifications are first-party - **Servosity (maintainer)** confirmed them against our own tenants.

That has not been true for a while. It undersells the wall, and on a page whose entire purpose is honest receipts, a stale claim is the worst kind of copy to leave standing.

## The registry evidence

`tools/maintainer/skills.json` stores a `live_verified` block per connector carrying `status`, `source`, `verified_by`, and `evidence`. Reading `source` across every connector at `status: "live-verified"`:

| `source` | meaning |
| --- | --- |
| `self` | Servosity, the maintainer, against our own tenants |
| `github` | an outside MSP filed a receipt as an issue or PR |
| `circle` | an outside MSP reported it in the Compounding Teams community |

The `github` + `circle` group is substantially larger than `self`. Named external reporters in the registry today include **@Xenith-B**, **@geekbrownbear** (Bearium Networks), **@AvlCompCo**, and **Abhi Saini** (Bearium Networks) - covering connectors such as NinjaOne, Hudu, Huntress, Axcient, ThreatLocker, ImmyBot, Avanan, Cove, SuperOps, CIPP, and Datto BCDR. The first-party receipts are the minority and are already labeled `Servosity (maintainer)` in `verified_by`, which the `verification-badge.html` include renders on every card.

So the page was contradicting the very badges printed beneath it.

## The fix

One paragraph rewritten. The new callout:

- leads with the true and stronger claim - most receipts come from MSPs outside Servosity running their own production tenants
- keeps the first-party receipts visible and explicitly labeled, and says plainly why that distinction matters to a reader
- keeps the invitation to send a receipt, now framed as joining the MSPs already on the wall

## Deliberate non-choices

- **No hardcoded counts.** The self-vs-external split moves every time a receipt lands, and a number baked into prose is a future lie. The per-connector badges already name each verifier, and the section headings already render generated counts from the catalog.
- **The `TODO` form-endpoint comment is untouched.** A separate workstream owns swapping the `mailto:` action for a real form endpoint.
- **Nothing else on the page repeats the stale claim.** Verified by grep for `first-party`, `maintainer`, `our own tenant`, and `Servosity` across the file - the callout was the only instance.
- **Scope is exactly one file.** `git status` shows `docs/verified.md` modified and nothing else.

## Gates

All four required checks pass on this branch:

- `bash tools/maintainer/ci_guards.sh` - all 6 guards passed
- `python3 tools/maintainer/check_vocabulary.py` - vocabulary contract satisfied
- `python3 tools/maintainer/check_aeo.py` - AEO answer-first + title/description contract satisfied
- `python3 tools/maintainer/check_md_links.py` - passed across 549 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review fix (amended 2026-08-26, commit `970fa3ec7`)

Review caught the first version of the rewritten callout overclaiming. It said:

> Every badge names who confirmed it and links the receipt where there is one

The registry does not support that. `sentinelone` is `status: "live-verified"` with `source: "github"`, **no** `verified_by`, and **no** `issue_url` in the Jekyll projection - only an `evidence` URL, which the badge include does not render. Its badge names no person and links no receipt.

Reworded to what the registry actually guarantees:

> Every badge carries the source of the receipt behind it: most name the reporting MSP and link the receipt itself, and a receipt that reached us without a name is credited to the channel it arrived on rather than to a person.

`tools/maintainer/skills.json` is still untouched - recording sentinelone's reporter is a registry edit owned by another branch, and the page must read honestly while the registry is incomplete. Scope remains exactly one file. All four gates re-run and pass.
