### PR TITLE
fix(docs): verification badge miscredits external receipts with null verifier

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -8,6 +8,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/abnormal/"
     },
@@ -18,6 +19,7 @@
       "category": "Backup/DR",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/acronis/"
     },
@@ -28,6 +30,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/action1/"
     },
@@ -38,6 +41,7 @@
       "category": "Backup/DR",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/afi/"
     },
@@ -48,6 +52,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/appdirect/"
     },
@@ -58,6 +63,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/atera/"
     },
@@ -68,6 +74,7 @@
       "category": "PSA",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/autotask/"
     },
@@ -78,6 +85,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/auvik/"
     },
@@ -88,6 +96,7 @@
       "category": "Security",
       "verification": "live-verified",
       "verified_by": "@geekbrownbear (Bearium Networks, MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/pull/271",
       "url": "/skills/avanan/"
     },
@@ -98,6 +107,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/aws-billing/"
     },
@@ -108,6 +118,7 @@
       "category": "Backup/DR",
       "verification": "live-verified",
       "verified_by": "@Xenith-B (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/101#issuecomment-4781241575",
       "url": "/skills/axcient/"
     },
@@ -118,6 +129,7 @@
       "category": "Monitoring",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/betterstack/"
     },
@@ -128,6 +140,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/blumira/"
     },
@@ -138,6 +151,7 @@
       "category": "Security",
       "verification": "live-verified",
       "verified_by": "Abhi Saini, Bearium Networks (MSP)",
+      "source": "circle",
       "issue_url": "https://compoundingteams.com/",
       "url": "/skills/cipp/"
     },
@@ -148,6 +162,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/connectwise-automate/"
     },
@@ -158,6 +173,7 @@
       "category": "Remote Access",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/connectwise-control/"
     },
@@ -168,6 +184,7 @@
       "category": "PSA",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/connectwise-manage/"
     },
@@ -178,6 +195,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/cork/"
     },
@@ -188,6 +206,7 @@
       "category": "Backup/DR",
       "verification": "live-verified",
       "verified_by": "@AvlCompCo (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/139",
       "url": "/skills/cove/"
     },
@@ -198,6 +217,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/crowdstrike/"
     },
@@ -208,6 +228,7 @@
       "category": "Backup/DR",
       "verification": "live-verified",
       "verified_by": "Abhi Saini, Bearium Networks (MSP)",
+      "source": "circle",
       "issue_url": "https://compoundingteams.com/",
       "url": "/skills/datto-bcdr/"
     },
@@ -218,6 +239,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/datto-rmm/"
     },
@@ -228,6 +250,7 @@
       "category": "Network Monitoring",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/domotz/"
     },
@@ -238,6 +261,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/gradient/"
     },
@@ -248,6 +272,7 @@
       "category": "PSA",
       "verification": "live-verified",
       "verified_by": "Servosity (maintainer)",
+      "source": "self",
       "issue_url": null,
       "url": "/skills/halopsa/"
     },
@@ -258,6 +283,7 @@
       "category": "CRM",
       "verification": "live-verified",
       "verified_by": "Servosity (maintainer)",
+      "source": "self",
       "issue_url": null,
       "url": "/skills/hubspot/"
     },
@@ -268,6 +294,7 @@
       "category": "Documentation",
       "verification": "live-verified",
       "verified_by": "@Xenith-B (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/183",
       "url": "/skills/hudu/"
     },
@@ -278,6 +305,7 @@
       "category": "Security",
       "verification": "live-verified",
       "verified_by": "@Xenith-B (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/144",
       "url": "/skills/huntress/"
     },
@@ -288,6 +316,7 @@
       "category": "RMM",
       "verification": "live-verified",
       "verified_by": "@geekbrownbear (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/pull/276",
       "url": "/skills/immybot/"
     },
@@ -298,6 +327,7 @@
       "category": "Documentation",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/itglue/"
     },
@@ -308,6 +338,7 @@
       "category": "PSA",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/kaseya-bms/"
     },
@@ -318,6 +349,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/knowbe4/"
     },
@@ -328,6 +360,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/levelio/"
     },
@@ -338,6 +371,7 @@
       "category": "Documentation",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/liongard/"
     },
@@ -348,6 +382,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/maxio/"
     },
