### PR TITLE
docs(contributing): the it-works door now says where Thursday is

### DIFF
--- a/.github/ISSUE_TEMPLATE/it-works.yml
+++ b/.github/ISSUE_TEMPLATE/it-works.yml
@@ -136,3 +136,9 @@ body:
       options:
         - label: I ran this against a real tenant (not a demo / sandbox).
           required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Want a hand live?** Bring it to a [Build Session](https://compoundingteams.com/build-sessions) - free, weekly, Thursdays. We debug real tenants on the call. Recordings and discussion live in the [community](https://ai-accelerator-233a51.circle.so/join).

--- a/.github/workflows/live-verified.yml
+++ b/.github/workflows/live-verified.yml
@@ -239,7 +239,7 @@ jobs:
           ISSUE: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          gh issue comment "$ISSUE" --body "Thank you for closing the loop. **$SLUG** is now badged **live-verified**. See the updated skill page: https://msp-skills.compoundingteams.com/skills/$SLUG/"
+          gh issue comment "$ISSUE" --body "Thank you for closing the loop. **$SLUG** is now badged **live-verified**. See the updated skill page: https://msp-skills.compoundingteams.com/skills/$SLUG/"$'\n\n'"Want a hand live? Bring it to a Build Session - free, weekly, Thursdays: https://compoundingteams.com/build-sessions"
 
   # A live-verified badge is the moment this connector becomes worth keeping
   # current: a real tenant exists, and someone is finally positioned to notice a


### PR DESCRIPTION
## What

- `it-works.yml`: adds the same closing markdown block `bug-report.yml` already carries (Build Session pointer + community link). It sits after the confirmation checkbox, outside the `id: skill` options block, so `build-catalog.py` does not touch it (ran the generator: no drift).
- `live-verified.yml`: the automated thank-you comment gains one plain line pointing at Thursday. Not conditional on anything.

## Why

Across all 53 outside issues and PRs in this repo's history, zero maintainer or automated replies ever pointed a contributor at a Build Session. The it-works form is the lowest-friction door on the contributor ladder and was the only form with no next step.

## Related, already done outside this PR

The workflow above gates on `confirmed-works` + `live-verified-report`. Neither label existed, so it skipped on all 22 runs to date. Both labels were created today and the five historical `[Works]` issues (#116, #139, #140, #144, #145) now carry `live-verified-report`. The next real it-works report is the first live test of the flip.

Does not touch the connector dropdown, so it is independent of #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5hXLRZvTVHmdRDx1uujKc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added invitations to free weekly Build Sessions in the issue reporting template and live verification comment.
  * Included links to the Build Sessions page and community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->