### PR TITLE
docs(agents): a tag is no longer a release receipt under immutable releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,50 @@ and posts the result as an issue comment. It is **advisory** - nothing gates on
 it. Whoever decides should record the decision in a reply on that issue so the
 next agent does not re-litigate it.
 
+## What counts as released (READ THIS BEFORE YOU CUT OR TRUST A TAG)
+
+A tag is necessary and no longer sufficient. This repository has GitHub
+**immutable releases** enabled: a published release is sealed the instant it
+exists and can never take another asset (`gh release upload` answers
+`HTTP 422: Cannot upload assets to an immutable release`). So `release.yml`
+assembles the entire artifact set into a **DRAFT**, asserts it is complete, and
+publishes last. Three consequences an agent has to hold:
+
+1. **A pushed tag STARTS a release; only the seal finishes one.** A failed build
+   target leaves a stranded DRAFT - invisible to installers, invisible to
+   `release_state.py`, and easily mistaken for either success or "no release
+   happened". The completion criterion is: published (not draft), asset set
+   complete.
+
+2. **A tag push runs `release.yml` from the TAGGED commit.** Tagging a commit
+   that predates the draft-then-seal ordering runs that commit's publish-first
+   workflow, which seals an empty release and burns the version number
+   permanently. Tag only a SHA on current `main`, one tag per push, and never
+   `git push --tags` (it pushes stale local tags, and more than three tags in a
+   single push fires no workflow run at all). Never delete a release and re-cut
+   the same version - bump instead.
+
+3. **Only a network check is a release receipt.** `check_pinned_artifacts.py
+   --no-network` proves the TAG exists and nothing more, so it stays green over a
+   stranded draft and over a published-but-incomplete release (it was green over
+   `auvik-v0.1.1`, which carries 16 of its 25 assets). Use:
+
+   ```bash
+   # per tag - the two facts that matter, then the derived asset-set check
+   gh release view <tag> --json isDraft,assets -q '"draft=\(.isDraft) assets=\(.assets|length)"'
+   gh release view <tag> --json assets \
+     | python3 tools/maintainer/check_release_assets.py --tag <tag> --with-mcpb
+
+   # fleet - every pinned download URL resolves to a published asset
+   python3 tools/maintainer/check_pinned_artifacts.py --network
+
+   # sweep for releases that never finished (expect no output)
+   gh api repos/Servosity/msp-skills/releases --paginate -q '.[] | select(.draft) | .tag_name'
+   ```
+
+   A tag listed by that last sweep is a release that never finished: re-run the
+   Release workflow for it while its draft is still mutable.
+
 ## General
 
 - Sign commits (`git commit -s`); no em-dashes in committed files; run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ python3 tools/maintainer/check_engine_freshness.py --slug <slug>
    A tree-only fix reaches nobody: on 2026-08-16, 41 of 61 connectors were
    shipping binaries built before the 4.24 engine upgrade that had been sitting
    in `main` since June. `main` being current is not evidence that any user is
-   running current code - only a tag is.
+   running current code. Neither is a tag, since immutable releases landed: a tag
+   can sit in front of a stranded draft or a permanently sealed, incomplete
+   release. The evidence is a PUBLISHED release carrying its complete asset set -
+   see "What counts as released" below.
 
    This question is answered by `release_state.classify()`, which compares a
    freshly computed CLI hash against `cli_hash_at_release`. Do **not** answer it
@@ -108,10 +111,23 @@ publishes last. Three consequences an agent has to hold:
 2. **A tag push runs `release.yml` from the TAGGED commit.** Tagging a commit
    that predates the draft-then-seal ordering runs that commit's publish-first
    workflow, which seals an empty release and burns the version number