@@ -358,6 +393,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/microsoft-graph/"
     },
@@ -368,6 +404,7 @@
       "category": "Analytics",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/mspbots/"
     },
@@ -378,6 +415,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/n-central/"
     },
@@ -388,6 +426,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/nerdio/"
     },
@@ -398,6 +437,7 @@
       "category": "RMM",
       "verification": "live-verified",
       "verified_by": "@Xenith-B (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/145",
       "url": "/skills/ninjaone/"
     },
@@ -408,6 +448,7 @@
       "category": "Incident Response",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/pagerduty/"
     },
@@ -418,6 +459,7 @@
       "category": "Documentation",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/pandadoc/"
     },
@@ -428,6 +470,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/pax8/"
     },
@@ -438,6 +481,7 @@
       "category": "CRM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/pipedrive/"
     },
@@ -448,6 +492,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/proofpoint/"
     },
@@ -458,6 +503,7 @@
       "category": "Billing",
       "verification": "live-verified",
       "verified_by": null,
+      "source": "self",
       "issue_url": null,
       "url": "/skills/quickbooks/"
     },
@@ -468,6 +514,7 @@
       "category": "Other",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/resourceguru/"
     },
@@ -478,6 +525,7 @@
       "category": "Automation",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/rewst/"
     },
@@ -488,6 +536,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/rocketcyber/"
     },
@@ -498,6 +547,7 @@
       "category": "Incident Response",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/rootly/"
     },
@@ -508,6 +558,7 @@
       "category": "Security",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/runzero/"
     },
@@ -518,6 +569,7 @@
       "category": "CRM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/salesbuildr/"
     },
@@ -528,6 +580,7 @@
       "category": "Security",
       "verification": "live-verified",
       "verified_by": null,
+      "source": "github",
       "issue_url": null,
       "url": "/skills/sentinelone/"
     },
@@ -538,6 +591,7 @@
       "category": "Backup/DR",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/servosity/"
     },
@@ -548,6 +602,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/sherweb/"
     },
@@ -558,6 +613,7 @@
       "category": "Backup/DR",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/skykick/"
     },
@@ -568,6 +624,7 @@
       "category": "PSA",
       "verification": "live-verified",
       "verified_by": "@AvlCompCo (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/140",
       "url": "/skills/superops/"
     },
@@ -578,6 +635,7 @@
       "category": "PSA",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/syncro/"
     },
@@ -588,6 +646,7 @@
       "category": "RMM",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/tactical-rmm/"
     },
@@ -598,6 +657,7 @@
       "category": "Security",
       "verification": "live-verified",
       "verified_by": "@geekbrownbear (MSP)",
+      "source": "github",
       "issue_url": "https://github.com/Servosity/msp-skills/issues/208",
       "url": "/skills/threatlocker/"
     },
@@ -608,6 +668,7 @@
       "category": "Network Monitoring",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/unifi-network/"
     },
@@ -618,6 +679,7 @@
       "category": "Backup/DR",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/veeam/"
     },
@@ -628,6 +690,7 @@
       "category": "Marketing",
       "verification": "live-verified",
       "verified_by": "Servosity (maintainer)",
+      "source": "self",
       "issue_url": null,
       "url": "/skills/wordpress/"
     },
@@ -638,6 +701,7 @@
       "category": "Billing",
       "verification": "awaiting",
       "verified_by": null,
+      "source": null,
       "issue_url": null,
       "url": "/skills/xero/"
     },
@@ -648,6 +712,7 @@
       "category": "PSA",
       "verification": "live-verified",
       "verified_by": "Servosity (maintainer)",
+      "source": "self",
       "issue_url": null,
       "url": "/skills/zammad/"
     }

--- a/docs/_includes/verification-badge.html
+++ b/docs/_includes/verification-badge.html
@@ -18,12 +18,13 @@ awaiting      -> terracotta-outline pill linking the 60-second receipt form.
 Attribution: .verified_by is the name when the registry recorded one. When it
 is null the fallback is derived from .source, never hardcoded to the
 maintainer - an external MSP receipt credited to Servosity would be a false
