### PR TITLE
fix(catalog): repoint the skill-README download links after the reverted release wave

### DIFF
--- a/skills/abnormal/README.md
+++ b/skills/abnormal/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Abnormal Security MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/abnormal-v0.1.2/abnormal-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Abnormal Security release on the [releases page](https://github.com/servosity/msp-skills/releases?q=abnormal).)
+[**Download Abnormal Security MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/abnormal-v0.1.1/abnormal-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Abnormal Security release on the [releases page](https://github.com/servosity/msp-skills/releases?q=abnormal).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/acronis/README.md
+++ b/skills/acronis/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Acronis MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/acronis-v0.1.2/acronis-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Acronis release on the [releases page](https://github.com/servosity/msp-skills/releases?q=acronis).)
+[**Download Acronis MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/acronis-v0.1.1/acronis-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Acronis release on the [releases page](https://github.com/servosity/msp-skills/releases?q=acronis).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/action1/README.md
+++ b/skills/action1/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Action1 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/action1-v0.1.2/action1-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Action1 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=action1).)
+[**Download Action1 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/action1-v0.1.1/action1-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Action1 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=action1).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/appdirect/README.md
+++ b/skills/appdirect/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download AppDirect MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/appdirect-v0.1.3/appdirect-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every AppDirect release on the [releases page](https://github.com/servosity/msp-skills/releases?q=appdirect).)
+[**Download AppDirect MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/appdirect-v0.1.2/appdirect-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every AppDirect release on the [releases page](https://github.com/servosity/msp-skills/releases?q=appdirect).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/autotask/README.md
+++ b/skills/autotask/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Autotask MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/autotask-v0.1.4/autotask-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Autotask release on the [releases page](https://github.com/servosity/msp-skills/releases?q=autotask).)
+[**Download Autotask MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/autotask-v0.1.3/autotask-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Autotask release on the [releases page](https://github.com/servosity/msp-skills/releases?q=autotask).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/auvik/README.md
+++ b/skills/auvik/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Auvik MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/auvik-v0.2.2/auvik-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Auvik release on the [releases page](https://github.com/servosity/msp-skills/releases?q=auvik).)
+[**Download Auvik MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/auvik-v0.2.1/auvik-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Auvik release on the [releases page](https://github.com/servosity/msp-skills/releases?q=auvik).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/aws-billing/README.md
+++ b/skills/aws-billing/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Amazon Web Services MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/aws-billing-v0.1.2/aws-billing-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Amazon Web Services release on the [releases page](https://github.com/servosity/msp-skills/releases?q=aws-billing).)
+[**Download Amazon Web Services MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/aws-billing-v0.1.1/aws-billing-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Amazon Web Services release on the [releases page](https://github.com/servosity/msp-skills/releases?q=aws-billing).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/axcient/README.md
+++ b/skills/axcient/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Axcient MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/axcient-v0.2.11/axcient-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Axcient release on the [releases page](https://github.com/servosity/msp-skills/releases?q=axcient).)
+[**Download Axcient MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/axcient-v0.2.10/axcient-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Axcient release on the [releases page](https://github.com/servosity/msp-skills/releases?q=axcient).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/betterstack/README.md
+++ b/skills/betterstack/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Better Stack MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/betterstack-v0.1.2/betterstack-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Better Stack release on the [releases page](https://github.com/servosity/msp-skills/releases?q=betterstack).)
+[**Download Better Stack MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/betterstack-v0.1.1/betterstack-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Better Stack release on the [releases page](https://github.com/servosity/msp-skills/releases?q=betterstack).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/blumira/README.md
+++ b/skills/blumira/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Blumira MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/blumira-v0.1.2/blumira-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Blumira release on the [releases page](https://github.com/servosity/msp-skills/releases?q=blumira).)
+[**Download Blumira MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/blumira-v0.1.1/blumira-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Blumira release on the [releases page](https://github.com/servosity/msp-skills/releases?q=blumira).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/cipp/README.md
+++ b/skills/cipp/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download CIPP MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/cipp-v0.1.4/cipp-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every CIPP release on the [releases page](https://github.com/servosity/msp-skills/releases?q=cipp).)
+[**Download CIPP MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/cipp-v0.1.3/cipp-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every CIPP release on the [releases page](https://github.com/servosity/msp-skills/releases?q=cipp).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/connectwise-automate/README.md
+++ b/skills/connectwise-automate/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download ConnectWise MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-automate-v0.1.2/connectwise-automate-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-automate).)
+[**Download ConnectWise MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-automate-v0.1.1/connectwise-automate-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-automate).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/connectwise-control/README.md
+++ b/skills/connectwise-control/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download ConnectWise MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-control-v0.1.3/connectwise-control-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-control).)
+[**Download ConnectWise MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-control-v0.1.2/connectwise-control-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-control).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/connectwise-manage/README.md
+++ b/skills/connectwise-manage/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download ConnectWise Manage MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-manage-v0.1.6/connectwise-manage-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise Manage release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-manage).)
+[**Download ConnectWise Manage MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/connectwise-manage-v0.1.5/connectwise-manage-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ConnectWise Manage release on the [releases page](https://github.com/servosity/msp-skills/releases?q=connectwise-manage).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/cove/README.md
+++ b/skills/cove/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Cove Data Protection MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/cove-v0.1.6/cove-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Cove Data Protection release on the [releases page](https://github.com/servosity/msp-skills/releases?q=cove).)
+[**Download Cove Data Protection MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/cove-v0.1.5/cove-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Cove Data Protection release on the [releases page](https://github.com/servosity/msp-skills/releases?q=cove).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/crowdstrike/README.md
+++ b/skills/crowdstrike/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download CrowdStrike MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/crowdstrike-v0.1.3/crowdstrike-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every CrowdStrike release on the [releases page](https://github.com/servosity/msp-skills/releases?q=crowdstrike).)
+[**Download CrowdStrike MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/crowdstrike-v0.1.2/crowdstrike-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every CrowdStrike release on the [releases page](https://github.com/servosity/msp-skills/releases?q=crowdstrike).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/datto-bcdr/README.md
+++ b/skills/datto-bcdr/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Datto BCDR MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/datto-bcdr-v0.1.4/datto-bcdr-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Datto BCDR release on the [releases page](https://github.com/servosity/msp-skills/releases?q=datto-bcdr).)
+[**Download Datto BCDR MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/datto-bcdr-v0.1.3/datto-bcdr-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Datto BCDR release on the [releases page](https://github.com/servosity/msp-skills/releases?q=datto-bcdr).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/datto-rmm/README.md
+++ b/skills/datto-rmm/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Datto RMM MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/datto-rmm-v0.1.4/datto-rmm-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Datto RMM release on the [releases page](https://github.com/servosity/msp-skills/releases?q=datto-rmm).)
+[**Download Datto RMM MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/datto-rmm-v0.1.3/datto-rmm-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Datto RMM release on the [releases page](https://github.com/servosity/msp-skills/releases?q=datto-rmm).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/domotz/README.md
+++ b/skills/domotz/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Domotz MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/domotz-v0.1.2/domotz-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Domotz release on the [releases page](https://github.com/servosity/msp-skills/releases?q=domotz).)
+[**Download Domotz MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/domotz-v0.1.1/domotz-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Domotz release on the [releases page](https://github.com/servosity/msp-skills/releases?q=domotz).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/gradient/README.md
+++ b/skills/gradient/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Gradient MSP MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/gradient-v0.1.2/gradient-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Gradient MSP release on the [releases page](https://github.com/servosity/msp-skills/releases?q=gradient).)
+[**Download Gradient MSP MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/gradient-v0.1.1/gradient-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Gradient MSP release on the [releases page](https://github.com/servosity/msp-skills/releases?q=gradient).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/halopsa/README.md
+++ b/skills/halopsa/README.md
@@ -35,7 +35,7 @@ For ChatGPT, the HaloPSA MCP server is stdio - to use it with ChatGPT you expose
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download HaloPSA MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/halopsa-v0.2.14/halopsa-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every HaloPSA release on the [releases page](https://github.com/servosity/msp-skills/releases?q=halopsa).)
+[**Download HaloPSA MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/halopsa-v0.2.13/halopsa-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every HaloPSA release on the [releases page](https://github.com/servosity/msp-skills/releases?q=halopsa).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/hudu/README.md
+++ b/skills/hudu/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Hudu MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/hudu-v0.1.8/hudu-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Hudu release on the [releases page](https://github.com/servosity/msp-skills/releases?q=hudu).)
+[**Download Hudu MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/hudu-v0.1.7/hudu-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Hudu release on the [releases page](https://github.com/servosity/msp-skills/releases?q=hudu).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/huntress/README.md
+++ b/skills/huntress/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Huntress MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/huntress-v0.1.4/huntress-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Huntress release on the [releases page](https://github.com/servosity/msp-skills/releases?q=huntress).)
+[**Download Huntress MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/huntress-v0.1.3/huntress-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Huntress release on the [releases page](https://github.com/servosity/msp-skills/releases?q=huntress).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/immybot/README.md
+++ b/skills/immybot/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download ImmyBot MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/immybot-v0.1.2/immybot-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ImmyBot release on the [releases page](https://github.com/servosity/msp-skills/releases?q=immybot).)
+[**Download ImmyBot MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/immybot-v0.1.1/immybot-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ImmyBot release on the [releases page](https://github.com/servosity/msp-skills/releases?q=immybot).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/itglue/README.md
+++ b/skills/itglue/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download IT Glue MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/itglue-v0.1.2/itglue-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every IT Glue release on the [releases page](https://github.com/servosity/msp-skills/releases?q=itglue).)
+[**Download IT Glue MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/itglue-v0.1.1/itglue-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every IT Glue release on the [releases page](https://github.com/servosity/msp-skills/releases?q=itglue).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/kaseya-bms/README.md
+++ b/skills/kaseya-bms/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Kaseya BMS MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/kaseya-bms-v0.1.2/kaseya-bms-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Kaseya BMS release on the [releases page](https://github.com/servosity/msp-skills/releases?q=kaseya-bms).)
+[**Download Kaseya BMS MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/kaseya-bms-v0.1.1/kaseya-bms-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Kaseya BMS release on the [releases page](https://github.com/servosity/msp-skills/releases?q=kaseya-bms).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/knowbe4/README.md
+++ b/skills/knowbe4/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download KnowBe4 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/knowbe4-v0.1.2/knowbe4-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every KnowBe4 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=knowbe4).)
+[**Download KnowBe4 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/knowbe4-v0.1.1/knowbe4-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every KnowBe4 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=knowbe4).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/liongard/README.md
+++ b/skills/liongard/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Liongard MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/liongard-v0.1.2/liongard-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Liongard release on the [releases page](https://github.com/servosity/msp-skills/releases?q=liongard).)
+[**Download Liongard MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/liongard-v0.1.1/liongard-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Liongard release on the [releases page](https://github.com/servosity/msp-skills/releases?q=liongard).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/maxio/README.md
+++ b/skills/maxio/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Maxio MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/maxio-v0.1.2/maxio-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Maxio release on the [releases page](https://github.com/servosity/msp-skills/releases?q=maxio).)
+[**Download Maxio MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/maxio-v0.1.1/maxio-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Maxio release on the [releases page](https://github.com/servosity/msp-skills/releases?q=maxio).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/microsoft-graph/README.md
+++ b/skills/microsoft-graph/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Microsoft Graph MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/microsoft-graph-v0.2.2/microsoft-graph-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Microsoft Graph release on the [releases page](https://github.com/servosity/msp-skills/releases?q=microsoft-graph).)
+[**Download Microsoft Graph MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/microsoft-graph-v0.2.1/microsoft-graph-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Microsoft Graph release on the [releases page](https://github.com/servosity/msp-skills/releases?q=microsoft-graph).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/mspbots/README.md
+++ b/skills/mspbots/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download MSPbots MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/mspbots-v0.1.2/mspbots-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every MSPbots release on the [releases page](https://github.com/servosity/msp-skills/releases?q=mspbots).)
+[**Download MSPbots MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/mspbots-v0.1.1/mspbots-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every MSPbots release on the [releases page](https://github.com/servosity/msp-skills/releases?q=mspbots).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/n-central/README.md
+++ b/skills/n-central/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download N-able N-central MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/n-central-v0.1.2/n-central-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every N-able N-central release on the [releases page](https://github.com/servosity/msp-skills/releases?q=n-central).)
+[**Download N-able N-central MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/n-central-v0.1.1/n-central-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every N-able N-central release on the [releases page](https://github.com/servosity/msp-skills/releases?q=n-central).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/nerdio/README.md
+++ b/skills/nerdio/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Nerdio Manager MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/nerdio-v0.1.2/nerdio-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Nerdio Manager release on the [releases page](https://github.com/servosity/msp-skills/releases?q=nerdio).)
+[**Download Nerdio Manager MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/nerdio-v0.1.1/nerdio-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Nerdio Manager release on the [releases page](https://github.com/servosity/msp-skills/releases?q=nerdio).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/pagerduty/README.md
+++ b/skills/pagerduty/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download PagerDuty MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pagerduty-v0.1.2/pagerduty-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every PagerDuty release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pagerduty).)
+[**Download PagerDuty MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pagerduty-v0.1.1/pagerduty-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every PagerDuty release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pagerduty).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/pandadoc/README.md
+++ b/skills/pandadoc/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download PandaDoc MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pandadoc-v0.1.2/pandadoc-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every PandaDoc release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pandadoc).)
+[**Download PandaDoc MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pandadoc-v0.1.1/pandadoc-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every PandaDoc release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pandadoc).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/pax8/README.md
+++ b/skills/pax8/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Pax8 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pax8-v0.1.2/pax8-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Pax8 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pax8).)
+[**Download Pax8 MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pax8-v0.1.1/pax8-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Pax8 release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pax8).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/pipedrive/README.md
+++ b/skills/pipedrive/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Pipedrive MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pipedrive-v0.1.2/pipedrive-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Pipedrive release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pipedrive).)
+[**Download Pipedrive MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/pipedrive-v0.1.1/pipedrive-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Pipedrive release on the [releases page](https://github.com/servosity/msp-skills/releases?q=pipedrive).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/proofpoint/README.md
+++ b/skills/proofpoint/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Proofpoint MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/proofpoint-v0.1.2/proofpoint-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Proofpoint release on the [releases page](https://github.com/servosity/msp-skills/releases?q=proofpoint).)
+[**Download Proofpoint MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/proofpoint-v0.1.1/proofpoint-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Proofpoint release on the [releases page](https://github.com/servosity/msp-skills/releases?q=proofpoint).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/quickbooks/README.md
+++ b/skills/quickbooks/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download QuickBooks Online MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/quickbooks-v0.1.7/quickbooks-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every QuickBooks Online release on the [releases page](https://github.com/servosity/msp-skills/releases?q=quickbooks).)
+[**Download QuickBooks Online MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/quickbooks-v0.1.6/quickbooks-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every QuickBooks Online release on the [releases page](https://github.com/servosity/msp-skills/releases?q=quickbooks).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/resourceguru/README.md
+++ b/skills/resourceguru/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Resource Guru MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/resourceguru-v0.1.2/resourceguru-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Resource Guru release on the [releases page](https://github.com/servosity/msp-skills/releases?q=resourceguru).)
+[**Download Resource Guru MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/resourceguru-v0.1.1/resourceguru-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Resource Guru release on the [releases page](https://github.com/servosity/msp-skills/releases?q=resourceguru).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/rewst/README.md
+++ b/skills/rewst/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Rewst MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rewst-v0.1.2/rewst-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Rewst release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rewst).)
+[**Download Rewst MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rewst-v0.1.1/rewst-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Rewst release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rewst).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/rocketcyber/README.md
+++ b/skills/rocketcyber/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download RocketCyber MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rocketcyber-v0.1.2/rocketcyber-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every RocketCyber release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rocketcyber).)
+[**Download RocketCyber MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rocketcyber-v0.1.1/rocketcyber-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every RocketCyber release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rocketcyber).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/rootly/README.md
+++ b/skills/rootly/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Rootly MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rootly-v0.1.2/rootly-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Rootly release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rootly).)
+[**Download Rootly MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/rootly-v0.1.1/rootly-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Rootly release on the [releases page](https://github.com/servosity/msp-skills/releases?q=rootly).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/runzero/README.md
+++ b/skills/runzero/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download runZero MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/runzero-v0.1.2/runzero-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every runZero release on the [releases page](https://github.com/servosity/msp-skills/releases?q=runzero).)
+[**Download runZero MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/runzero-v0.1.1/runzero-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every runZero release on the [releases page](https://github.com/servosity/msp-skills/releases?q=runzero).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/salesbuildr/README.md
+++ b/skills/salesbuildr/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Salesbuildr MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/salesbuildr-v0.1.2/salesbuildr-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Salesbuildr release on the [releases page](https://github.com/servosity/msp-skills/releases?q=salesbuildr).)
+[**Download Salesbuildr MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/salesbuildr-v0.1.1/salesbuildr-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Salesbuildr release on the [releases page](https://github.com/servosity/msp-skills/releases?q=salesbuildr).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/sentinelone/README.md
+++ b/skills/sentinelone/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download SentinelOne MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/sentinelone-v0.1.4/sentinelone-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SentinelOne release on the [releases page](https://github.com/servosity/msp-skills/releases?q=sentinelone).)
+[**Download SentinelOne MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/sentinelone-v0.1.3/sentinelone-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SentinelOne release on the [releases page](https://github.com/servosity/msp-skills/releases?q=sentinelone).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/servosity/README.md
+++ b/skills/servosity/README.md
@@ -35,7 +35,7 @@ For ChatGPT, the Servosity MCP server is stdio - to use it with ChatGPT you expo
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Servosity MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/servosity-v0.6.2/servosity-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Servosity release on the [releases page](https://github.com/servosity/msp-skills/releases?q=servosity).)
+[**Download Servosity MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/servosity-v0.6.1/servosity-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Servosity release on the [releases page](https://github.com/servosity/msp-skills/releases?q=servosity).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/sherweb/README.md
+++ b/skills/sherweb/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Sherweb MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/sherweb-v0.1.2/sherweb-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Sherweb release on the [releases page](https://github.com/servosity/msp-skills/releases?q=sherweb).)
+[**Download Sherweb MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/sherweb-v0.1.1/sherweb-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Sherweb release on the [releases page](https://github.com/servosity/msp-skills/releases?q=sherweb).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/skykick/README.md
+++ b/skills/skykick/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download SkyKick MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/skykick-v0.1.2/skykick-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SkyKick release on the [releases page](https://github.com/servosity/msp-skills/releases?q=skykick).)
+[**Download SkyKick MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/skykick-v0.1.1/skykick-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SkyKick release on the [releases page](https://github.com/servosity/msp-skills/releases?q=skykick).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/superops/README.md
+++ b/skills/superops/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download SuperOps MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/superops-v0.1.6/superops-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SuperOps release on the [releases page](https://github.com/servosity/msp-skills/releases?q=superops).)
+[**Download SuperOps MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/superops-v0.1.5/superops-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every SuperOps release on the [releases page](https://github.com/servosity/msp-skills/releases?q=superops).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/syncro/README.md
+++ b/skills/syncro/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Syncro MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/syncro-v0.1.2/syncro-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Syncro release on the [releases page](https://github.com/servosity/msp-skills/releases?q=syncro).)
+[**Download Syncro MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/syncro-v0.1.1/syncro-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Syncro release on the [releases page](https://github.com/servosity/msp-skills/releases?q=syncro).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/tactical-rmm/README.md
+++ b/skills/tactical-rmm/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Tactical RMM MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/tactical-rmm-v0.1.2/tactical-rmm-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Tactical RMM release on the [releases page](https://github.com/servosity/msp-skills/releases?q=tactical-rmm).)
+[**Download Tactical RMM MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/tactical-rmm-v0.1.1/tactical-rmm-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Tactical RMM release on the [releases page](https://github.com/servosity/msp-skills/releases?q=tactical-rmm).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/threatlocker/README.md
+++ b/skills/threatlocker/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download ThreatLocker MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/threatlocker-v0.3.3/threatlocker-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ThreatLocker release on the [releases page](https://github.com/servosity/msp-skills/releases?q=threatlocker).)
+[**Download ThreatLocker MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/threatlocker-v0.3.2/threatlocker-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every ThreatLocker release on the [releases page](https://github.com/servosity/msp-skills/releases?q=threatlocker).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/unifi-network/README.md
+++ b/skills/unifi-network/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download UniFi MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/unifi-network-v0.1.3/unifi-network-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every UniFi release on the [releases page](https://github.com/servosity/msp-skills/releases?q=unifi-network).)
+[**Download UniFi MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/unifi-network-v0.1.2/unifi-network-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every UniFi release on the [releases page](https://github.com/servosity/msp-skills/releases?q=unifi-network).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/veeam/README.md
+++ b/skills/veeam/README.md
@@ -50,7 +50,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Veeam MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/veeam-v0.1.2/veeam-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Veeam release on the [releases page](https://github.com/servosity/msp-skills/releases?q=veeam).)
+[**Download Veeam MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/veeam-v0.1.1/veeam-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Veeam release on the [releases page](https://github.com/servosity/msp-skills/releases?q=veeam).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/wordpress/README.md
+++ b/skills/wordpress/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download WordPress MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/wordpress-v0.1.3/wordpress-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every WordPress release on the [releases page](https://github.com/servosity/msp-skills/releases?q=wordpress).)
+[**Download WordPress MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/wordpress-v0.1.2/wordpress-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every WordPress release on the [releases page](https://github.com/servosity/msp-skills/releases?q=wordpress).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/xero/README.md
+++ b/skills/xero/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Xero MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/xero-v0.1.2/xero-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Xero release on the [releases page](https://github.com/servosity/msp-skills/releases?q=xero).)
+[**Download Xero MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/xero-v0.1.1/xero-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Xero release on the [releases page](https://github.com/servosity/msp-skills/releases?q=xero).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 

--- a/skills/zammad/README.md
+++ b/skills/zammad/README.md
@@ -46,7 +46,7 @@ Big install base, but an honest heads-up: these are the **remote / enterprise** 
 
 ### Fastest for Claude Desktop - one-click `.mcpb`
 
-[**Download Zammad MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/zammad-v0.1.3/zammad-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Zammad release on the [releases page](https://github.com/servosity/msp-skills/releases?q=zammad).)
+[**Download Zammad MCP (.mcpb)**](https://github.com/servosity/msp-skills/releases/download/zammad-v0.1.2/zammad-mcp.mcpb) - then open **Claude Desktop > Settings > Extensions** and select the file. One click, no JSON, no shell. (Browse every Zammad release on the [releases page](https://github.com/servosity/msp-skills/releases?q=zammad).)
 
 Prefer the Claude Code plugin? Add the marketplace once, then install - works immediately, no directory listing required:
 


### PR DESCRIPTION
Follow-up to #301.

The revert put `server.json` back to the previous versions, but the **tags** from the failed wave survived it. `build-catalog.py` pins each skill README's one-click `.mcpb` link to the newest tag that *exists* - so 58 READMEs pointed at tags that had no release behind them:

```
before:  all pinned release URLs on main: 192 -> {200: 134, 404: 58}
         (all 58 were skill-README .mcpb links; server.json pins were already 200)
```

Deleted the 61 tags whose releases never completed - 4 of the 65 finished and are kept (`afi-v0.1.2`, `atera-v0.1.2`, `levelio-v0.1.2`, `ninjaone-v0.1.11`) - then regenerated:

```
after:   skill README .mcpb pins: 62 -> {200: 62}
```

This is exactly the gap the Codex review named and I acknowledged in #289: **tag existence is not asset existence**, and `build-catalog.py` cannot check the latter without making a network call from a generator. Pinning to the newest existing tag is still strictly better than pinning to the registry version (which is how the original 404s happened), but it inherits this weakness when a release wave leaves tags behind. The cleanup is what closes it here; the durable fix is to not leave tags behind - `check_pinned_artifacts.py --network` already detects the condition and is wired into `verify_all.sh`.

Refs #282