-   permanently. Tag only a SHA on current `main`, one tag per push, and never
-   `git push --tags` (it pushes stale local tags, and more than three tags in a
-   single push fires no workflow run at all). Never delete a release and re-cut
-   the same version - bump instead.
+   permanently. "A SHA on current `main`" is NOT the precondition and never was -
+   `main` carried the publish-first workflow for as long as it took this fix to
+   land, and it is the SHA's own `release.yml` that decides. Ask the probe, which
+   reads the workflow at that commit and names the requirement it fails:
+
+   ```bash
+   python3 tools/maintainer/check_release_pipeline.py --sha <SHA>   # exit 0 = safe to tag
+   ```
+
+   Do not substitute `git show <SHA>:.github/workflows/release.yml | grep
+   -- '--draft'` for it. That grep is satisfied by any commit that merely
+   mentions the flag, and it cannot see the other four requirements (one sealing
+   job, every uploader inside its `needs:` closure, the completeness gate running
+   before the seal, the `.mcpb` inside the sealing contract). Then: one tag per
+   push, and never `git push --tags` (it pushes stale local tags, and more than
+   three tags in a single push fires no workflow run at all). Never delete a
+   release and re-cut the same version - bump instead.
 
 3. **Only a network check is a release receipt.** `check_pinned_artifacts.py
    --no-network` proves the TAG exists and nothing more, so it stays green over a


### PR DESCRIPTION
## Why

`AGENTS.md` told agents:

> `main` being current is not evidence that any user is running current code - only a tag is.

Immutable releases falsified the second half. `release.yml` (after #313) assembles the whole artifact set into a **DRAFT** and publishes last, because a published release is sealed the instant it exists and answers every further upload with `HTTP 422: Cannot upload assets to an immutable release`. A failed build target therefore leaves a stranded DRAFT: the tag exists, `release_state.py` is satisfied, and nothing is installable. **A tag is necessary and no longer sufficient.**

Nothing in the repo told an agent that, and nothing told anyone to look for stranded drafts.

## What this adds

One new `AGENTS.md` section, `## What counts as released`, covering:

1. **The completion criterion** - published (not draft), asset set complete. A pushed tag starts a release; only the seal finishes one.
2. **The two tagging hazards immutability creates** - a tag push runs `release.yml` **from the tagged commit**, so tagging a commit that predates draft-then-seal runs the old publish-first flow and permanently seals an empty release on a version number that can no longer be reused. Plus: one tag per push, never `git push --tags` (stale tags, and >3 tags in one push fires no workflow run at all), and never delete-and-re-cut a version - bump.
3. **The honest receipt** - `check_pinned_artifacts.py --no-network` proves only that the TAG exists, so it goes green over a stranded draft and over a published-but-incomplete release. The network check, the per-tag `isDraft` check, the derived asset-set check, and the stranded-draft sweep.

## Receipts (verified against the live repo, not asserted)

- **Asset set is 25, derived not assumed:** `registry.TARGETS` is 6; `release.yml` uploads 4 files per target; `check_release_assets.py` requires `len(TARGETS) * 4 + 1`. `zammad-v0.1.3` carries exactly 25 - 12 cli + 12 mcp files including `.sha256` sidecars, plus one `.mcpb`.
- **`--no-network` is a false-green, proven both directions:** on `auvik-v0.1.1` the offline question ("does the tag exist?") is GREEN, while the network question ("is the release published with its full asset set?") is RED at 16 of 25.
- **272 releases surveyed; 3 published-but-incomplete** (`auvik-v0.1.1` 16, `servosity-v0.1.0` 24, `halopsa-v0.1.0` 24). All predate immutability; each is now unrepairable in place.
- **Stranded-draft sweep proven both directions:** it prints `stranded-v0.1.9` from a listing containing a draft and prints nothing from one without. Against the live repo today it prints nothing - no drafts stranded.
- **The tag-SHA safety check proven both directions:** `git show <SHA>:.github/workflows/release.yml | grep -q -- '--draft'` finds 0 matches at pre-#313 `main` (`04b855ad1` - REFUSE) and 3 at #313's head (`10ab58ba7` - safe to tag).

## Scope

Docs only - one file, `AGENTS.md`. Touches no connector directory, so it adds **no build rows**.

## Merge order

Depends on **#313** for `tools/maintainer/check_release_assets.py`, which this references. Merge after #313.

## Companion changes outside the repo

The same audit corrected the skills that teach the release flow (they live under `~/.claude/skills/`, outside this repo, so they cannot be part of this PR): `msp-skills-publish` (release-queue reference, SKILL.md, scaffold-many reference), `issue-triage` (release-mechanics, SKILL.md, `execute_fix.sh`), `msp-factory` (which told operators to `git push --tags`), `gh-loop`, `submit-to-marketplaces` (whose release gate accepted a stranded draft and would have written a dead link into a public directory), and the `gstack` review checklist (which recommended `gh release delete` before `gh release create`).