-claim on the receipts wall. Unknown/absent source is not assumed to be
-first-party either; it falls back to the same generic wording the per-skill
-page renderer uses.
+claim on the receipts wall. Only an explicit source of "self" credits the
+maintainer. An unknown or absent source gets the same generic wording the
+per-skill page renderer uses, so a record that reaches the wall without a
+source can never be misattributed to us.
 {%- endcomment -%}
 {%- assign conn = include.connector -%}
-{%- assign verif_source = conn.source | default: "self" -%}
+{%- assign verif_source = conn.source -%}
 {%- case verif_source -%}
   {%- when "self" -%}{%- assign verif_fallback = "Servosity (maintainer)" -%}
   {%- when "github" -%}{%- assign verif_fallback = "an MSP via GitHub report" -%}

--- a/docs/_includes/verification-badge.html
+++ b/docs/_includes/verification-badge.html
@@ -8,15 +8,31 @@ Usage:
   include.connector  - a catalog.json connector object with:
       .verification   "live-verified" | "awaiting"
       .verified_by    who confirmed it against a production tenant (live only)
+      .source         where the receipt came from: "self" | "github" | "circle"
       .issue_url      optional receipt link (live only)
       .display_name   connector name
 
 live-verified -> terracotta-fill pill + optional receipt link.
 awaiting      -> terracotta-outline pill linking the 60-second receipt form.
+
+Attribution: .verified_by is the name when the registry recorded one. When it
+is null the fallback is derived from .source, never hardcoded to the
+maintainer - an external MSP receipt credited to Servosity would be a false
+claim on the receipts wall. Unknown/absent source is not assumed to be
+first-party either; it falls back to the same generic wording the per-skill
+page renderer uses.
 {%- endcomment -%}
 {%- assign conn = include.connector -%}
+{%- assign verif_source = conn.source | default: "self" -%}
+{%- case verif_source -%}
+  {%- when "self" -%}{%- assign verif_fallback = "Servosity (maintainer)" -%}
+  {%- when "github" -%}{%- assign verif_fallback = "an MSP via GitHub report" -%}
+  {%- when "circle" -%}{%- assign verif_fallback = "an MSP in the Compounding Teams community" -%}
+  {%- else -%}{%- assign verif_fallback = "a real MSP" -%}
+{%- endcase -%}
+{%- assign verif_by = conn.verified_by | default: verif_fallback -%}
 {%- if conn.verification == "live-verified" -%}
-<span class="verif-badge verified">&#10003; Live-verified by {{ conn.verified_by | default: "Servosity (maintainer)" }} against a production tenant{%- if conn.issue_url %} &middot; <a href="{{ conn.issue_url }}">receipt &rarr;</a>{%- endif -%}</span>
+<span class="verif-badge verified">&#10003; Live-verified by {{ verif_by }} against a production tenant{%- if conn.issue_url %} &middot; <a href="{{ conn.issue_url }}">receipt &rarr;</a>{%- endif -%}</span>
 {%- else -%}
 <span class="verif-badge awaiting">Passes all 4 mechanical gates - awaiting its first MSP receipt. <a href="{{ site.receipt_form_url | default: '/verified/#receipt' }}">Be the first, 60 seconds &rarr;</a></span>
 {%- endif -%}

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -527,6 +527,13 @@ def build_docs_catalog(skills: list[dict]) -> dict:
             "verified_by": (
                 (SKILL_META[s["name"]].get("live_verified") or {}).get("verified_by")
             ),
+            # Where the receipt came from ("self" | "github" | "circle").
+            # docs/_includes/verification-badge.html derives honest attribution
+            # from this when verified_by is null, so an external MSP receipt is
+            # never credited to the maintainer on the receipts wall.
+            "source": (
+                (SKILL_META[s["name"]].get("live_verified") or {}).get("source")
+            ),
             "issue_url": (
                 (SKILL_META[s["name"]].get("live_verified") or {}).get("issue_url")
             ),


### PR DESCRIPTION
## The bug

`docs/_includes/verification-badge.html` hardcoded the maintainer as the fallback attribution:

```liquid
Live-verified by {{ conn.verified_by | default: "Servosity (maintainer)" }}
```

That default fires whenever a live-verified connector has no `verified_by` name recorded, regardless of **who actually sent the receipt**. The receipts wall (`/verified/`) therefore credits Servosity for work an external MSP did.

### The live case: sentinelone

`tools/maintainer/skills.json`:

