### PR TITLE
docs: hosted request + it-works forms for MSPs without a GitHub account

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,8 +13,8 @@ contact_links:
     about: Discussion and Build Session recordings.
 
   - name: Request a connector or send an it-works receipt without a GitHub account
-    url: https://msp-skills.compoundingteams.com/verified/
-    about: This page gives you a plain-email option - no account needed. Tell us what to build, or tell us a Skill worked against your real tenant. Plain text is fine.
+    url: https://msp-skills.compoundingteams.com/request-or-report/
+    about: Two short web forms - no account needed. Tell us what to build, or tell us a Skill worked against your real tenant. A person reads every one and files the public issue for you. Plain email works too.
 
   - name: Report a security issue privately
     url: https://github.com/Servosity/msp-skills/blob/main/SECURITY.md

--- a/docs/request-or-report.md
+++ b/docs/request-or-report.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: "Request a connector or send an it-works receipt - no GitHub account needed | MSP Skills"
+description: "Two short web forms for MSPs who do not use GitHub: ask for an MSP Skills connector for a system you run, or send an it-works receipt after a connector worked against your live tenant. A person reads every submission before it becomes a public issue, and plain email works just as well."
+permalink: /request-or-report/
+---
+
+# Request a connector, or tell us one worked
+
+Two forms, about a minute each, and neither needs a GitHub account. Use the request form to ask for a connector for a system you run. Use the receipt form after you ran a connector against your own live tenant and it did the job. A person reads every submission before anything is published, and plain email works just as well.
+
+## Request a connector
+
+Your PSA, RMM, backup, security, or M365 tool is not covered yet? Tell us which one, and what you would ask it. Requests with more MSPs behind them move up the queue, and some get co-built live in a Build Session.
+
+**[Open the request form →](https://252473a9.sibforms.com/serve/MUIFAF_1xthQoJ96lF0w8QmyhYHZ3dJ4azDJnKuWf3dgcJnE0Sf2p271Hu6rXlQcfKkN5feLSCznMIfFtmwDaWZh-o4DDD-zTIZxcHYILOOeD1zLPjg3Unthd4GjduCgINt_v2RzGBHHWngdEGEM65Xbg4g-OKSXrF7jH_8BEznOWzIK3t2GzTYpnk58jNi54zVM9d0PF2zkY1mNFw==)**
+
+It asks for the vendor name, the category, one question you would ask that system in plain English, a link to its API docs if you happen to have one, roughly how big your MSP is, and whether you would like to watch it built live. Only your email and the vendor name are required; skip anything you do not know.
+
+## Tell us a connector worked
+
+You ran a connector against your own tenant and it did the job. That is a receipt, and it is the most useful thing you can send us: a receipt from a real MSP is what flips a connector to **Live-verified** on [the receipts wall](/verified/).
+
+**[Open the it-works form →](https://252473a9.sibforms.com/serve/MUIFAGZKATvCi87szPFu2P0ozML4WjSk4glC-5q9NK-833eR0BSliyYP_52804bWZERF1fSrvhvUxma0-YU5AKx8i_OeYNF3JMoEnXbl2F45xE_Kum2jcVsFrrSOTyJeVCUed2DR7q_IrrRrIfsvLYa8cnbyrObpRSNYzOpJy6E922yhUu7gFkCuBSpgXMhZ2E0s7XJAq1eOn6ZG2g==)**
+
+It asks which connector you ran, what you ran or asked in your own words, what kind of tenant it was, and whether we may credit your MSP publicly. Only your email and the connector name are required.
+
+## What happens after you send one
+
+1. **A person reads it first.** Nothing is auto-published.
+2. **After that review it becomes a public GitHub issue** on the MSP Skills project, so other MSPs can read it, vote on it, and see the same thing you saw. We file that issue for you.
+3. **We email you if we have a question.** Your email address is not part of the public issue, and on the receipt form your MSP is named only if you ticked the credit box.
+
+## Prefer plain email
+
+Email <a href="mailto:hello@servosity.com?subject=MSP%20Skills%20request%20or%20receipt">hello@servosity.com</a> instead. For a request, name the system and one question you would ask it. For a receipt, name the connector and what you ran. Plain text is perfect: no markdown, no issue tracker, no account.
+
+## Already have a GitHub account
+
+Then file it yourself and skip the handoff. [How to request a Skill](/requesting-a-skill/) walks through the GitHub route step by step, and [the contributor guide](/contributing/) covers bug reports, small fixes, and whole connectors.

--- a/docs/requesting-a-skill.md
+++ b/docs/requesting-a-skill.md
@@ -11,6 +11,10 @@ You don't see your PSA, RMM, backup, or M365 tool listed yet? Tell us. This is t
 
 No code experience required. No terminal. No GitHub-fu. If you can fill in a web form, you can do this.
 
+## No GitHub account?
+
+You don't need one. **[Use the plain web form instead →](/request-or-report/)** It takes about a minute, a person reads it, and we file the public issue for you. That page also covers the other direction: telling us a connector already worked against your tenant. The rest of this page is the GitHub route.
+
 ## What "filing an issue" actually means
 
 A GitHub "issue" is just a public note on the project. Anyone can read it, anyone can vote (👍) it. We use the votes to rank what to build next. Filing one takes about a minute.

--- a/docs/verified.md
+++ b/docs/verified.md
@@ -37,17 +37,13 @@ Each of these passed all four mechanical gates and is ready to run. Be the first
 
 ## Tell us it worked {#receipt}
 
-You ran a connector against your tenant and it did the job. That's a receipt - and it's the single most useful thing you can send us. **No GitHub account needed.** Drop your email and which connector worked, or just email us. We'll add it to the wall and follow up if we have a question.
+You ran a connector against your tenant and it did the job. That's a receipt - and it's the single most useful thing you can send us. **No GitHub account needed.** Fill in the short form below, or just email us. We'll add it to the wall and follow up if we have a question.
 
 <div class="email-capture">
   <p class="ec-title">Send us a receipt</p>
   <p>Tell us which connector you verified against a live tenant. We'll put it on the wall.</p>
-  <!-- TODO: swap action to Brevo/HubSpot form endpoint when creds land -->
-  <form action="mailto:hello@servosity.com" method="post" enctype="text/plain">
-    <input type="email" name="email" placeholder="you@yourmsp.com" aria-label="Your work email" autocomplete="email">
-    <button type="submit">It worked - tell us</button>
-  </form>
-  <p style="margin-top:0.75rem; margin-bottom:0;">Or just email <a href="mailto:hello@servosity.com?subject=MSP%20Skills%20receipt">hello@servosity.com</a> with the connector name and your MSP. Plain text is perfect - no markdown, no issue tracker.</p>
+  <p style="margin-bottom:0.75rem;"><a class="ec-cta" href="https://252473a9.sibforms.com/serve/MUIFAGZKATvCi87szPFu2P0ozML4WjSk4glC-5q9NK-833eR0BSliyYP_52804bWZERF1fSrvhvUxma0-YU5AKx8i_OeYNF3JMoEnXbl2F45xE_Kum2jcVsFrrSOTyJeVCUed2DR7q_IrrRrIfsvLYa8cnbyrObpRSNYzOpJy6E922yhUu7gFkCuBSpgXMhZ2E0s7XJAq1eOn6ZG2g==">It worked - open the receipt form →</a></p>
+  <p style="margin-top:0.75rem; margin-bottom:0;">Or just email <a href="mailto:hello@servosity.com?subject=MSP%20Skills%20receipt">hello@servosity.com</a> with the connector name and your MSP. Plain text is perfect - no markdown, no issue tracker. <a href="/request-or-report/">What happens to a receipt after you send it →</a></p>
 </div>
 
 Want to see what these connectors actually do first? [Browse every connector →](/skills/) · [Read why MSP owners use them →](/why/) · [The Trust Center →](/governance/)

--- a/tools/maintainer/check_aeo.py
+++ b/tools/maintainer/check_aeo.py
@@ -52,6 +52,7 @@ REQUIRE_TITLE_DESC_PERMALINKS = {
     "/skills/",
     "/governance/",
     "/verified/",
+    "/request-or-report/",
     "/build-sessions/",
     "/reprint-survival/",
     "/answers/are-mcp-servers-safe-for-msp-client-data/",


### PR DESCRIPTION
## Why

The issue chooser already promises an MSP with no GitHub account a way in. Until now that link pointed at `/verified/`, whose receipt box was a `mailto:` form action (a no-op in most browsers) wrapped in a marker waiting on a form endpoint. The endpoint now exists, so the promise can be kept.

Two hosted forms are live, one per direction, each bound to its own contact list so a connector request and an it-works receipt never land in the same bucket.

## Brevo objects created

| Object | Name | Id |
| --- | --- | --- |
| Folder | MSP Skills | 74 |
| List | MSP Skills - connector requests | 75 |
| List | MSP Skills - it-works receipts | 76 |
| Form | Request a connector | `6a8f64063ab64b0770f6d1ce` (bound to list 75) |
| Form | Report: it works | `6a8f640b58ceea94e31c8e59` (bound to list 76) |

Contact attributes used: `VENDOR_NAME`, `VENDOR_CATEGORY`, `FIRST_QUESTION`, `API_DOCS_URL`, `MSP_SIZE`, `BUILD_SESSION_INTEREST` (boolean) on the request form; `CONNECTOR_SLUG`, `WHAT_YOU_RAN`, `TENANT`, `ATTRIBUTION_CONSENT` (boolean) on the receipt form. `EMAIL` is required on both; nothing else is.

No credentials appear in this PR or in the pages it adds.

## Receipts

Both public URLs were fetched and every designed label was grepped out of the returned HTML:

```
Request a connector: {"http": "200", "has_email_input": true, "has_checkbox": true,
                      "checkbox_count": 1, "bytes": 20359}
  labels missing from rendered HTML: none
  input names: API_DOCS_URL, BUILD_SESSION_INTEREST, EMAIL, FIRST_QUESTION,
               MSP_SIZE, VENDOR_CATEGORY, VENDOR_NAME
  checkbox inputs: BUILD_SESSION_INTEREST

Report: it works:    {"http": "200", "has_email_input": true, "has_checkbox": true,
                      "checkbox_count": 1, "bytes": 17302}
  labels missing from rendered HTML: none
  input names: ATTRIBUTION_CONSENT, CONNECTOR_SLUG, EMAIL, TENANT, WHAT_YOU_RAN
  checkbox inputs: ATTRIBUTION_CONSENT
```

Checkbox verdict: **both boolean fields render as real checkboxes.** They did not at first. Setting the block's `dataType` to `boolean` persists in the stored design but the hosted renderer ignores it and emits `<input type="text">`; the renderer keys off the block `type`, so a boolean attribute needs `type: "checkbox"`. That was found by probing candidate block shapes against the live serve page rather than by reading the design back, since the stored design looked correct in both cases.

## What changed on the site

- **`docs/request-or-report.md` (new)** - answers its own title in the first paragraph, links both forms, says plainly what happens next: a person reads it, then it becomes a public GitHub issue filed on the sender's behalf. Plain email to `hello@servosity.com` stays a first-class option.
- **`docs/verified.md`** - the receipt box links the hosted form instead of posting to a `mailto:` action. The plain-email line stays; the waiting-on-an-endpoint marker is gone, because the thing it was waiting for is here.
- **`.github/ISSUE_TEMPLATE/config.yml`** - the no-account contact link points at the new page instead of the receipts wall, with `about` text that says a person files the issue for you.
- **`docs/requesting-a-skill.md`** - a short section near the top for the reader who does not have a GitHub account, rather than making them read four more steps before finding out there is another way.
- **`tools/maintainer/check_aeo.py`** - the new permalink joins the pages that owe a unique title and description, so the gate covers it.

## Gates

`ci_guards.sh`, `check_vocabulary.py`, `check_aeo.py`, `check_md_links.py` all green locally. `check_no_todos.py` also green.

## Follow-up, not in this PR

The **Brevo to GitHub bridge poller** (reading list ids 75 and 76, surfacing each submission for human review, then filing the public issue) is the named next piece. Until it exists, submissions land in the two lists and a person moves them across by hand, which is exactly what the page promises and no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
