### PR TITLE
fix(release): stamp the version into the MCP binary, not just the CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,12 +336,14 @@ jobs:
           fi
 
           # $version (derived above as ${TAG##*-v}) is stamped into the CLI,
-          # matching the prior goreleaser config.
+          # matching the prior goreleaser config, and into the MCP server's
+          # `var version` (package main) so serverInfo.version stops reporting
+          # 0.0.0-dev on every release (#322).
           mkdir -p "$GITHUB_WORKSPACE/dist"
           (
             cd "${{ matrix.skill.dir }}"
             go build -trimpath -ldflags "-s -w -X ${{ matrix.skill.module }}/internal/cli.version=${version}" -o "$GITHUB_WORKSPACE/dist/${cli}" "${{ matrix.skill.cli_cmd }}"
-            go build -trimpath -ldflags "-s -w" -o "$GITHUB_WORKSPACE/dist/${mcp}" "${{ matrix.skill.mcp_cmd }}"
+            go build -trimpath -ldflags "-s -w -X main.version=${version}" -o "$GITHUB_WORKSPACE/dist/${mcp}" "${{ matrix.skill.mcp_cmd }}"
           )
 
           cd "$GITHUB_WORKSPACE/dist"


### PR DESCRIPTION
Refs #322 (stays open as the rollout tracker; it closes when the last connector re-releases past this change).

`release.yml` line 343 bakes `$version` into the CLI build; line 344 built the MCP server with no `-X`, so every released MCP binary reported `serverInfo.version` as `0.0.0-dev`. This adds `-X main.version=${version}` to the MCP build.

63 MCP mains declare `var version` in package main (62 as `"0.0.0-dev"`; unifi-network as `"2026.8.1"`, which `-X` now overrides to the tag version - an improvement). The three that hard-code a literal instead of declaring the variable - **aws-billing** (`1.0.0`), **immybot** (`0.0.0-dev`), **riverside-fm** (`1.0.0`) - are NOT fixed by this flag: the Go linker silently ignores `-X` for a symbol that does not exist, and the build stays green. They get a 2-line hand-fix plus a `handfixes.json` entry in the fleet PR that follows.

**Second commit: a run-the-binary receipt.** A green build was never proof of the version - that is how a green release shipped `serverInfo.version 1.0.0` on an `aws-billing-v0.1.3` tag with nothing in the pipeline able to notice. On the one matrix row that can execute what it built (linux/amd64 on ubuntu-latest), the `Build and upload` step now runs both freshly built binaries after `go build` and before the checksums: the last word of `<cli> --version` must equal `$version` exactly, and one JSON-RPC `initialize` piped into `<mcp>` must answer with `result.serverInfo.version == $version`. Both run under a scoped throwaway `HOME` (removed via an EXIT trap) and `timeout -k 2 10`; the reply is parsed by a python heredoc that takes the reply path and expected version as argv, never as program text. Cross-compiled rows are unchanged. Proven locally: hudu built with `9.9.9` passes; a wrong expected version fails; aws-billing's literal `1.0.0` fails (the exact #322 shape); a server that never answers times out and fails. Codex adversarial review: one P0 (substring match) and two P2s, all cured; second pass APPROVE.

Reported by @geekbrownbear in #282. Takes effect on the next release of each connector; no rebuild is triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5hXLRZvTVHmdRDx1uujKc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP server releases now report the correct release version instead of displaying the development version.
  * Release builds now verify that both the CLI and MCP server report the expected version, helping prevent incorrectly versioned binaries from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also in this PR: the companion CLI ships inside the `.mcpb` (refs #331, #287)

Every MCP tool shells out to `<slug>-cli`, but the bundle carried only the MCP server, so a Claude Desktop-only install failed at the first tool call with "companion CLI binary not found". The bundle job now downloads the CLI assets too and `tools/maintainer/mcpb_bundle.py` lays the archive out per OS with bare sibling names (`bin/darwin/<slug>-mcp` + `bin/darwin/<slug>-cli`, both universal; `bin/linux/`; `bin/win32/*.exe`), which the existing sibling lookup finds with no manifest change. The validator now requires the companion beside every declared server, rejects path traversal and mixed layouts, and still accepts the sealed flat-layout bundles so `mcp-publish` re-validation of older tags keeps working. Proven with a Desktop-like stdio harness on a rebuilt hudu-v0.1.10 bundle: with the CLI present `workflow_status` returns a real result on macOS and Linux (Docker); with it removed the same call fails with the "companion CLI binary not found" text. Bundle size 32 MB to 49 MB. linux-arm64 is dropped from the bundle because the MCPB manifest has no architecture selector (the raw release asset is unchanged). Bundles change only at each connector's next tag; sealed bundles are never touched.