```json
"sentinelone": {
  "live_verified": {
    "status": "live-verified",
    "date": "2026-06-16",
    "source": "github",
    "evidence": "https://github.com/Servosity/msp-skills/issues/116"
  }
}
```

An **external GitHub receipt** (issue #116), with `verified_by` never recorded. Rendered on the wall before this PR:

```html
<span class="verif-badge verified">&#10003; Live-verified by Servosity (maintainer) against a production tenant</span>
```

`quickbooks` (`source: "self"`, `verified_by` null) rendered correctly only by luck: its true attribution happens to be the hardcoded string.

The per-skill pages were never wrong here. `tools/maintainer/render_docs_page.py:111` already falls back to a neutral `"a real MSP"`. Only the shared include, which the wall uses, asserted the maintainer.

## The fix

Derive the fallback from the receipt's `source` instead of assuming it:

| `source` | fallback when `verified_by` is null |
| --- | --- |
| `self` or absent | `Servosity (maintainer)` |
| `github` | `an MSP via GitHub report` |
| `circle` | `an MSP in the Compounding Teams community` |
| anything else | `a real MSP` (same wording `render_docs_page.py` already emits) |

A recorded `verified_by` name still wins, unchanged. An unknown future `source` value does **not** fall back to the maintainer, so this bug class cannot reappear when a new receipt channel is added.

`source` was not in the Jekyll projection, so `tools/maintainer/build-catalog.py` now carries it into `docs/_data/catalog.json` alongside `verified_by`. The regenerated data file is a **pure addition**: one `"source"` key per connector, 65 insertions, 0 deletions, no other field touched.

`tools/maintainer/skills.json` is deliberately **not** touched. Recording sentinelone's actual reporter is a registry edit owned by another in-flight branch, and independently of that the site must render honestly when the registry is incomplete.

## Proof, both directions

Rendered `verification-badge.html` through Liquid 5.13 (the engine Jekyll uses) against the real `docs/_data/catalog.json`, for **all 65 connectors**, on `origin/main` vs this branch. Exactly one line differs:

```
53c53
< sentinelone	...Live-verified by Servosity (maintainer) against a production tenant...
---
> sentinelone	...Live-verified by an MSP via GitHub report against a production tenant...
```

The other 64 render byte-identical. Spot check of the unchanged side:

```
halopsa       (verified_by="Servosity (maintainer)" source="self")
   Live-verified by Servosity (maintainer) against a production tenant
quickbooks    (verified_by=nil source="self")
   Live-verified by Servosity (maintainer) against a production tenant
cipp          (verified_by="Abhi Saini, Bearium Networks (MSP)" source="circle")
   Live-verified by Abhi Saini, Bearium Networks (MSP) ... receipt ->
avanan        (verified_by="@geekbrownbear (Bearium Networks, MSP)" source="github")
   Live-verified by @geekbrownbear (Bearium Networks, MSP) ... receipt ->
abnormal      (verification="awaiting")
   Passes all 4 mechanical gates - awaiting its first MSP receipt.
```

Every branch exercised against synthetic connectors, including the ones no registry entry hits today:

| case | rendered |
| --- | --- |
| `source: "self"`, verified_by null | Live-verified by **Servosity (maintainer)** |
| `source: "github"`, verified_by null | Live-verified by **an MSP via GitHub report** |
| `source: "circle"`, verified_by null | Live-verified by **an MSP in the Compounding Teams community** |
| `source: "email"` (unknown), verified_by null | Live-verified by **a real MSP** |
| `source` key absent entirely (stale data file) | Live-verified by **Servosity (maintainer)** |
| `source: "github"`, verified_by named | Live-verified by **@somebody (MSP)** + receipt link |
| `verification: "awaiting"` | awaiting pill, unchanged |

## Callers checked

`grep -rn verification-badge docs/ tools/` finds three references:

- `docs/verified.md:27` and `:35` - the only real callers, both loop over `site.data.catalog.connectors`, both now get the corrected attribution.
- `docs/_includes/skill-table.html` - a comment explaining it deliberately does **not** call the include (the HTML pill would break the kramdown table). Not a caller.
- `tools/maintainer/check_aeo.py:123` - a comment about the paragraph `render_docs_page.py` emits on per-skill pages. Not a caller.

No caller breaks.

## Gates

```
bash tools/maintainer/ci_guards.sh              -> All CI guards passed
python3 tools/maintainer/check_vocabulary.py    -> PASS: vocabulary contract satisfied
python3 tools/maintainer/check_md_links.py      -> passed across 549 file(s)
python3 tools/maintainer/check_surface_coverage.py -> PASS: 65 connector(s)
python3 tools/maintainer/build-catalog.py       -> idempotent on re-run (no further drift)
```

`build-catalog.py` was run once and only its `docs/_data/catalog.json` output committed. It also rewrote 37 `skills/*/README.md` `.mcpb` release pins (`v0.1.1 -> v0.1.2`); that churn is unrelated to this change and belongs to the release wave, so it was reverted.

## Rebase note

This touches `tools/maintainer/build-catalog.py` (the `build_docs_catalog` projection, ~line 527). PR #293 also touches that file, in the module docstring, the constants block, the `_FORM_OPTIONS_RE` form-dropdown region, and `main()`. The hunks do not overlap, but if #293 lands first this may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review fix (amended 2026-08-26, commit `4a1aba81b`)

Review caught the fix reintroducing its own bug class one line above itself. The first cut wrote:

```liquid
{%- assign verif_source = conn.source | default: "self" -%}
```

That contradicts the include's own comment, which promises an unknown or absent source is not assumed to be first-party. `default` maps absent, `null`, and `""` onto `"self"`, and `"self"` is the single value that renders **Servosity (maintainer)**. A live-verified record reaching the wall without a source would have been credited to the maintainer.

**Fix:** drop the `default`. An explicit `source: "self"` still maps to `Servosity (maintainer)`. Absent, null, empty, and any unknown future channel now fall through the `case` to the generic `a real MSP` wording that `render_docs_page.py` already emits.

### Re-run of the both-directions proof

Liquid 5.13, the same `render_all.rb` harness, against the real `docs/_data/catalog.json`.

**Direction 1 - no regression on today's data. All 65 connectors, before vs after this amendment: ZERO lines differ.**

```
$ diff r299-before.txt r299-after.txt
$ echo $?
0
```

That is expected and worth stating plainly: **every current live-verified record already has a source**, so no rendered badge changes. The split today is 10 `github`, 5 `self`, 2 `circle` across the 17 live-verified records; the other 48 are `awaiting` and never render an attribution at all. **This amendment corrects no current badge - it is protection for future records**, including any record written by a channel that has not been added to the `case` yet.

`sentinelone` still renders the delta this PR was opened for:

```
sentinelone	<span class="verif-badge verified">&#10003; Live-verified by an MSP via GitHub report against a production tenant</span>
```

**Direction 2 - the change actually fires on the broken shape.** Synthetic records, before vs after:

```
1,3c1,3
< syn-source-absent   ...Live-verified by Servosity (maintainer) against a production tenant...
< syn-source-null     ...Live-verified by Servosity (maintainer) against a production tenant...
< syn-source-empty    ...Live-verified by Servosity (maintainer) against a production tenant...
---
> syn-source-absent   ...Live-verified by a real MSP against a production tenant...
> syn-source-null     ...Live-verified by a real MSP against a production tenant...
> syn-source-empty    ...Live-verified by a real MSP against a production tenant...
```

Every other synthetic case is byte-identical across the amendment:

| case | rendered (after) |
| --- | --- |
| `source: "self"`, verified_by null | Live-verified by **Servosity (maintainer)** |
| `source: "github"`, verified_by null | Live-verified by **an MSP via GitHub report** |
| `source: "circle"`, verified_by null | Live-verified by **an MSP in the Compounding Teams community** |
| `source: "email"` (unknown) | Live-verified by **a real MSP** |
| `source` absent / null / empty | Live-verified by **a real MSP** (was: Servosity (maintainer)) |
| verified_by named | Live-verified by **@somebody (MSP)** + receipt link |
| `verification: "awaiting"` | awaiting pill, unchanged |

The include's comment was updated to match: only an explicit `self` credits the maintainer.

Gates re-run on the amended branch: `ci_guards.sh`, `check_vocabulary.py`, `check_md_links.py`, `check_surface_coverage.py` all pass. Scope is unchanged - `docs/_includes/verification-badge.html` is the only file this amendment touches.
