### PR TITLE
ci(economy): build only what a push changed; catalog truth from complete published releases

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -11,44 +11,83 @@ on:
       - "tools/maintainer/check_marketplace_sync.py"
       - ".claude-plugin/marketplace.json"
       - ".github/workflows/catalog.yml"
+      - ".github/ISSUE_TEMPLATE/it-works.yml"
+      - ".github/ISSUE_TEMPLATE/bug-report.yml"
   push:
     branches: [main]
-    # Tag pushes too: docs/_data/pending.json is DERIVED FROM TAGS (release
-    # state), so it goes stale the moment a release tag lands even though no
-    # commit touched the tree. On main/tag events this workflow regenerates
-    # and auto-commits; only PRs get a hard drift gate (and only for the
-    # tree-derived files).
-    tags: ["*-v*.*.*"]
+  # A release, once it has actually FINISHED. docs/_data/pending.json and the
+  # per-skill README .mcpb pins are derived from release state, so they go
+  # stale the moment a release seals even though no commit touched the tree.
+  # This used to be `push: tags:`, which fires the instant a tag lands -
+  # BEFORE release.yml has built a single asset - so for the minutes a release
+  # took, and forever over a stranded draft, pending.json read "up-to-date"
+  # and the README linked a download that 404s. workflow_run fires when
+  # release.yml completes; the job gate below runs only when it SUCCEEDED, so
+  # a failed release regenerates nothing and main keeps the last true state.
+  # The regenerate step then reads the PUBLISHED release list from the API,
+  # not `git tag`, and admits only releases whose asset set is COMPLETE, so a
+  # tag that fronts a draft or a sealed-but-partial release reads as pending.
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  # A release taken AWAY. Deleting a published release (the tag stays) or
+  # unpublishing it back to a draft changes neither main nor a Release run,
+  # so nothing above would ever notice; pending.json would say up-to-date
+  # and the README would link a download that is gone. AGENTS.md forbids
+  # deleting a release (bump instead), which is exactly why the one time it
+  # happens must not go unreconciled.
+  release:
+    types: [deleted, unpublished]
+  # Weekly reconciliation for any event the above missed (a workflow_run
+  # that never fired, an API hiccup that failed a run). Idempotent: with
+  # nothing changed it commits nothing. Offset from ci.yml's Sunday 06:00
+  # sweep so the two do not queue on the same runners.
+  schedule:
+    - cron: "30 6 * * 0"
 
 permissions:
   contents: write
 
-# Serialize this workflow's push/tag runs (the derived-file auto-committers)
-# under one group so two release tags landing seconds apart queue instead of
-# racing non-fast-forward. live-verified.yml deliberately does NOT share this
-# group: its runs are per-issue and NOT interchangeable (GitHub keeps only one
-# pending run per group and replaces older queued runs - fine for idempotent
-# full-regenerations like these, lossy for badge flips). Cross-workflow races
-# are handled by both sides' regenerate-on-top push-retry loops instead. PR runs get a per-PR group instead: they only
-# read (drift gate), and a global group would wrongly serialize unrelated PR
-# checks (GitHub keeps at most ONE pending run per group, replacing older queued
-# runs). cancel-in-progress stays false: each writer run regenerates from the
-# LATEST tree+tags (idempotent, not delta-based), so a queued run is still
-# useful, and the one-pending-run replacement is harmless for the same reason -
-# whichever queued run survives produces the correct end state.
+# Serialize this workflow's main/workflow_run runs (the derived-file
+# auto-committers) under one group so two releases sealing seconds apart queue
+# instead of racing non-fast-forward. live-verified.yml deliberately does NOT
+# share this group: its runs are per-issue and NOT interchangeable (GitHub keeps
+# only one pending run per group and replaces older queued runs - fine for
+# idempotent full-regenerations like these, lossy for badge flips). Cross-workflow
+# races are handled by both sides' regenerate-on-top push-retry loops instead.
+# PR runs get a per-PR group instead: they only read (drift gate), and a global
+# group would wrongly serialize unrelated PR checks (GitHub keeps at most ONE
+# pending run per group, replacing older queued runs). cancel-in-progress stays
+# false: each writer run regenerates from the LATEST tree + published releases
+# (idempotent, not delta-based), so a queued run is still useful, and the
+# one-pending-run replacement is harmless for the same reason - whichever queued
+# run survives produces the correct end state.
+#
+# ...which holds only for runs that WRITE. A workflow_run event from a FAILED
+# Release is skipped by the job gate below, so it must not enter the writer
+# group: GitHub replaces the older pending run with the newer one, and a
+# skipped run replacing a queued writer (say, the run for release B, queued
+# behind an active run that listed releases before B sealed) would leave B
+# absent from the derived files until the next unrelated push. Each such
+# event gets a group of its own instead and displaces nothing.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('catalog-pr-{0}', github.event.pull_request.number) || 'main-autocommit' }}
+  group: ${{ github.event_name == 'pull_request' && format('catalog-pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' && format('catalog-skipped-{0}', github.run_id)) || 'main-autocommit' }}
   cancel-in-progress: false
 
 jobs:
   catalog:
     runs-on: ubuntu-latest
+    # A Release that failed (a stranded draft, a missing build target) must not
+    # regenerate: the derived files on main already say "pending" for it, and
+    # that is the truth until the release is re-run and seals.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # release_state.py derives per-skill release state from git tags;
-          # a shallow tagless checkout would misreport version-pending.
+          # build-catalog.py falls back to git tags when no published-release
+          # list is given (the PR drift gate); a shallow tagless checkout would
+          # leave every .mcpb pin untouched and the drift gate blind to it.
           fetch-depth: 0
           fetch-tags: true
           # Push derived-file commits as the repo admin (fine-grained PAT) so they
@@ -68,36 +107,94 @@ jobs:
 
       - name: Drift gate (pull requests - tree-derived files only)
         if: github.event_name == 'pull_request'
+        # NOT gated here: skills/*/README.md. Its .mcpb pin is derived from
+        # RELEASE state (the newest published tag), not from the tree, and a PR
+        # checkout's tag set is whatever this runner fetched - so a contributor
+        # with a stale fork, or a PR racing a release, would fail on a file
+        # they never touched. The main writer path below owns those pins.
+        # pending.json is release-derived too and is likewise not gated.
         run: |
           python3 tools/maintainer/build-catalog.py
+          gated=(catalog.json README.md docs/_data/catalog.json docs/skills/
+                 .github/ISSUE_TEMPLATE/it-works.yml .github/ISSUE_TEMPLATE/bug-report.yml)
           # status --porcelain (not diff) so newly GENERATED files (e.g. a new
           # skill's docs page) count as drift too - git diff ignores untracked.
-          if [ -n "$(git status --porcelain -- catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md')" ]; then
-            git status --porcelain -- catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md'
+          if [ -n "$(git status --porcelain -- "${gated[@]}")" ]; then
+            git status --porcelain -- "${gated[@]}"
             echo ""
-            echo "::error::catalog.json, the README, docs/_data/catalog.json, or a docs/skills page is stale."
+            echo "::error::catalog.json, the README, docs/_data/catalog.json, a docs/skills page, or an issue-form connector dropdown is stale."
             echo "::error::Run 'python3 tools/maintainer/build-catalog.py' locally and commit."
             exit 1
           fi
-          # pending.json is tag-derived and auto-committed on main; not gated here.
 
-      - name: Regenerate + auto-commit derived files (main + tags)
-        if: github.event_name == 'push'
+      - name: Regenerate + auto-commit derived files (main + published releases)
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Tag pushes check out a detached tag ref; derived files live on main.
+          set -euo pipefail
+          # workflow_run and schedule check out the default branch and a
+          # `release` event checks out the tagged commit; say it explicitly
+          # either way: derived files live on main and only main.
           git checkout -B main origin/main
-          python3 tools/maintainer/build-catalog.py
-          python3 tools/maintainer/build-llms.py
-          mkdir -p docs/_data
-          python3 tools/maintainer/release_state.py --json > docs/_data/pending.json
-          if [ -z "$(git status --porcelain -- catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md' docs/llms.txt docs/llms-full.txt docs/_data/pending.json)" ]; then
+
+          # The set of files this job owns. One list, used by the sync check,
+          # the add, and the retry loop, so the three can never disagree.
+          derived=(catalog.json README.md docs/_data/catalog.json docs/skills/
+                   ':(glob)skills/*/README.md' docs/llms.txt docs/llms-full.txt
+                   docs/_data/pending.json
+                   .github/ISSUE_TEMPLATE/it-works.yml .github/ISSUE_TEMPLATE/bug-report.yml)
+          listing="$RUNNER_TEMP/releases.ndjson"
+          released="$RUNNER_TEMP/released-tags.txt"
+
+          # The PUBLISHED release list, from the API - never `git tag` - and
+          # then only the releases whose asset set is COMPLETE under the same
+          # contract release.yml seals with (check_release_assets.py, .mcpb
+          # included). With immutable releases a tag can front a stranded
+          # draft, an empty sealed release, or a sealed release missing a
+          # build target (auvik-v0.1.1 is public with 16 of 25 assets); an
+          # admitted tag becomes a README download link, so "published" alone
+          # is not the bar. FATAL on any failure or an empty answer:
+          # regenerating from git tags would write the exact false-green
+          # state this trigger exists to prevent, while leaving main's
+          # last-good derived files in place costs nothing (the next run
+          # regenerates from scratch).
+          fetch_released() {
+            if ! gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --paginate \
+                 -q '.[] | select(.draft|not) | {tag_name, assets: [.assets[] | {name, size, state}]}' > "$listing"; then
+              echo "::error::could not list published releases; not regenerating release-derived files"
+              exit 1
+            fi
+            if ! python3 tools/maintainer/check_release_assets.py --admit-published < "$listing" > "$released"; then
+              echo "::error::the release listing could not be read; not regenerating release-derived files"
+              exit 1
+            fi
+            if [ ! -s "$released" ]; then
+              echo "::error::no complete published release was admitted; refusing to regenerate from an empty list"
+              exit 1
+            fi
+            echo "complete published releases admitted: $(wc -l < "$released")"
+          }
+          regenerate() {
+            python3 tools/maintainer/build-catalog.py --released-tags "$released"
+            python3 tools/maintainer/build-llms.py
+            mkdir -p docs/_data
+            python3 tools/maintainer/release_state.py --json --released-tags "$released" > docs/_data/pending.json
+          }
+          commit_derived() {
+            git add "${derived[@]}"
+            git commit -s -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+          }
+
+          fetch_released
+          regenerate
+          if [ -z "$(git status --porcelain -- "${derived[@]}")" ]; then
             echo "derived files already in sync - nothing to commit"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md' docs/llms.txt docs/llms-full.txt docs/_data/pending.json
-          git commit -s -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+          commit_derived
           # Push with a self-heal loop: the concurrency group serializes the
           # common case, but a peer commit can still land between our checkout
           # and our push (e.g. a release_batch push). Derived files are
@@ -109,21 +206,19 @@ jobs:
               exit 0
             fi
             echo "push rejected (attempt $attempt) - refetch and regenerate on top"
-            # --tags matters: pending.json is DERIVED FROM TAGS, and the peer
-            # commit that beat us may have been a release whose tag we have not
-            # fetched yet - regenerating from stale tags would overwrite the
-            # newer state that just landed.
+            # Refetch tags AND re-list published releases: the peer that beat
+            # us may have been a release that sealed since we last asked, and
+            # regenerating from a stale list would overwrite the newer state
+            # that just landed.
             git fetch --force --tags origin main
             git reset --hard origin/main
-            python3 tools/maintainer/build-catalog.py
-            python3 tools/maintainer/build-llms.py
-            python3 tools/maintainer/release_state.py --json > docs/_data/pending.json
-            if [ -z "$(git status --porcelain -- catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md' docs/llms.txt docs/llms-full.txt docs/_data/pending.json)" ]; then
+            fetch_released
+            regenerate
+            if [ -z "$(git status --porcelain -- "${derived[@]}")" ]; then
               echo "now in sync after peer commit - nothing left to push"
               exit 0
             fi
-            git add catalog.json README.md docs/_data/catalog.json docs/skills/ ':(glob)skills/*/README.md' docs/llms.txt docs/llms-full.txt docs/_data/pending.json
-            git commit -s -m "chore: regenerate derived files (catalog/llms/pending) [bot]"
+            commit_derived
           done
           echo "::error::could not push derived files after 5 attempts"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,32 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Weekly FULL-matrix sweep. Pushes to main build only the skills the push
+  # changed (see `prepare`), so this is the bound on anything scoping could
+  # miss: a toolchain or module-cache drift, a base SHA the runner could not
+  # resolve, a registry edit that touched nothing under skills/. Sunday 06:00
+  # UTC is the quietest hour for the org's runner pool.
+  schedule:
+    - cron: "0 6 * * 0"
+  # The same sweep on demand (after a mis-scoped push, or to re-prove the fleet
+  # before a release wave). No inputs: dispatch = full matrix.
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+# PR runs supersede each other: a new push to the same PR cancels the run for
+# the commit it just replaced (nobody is waiting on that verdict). Every other
+# run is keyed by its own run id, so main pushes are NEVER cancelled or
+# coalesced: `prepare` diffs each push against its own github.event.before, so
+# a run dropped in favour of a newer one would leave its change-set built by
+# nobody - the newer run's `before` starts where the dropped push ended. Not
+# keyed by SHA either: two force-pushes landing on the same commit have
+# different `before`s and different matrices, and GitHub replaces a PENDING
+# run in a group even with cancel-in-progress off.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-{0}-{1}', github.event_name, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   guards:
@@ -114,6 +137,16 @@ jobs:
         #                       five malformed ledgers raise rather than reading
         #                       as "nothing is burned", while a missing one
         #                       correctly reads as empty.
+        #   release_matrix.py - the change-set classifier that decides which
+        #                       skills a push or PR builds. A bot regen commit
+        #                       (pending.json + .mcpb pin re-mints in skill
+        #                       READMEs) yields an EMPTY matrix; a human edit
+        #                       to the same README, a Go change, or a per-slug
+        #                       skills.json edit yields that skill's row; a
+        #                       matrix-row checker or a build-feeding workflow
+        #                       yields the FULL matrix; catalog.yml and the
+        #                       docs site yield nothing. Every case is asserted
+        #                       in both directions, offline.
         run: |
           set -euo pipefail
           python3 tools/maintainer/registry.py --self-test
@@ -121,6 +154,7 @@ jobs:
           python3 tools/maintainer/mcpb_bundle.py --self-test
           python3 tools/maintainer/check_release_assets.py --self-test
           python3 tools/maintainer/check_release_pipeline.py --self-test
+          python3 tools/maintainer/release_matrix.py --self-test
 
       - name: Skill contract (frontmatter + required files)
         run: python3 tools/maintainer/check_skill_contract.py
@@ -141,29 +175,6 @@ jobs:
 
       - name: Markdown local links
         run: python3 tools/maintainer/check_md_links.py
-
-      - name: Pinned release URLs resolve (tag cut, or an in-flight release)
-        # check_md_links.py skips http(s) entirely, so nothing verified that the
-        # version-pinned .mcpb identifiers and release links this repo publishes
-        # point at a tag that exists. On 2026-08-25 seventy of them did not: a
-        # version bump rewrites the pin, the tag is cut by hand afterwards, and
-        # skipping that step leaves main serving a 404 forever.
-        #
-        # BASE is what makes this checkable without failing every release
-        # commit: a pin that is NEW or MOVED in this change-set is an in-flight
-        # release (allowed, with a reminder), a pin byte-identical to BASE whose
-        # tag still does not exist is a release that was never cut (failure).
-        # On a push BASE must be github.event.before, NOT origin/main: the
-        # runner's origin/main already contains the push. The checkout above is
-        # fetch-depth: 0, so every tag is local and no network call is made.
-        env:
-          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        # Hard gate. The backlog this shipped in warn mode for - 62 pins across
-        # 31 connectors whose releases were never cut - was cleared by the
-        # 65-tag push on 2026-08-26. All 192 pinned release URLs across 128
-        # files now resolve, verified by HTTP HEAD against every one of them, so
-        # any new finding here is a new defect and should block.
-        run: python3 tools/maintainer/check_pinned_artifacts.py --base "$BASE" --no-network
 
       - name: Manifest env schema matches the binaries' reads
         # Asserts every operator-facing env var a connector READS is declared in
@@ -267,13 +278,66 @@ jobs:
             claude plugin validate "skills/$(basename "$d")" --strict
           done
 
+  # Its own job, deliberately. This check is RED BY DESIGN for the window
+  # between a version-bump merge and the hand-cut tag that makes its pins real
+  # (and for the whole life of a release that was never cut). While it was a
+  # step inside `guards`, that red skipped every step after it - env schema,
+  # MCP registry, install docs, DCO, ShellCheck, gitleaks, plugin validate: a
+  # dozen unrelated gates silently not run on exactly the commits that most
+  # need them. Here it can only ever fail itself.
+  pins:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # every tag local, BASE resolvable, no network call
+
+      - name: Pinned release URLs resolve (tag cut, or an in-flight release)
+        # check_md_links.py skips http(s) entirely, so nothing verified that the
+        # version-pinned .mcpb identifiers and release links this repo publishes
+        # point at a tag that exists. On 2026-08-25 seventy of them did not: a
+        # version bump rewrites the pin, the tag is cut by hand afterwards, and
+        # skipping that step leaves main serving a 404 forever.
+        #
+        # BASE is what makes this checkable without failing every release
+        # commit: a pin that is NEW or MOVED in this change-set is an in-flight
+        # release (allowed, with a reminder), a pin byte-identical to BASE whose
+        # tag still does not exist is a release that was never cut (failure).
+        # On a push BASE must be github.event.before, NOT origin/main: the
+        # runner's origin/main already contains the push. The checkout above is
+        # fetch-depth: 0, so every tag is local and no network call is made.
+        # On the weekly sweep and on workflow_dispatch there is no base; the
+        # script says so and skips the tag-existence check rather than
+        # inventing one.
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        # Hard gate. The backlog this shipped in warn mode for - 62 pins across
+        # 31 connectors whose releases were never cut - was cleared by the
+        # 65-tag push on 2026-08-26. All 192 pinned release URLs across 128
+        # files now resolve, verified by HTTP HEAD against every one of them, so
+        # any new finding here is a new defect and should block.
+        run: python3 tools/maintainer/check_pinned_artifacts.py --base "$BASE" --no-network
+
   # Skill build matrix is computed from the repo, so a new skill is built+vetted
-  # with no edit here (mirrors the release workflow). On PRs the matrix is
-  # SCOPED to skills changed since the merge-base (a docs/tools PR builds zero
-  # skills; a one-skill PR builds one) - at fleet scale (50+ skills) an
-  # unscoped matrix would spawn 50+ build jobs on every PR. Pushes to main
-  # keep the FULL matrix as the post-merge safety net, and release_matrix.py
-  # fails open to the full matrix when build machinery itself changed.
+  # with no edit here (mirrors the release workflow). The matrix is SCOPED to
+  # the skills the change-set touched: on a PR that is the diff against the
+  # merge-base; on a push to main it is the two-point diff from
+  # github.event.before, the tip main had before the push, to HEAD - exactly
+  # what the push changed, including what a force-push took away. At fleet
+  # scale (65 skills) an unscoped matrix is 65 jobs and ~210-240 runner-minutes
+  # per run, and before 2026-09-07 every push to main paid it: the catalog
+  # bot's "regenerate derived files" commits (11 in one day, docs only) each
+  # burned a full matrix, and during a 21-tag release wave those runs pinned
+  # the org's runner pool (59 of 60 busy, 232 queued) so the RELEASE builds
+  # starved.
+  #
+  # release_matrix.py classifies the change-set (see its MACHINERY / DERIVED
+  # lists and --self-test): derived files the bot commits yield NO row, a
+  # human edit to a skill yields that skill's row, and a change to build
+  # machinery yields the FULL matrix. It fails open (full matrix) whenever the
+  # diff cannot be computed. The full matrix also runs on the weekly schedule
+  # and on workflow_dispatch, which is what bounds the scoping.
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -283,16 +347,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # need history for merge-base on PRs
+          fetch-depth: 0 # need history for the merge-base (PRs) and `before` (pushes)
       - name: Compute skill matrix
         id: gen
         env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          # PRs: the merge base. Pushes: github.event.before. Anything else
+          # (schedule, workflow_dispatch) has no base and builds everything.
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before) || '' }}
         run: |
           set -euo pipefail
-          if [ -n "$BASE_SHA" ]; then
-            git fetch -q origin "$BASE_SHA"
-            matrix="$(python3 tools/maintainer/release_matrix.py --skills-only --changed-only "$BASE_SHA")"
+          zeros='0000000000000000000000000000000000000000'
+          base=""
+          if [ -z "$BASE_SHA" ]; then
+            echo "no diff base for a '$EVENT_NAME' event - building the FULL matrix"
+          elif [ "$BASE_SHA" = "$zeros" ]; then
+            # Branch creation (or a push whose `before` GitHub could not name).
+            echo "::warning::base is the all-zeros SHA - building the FULL matrix"
+          else
+            # A force-push or a rewritten history can name a `before` this
+            # clone never received; fetching it is best-effort, and a base the
+            # checkout cannot resolve means the FULL matrix (fail open), never
+            # an empty one. release_matrix.py fails open the same way if the
+            # merge-base or diff below errors.
+            git fetch -q origin "$BASE_SHA" 2>/dev/null || true
+            if git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null; then
+              base="$BASE_SHA"
+            else
+              echo "::warning::base $BASE_SHA is not reachable from this checkout - building the FULL matrix"
+            fi
+          fi
+          if [ -n "$base" ] && [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "diff base (merge-base): $base"
+            matrix="$(python3 tools/maintainer/release_matrix.py --skills-only --changed-only "$base")"
+          elif [ -n "$base" ]; then
+            # Two-point diff, deliberately not a merge-base: a force-push that
+            # rewinds main to an ancestor has merge-base == HEAD and would
+            # diff nothing; the files it removed still need their rows built.
+            echo "diff base (two-point, github.event.before): $base"
+            matrix="$(python3 tools/maintainer/release_matrix.py --skills-only --changed-since "$base")"
           else
             matrix="$(python3 tools/maintainer/release_matrix.py --skills-only)"
           fi
@@ -354,10 +447,15 @@ jobs:
       - name: CLI claims vs built binary (this skill)
         # Runs here, in the per-skill matrix job, because verifying doc claims
         # builds the real CLI and needs Go on PATH (already set up above). The
-        # --slug filter checks only this matrix row's skill. WARN mode for now
-        # while the fleet calibrates.
-        # NOTE(calibration): drop --warn after fleet calibration to make this gate.
-        run: python3 tools/maintainer/check_cli_claims.py --warn --slug ${{ matrix.skill.name }}
+        # --slug filter checks only this matrix row's skill.
+        #
+        # Hard gate. It shipped behind --warn "while the fleet calibrates", and
+        # --warn exits 0 on real findings, so a README telling an MSP to run a
+        # flag the binary rejects printed the defect and left the verdict
+        # green. The fleet has been clean since: a hard-mode run over all 65
+        # connectors on 2026-09-07 returned 0 findings, so a finding here is a
+        # new defect and blocks.
+        run: python3 tools/maintainer/check_cli_claims.py --slug ${{ matrix.skill.name }}
 
       - name: Hand-fix ledger intact (this skill)
         # Hard gate: if this skill carries a skills/<slug>/handfixes.json ledger,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,26 @@ publishes last. Three consequences an agent has to hold:
    A tag listed by that last sweep is a release that never finished: re-run the
    Release workflow for it while its draft is still mutable.
 
+4. **`docs/_data/pending.json` and the README `.mcpb` pins follow COMPLETE
+   PUBLISHED releases, not tags.** `catalog.yml` regenerates them after the
+   Release workflow SUCCEEDS (`workflow_run`), when a release is deleted or
+   unpublished, and weekly, from the API's non-draft
+   release list filtered by `check_release_assets.py --admit-published` (the
+   same asset-set contract the seal uses, `.mcpb` included), and hands that
+   list to `release_state.py --released-tags` and `build-catalog.py
+   --released-tags`. A tag whose release is a stranded draft, or sealed with a
+   build target missing, therefore reads as `version-pending` there, and the
+   README keeps its last complete published link, until a complete release
+   for that version exists.
+
 ## General
 
 - Sign commits (`git commit -s`); no em-dashes in committed files; run
   `tools/maintainer/verify_all.sh <slug>` before pushing. See `CONTRIBUTING.md`.
+- CI builds only what a change-set touched, on PRs AND on pushes to `main`
+  (`release_matrix.py --changed-only`; see `tools/maintainer/README.md`). A
+  docs-only or catalog-bot commit builds nothing; a change to a matrix-row
+  checker, `registry.py`, or a build-feeding workflow builds all 65; a weekly
+  sweep builds everything regardless. `check_cli_claims.py` is a hard gate in
+  the matrix (no `--warn`): a README that names a command or flag the built
+  binary does not have fails that skill's row.

--- a/tools/maintainer/README.md
+++ b/tools/maintainer/README.md
@@ -9,8 +9,9 @@ the statusline, you do not need anything in this folder - see the root
 | Script | What it does |
 | --- | --- |
 | `verify_all.sh` | One command, one verdict: runs every gate below. `bash tools/maintainer/verify_all.sh` |
-| `build-catalog.py` | Regenerates `catalog.json` and the README catalog table from each skill's `manifest.json`. |
-| `release_matrix.py` | Prints the GitHub Actions build matrix (skills x os/arch). |
+| `build-catalog.py` | Regenerates `catalog.json`, the README catalog table and generated blocks, the docs site pages, the issue-form connector dropdowns, and each skill README's `.mcpb` pin. `--released-tags FILE` (catalog.yml passes the complete-published release list) keeps a pin from ever naming a tag whose release is a stranded draft or is missing an asset. |
+| `release_matrix.py` | Prints the GitHub Actions build matrix (skills x os/arch). `--changed-only <base>` (merge-base; ci.yml PRs) and `--changed-since <sha>` (two-point diff; ci.yml pushes, from `github.event.before`) scope it to the skills a change-set touched, so a docs-only or catalog-bot commit builds nothing and a build-machinery edit builds the fleet. `--self-test` proves the classifier both ways. |
+| `release_state.py` | Reports each skill's release state (up-to-date, version-pending, binary-pending, never-released) and writes `docs/_data/pending.json`. `--released-tags FILE` replaces "the tag exists" with "the tag names a published release". |
 | `check_skill_contract.py` | Asserts every skill has the required frontmatter and files. |
 | `check_release_contract.py` | Asserts install scripts and release assets agree on names. |
 | `check_md_links.py` | Verifies relative Markdown links resolve. |
@@ -24,6 +25,27 @@ the statusline, you do not need anything in this folder - see the root
 | `check_release_pipeline.py` | Refuses a SHA (`--sha`) or a whole tag (`--tag T --sha S`) that must not be released. Run it before every `git tag`. |
 | `burned_versions.json` | Version numbers a destroyed release already spent. Retired forever; never cut again. |
 | `hooks/pre-push` | Optional hook: refuses a release-tag push the probe refuses. Install with `git config core.hooksPath tools/maintainer/hooks`. |
+
+## What CI builds, and when
+
+`ci.yml` computes its build matrix with `release_matrix.py --changed-only`: a PR builds the
+skills changed since its merge-base, and a push to `main` builds the skills changed since
+`github.event.before` (the tip `main` had before that push). The catalog bot's
+`chore: regenerate derived files [bot]` commits touch only derived files (`pending.json`,
+`docs/skills/`, the `.mcpb` pin in a skill README, ...) and build nothing; a hand edit to the
+same README builds that skill; a change to a matrix-row checker or a build-feeding workflow
+builds all 65. A weekly full-matrix sweep (Sunday 06:00 UTC, also `workflow_dispatch`) bounds
+anything scoping could miss. Before 2026-09-07 every push to `main` built the whole fleet,
+which is ~210-240 runner-minutes per docs-only bot commit and, during a 21-tag release wave,
+enough to starve the release builds themselves.
+
+`catalog.yml` regenerates the release-derived files (`docs/_data/pending.json`, README
+`.mcpb` pins) when the **Release** workflow completes successfully (`workflow_run`), when a
+release is deleted or unpublished, and weekly - not when a tag is pushed - and it reads the
+PUBLISHED release list from the API rather than `git tag`,
+admitting only releases whose asset set is complete (`check_release_assets.py
+--admit-published`, `.mcpb` included) - so a tag in front of a stranded draft or a partial
+release reads as pending and the README keeps its last complete published download link.
 
 ## Cutting a release tag
 

--- a/tools/maintainer/build-catalog.py
+++ b/tools/maintainer/build-catalog.py
@@ -21,6 +21,14 @@ derived file drifts from what this script would produce.
 
 Run locally:
     python3 tools/maintainer/build-catalog.py
+    python3 tools/maintainer/build-catalog.py --released-tags /tmp/released.txt
+
+`--released-tags FILE` (one tag per line, the PUBLISHED release list as
+catalog.yml fetches it from the releases API with drafts excluded) replaces
+`git tag` as the source the skill-README `.mcpb` pins are repointed from. A tag
+can front a stranded draft that no installer can download; with the file given,
+such a tag is never emitted and the README keeps its last PUBLISHED link. The
+file is authoritative when present; a missing or empty file is an error.
 """
 
 from __future__ import annotations
@@ -413,20 +421,46 @@ def render_agent_can_do() -> str:
     return "\n".join(rows)
 
 
-def _released_tags() -> dict[str, str] | None:
-    """slug -> the highest `<slug>-v<x.y.z>` tag that EXISTS in this checkout.
+def load_released_tags(released_file: Path) -> list[str]:
+    """The published-release tag list, one tag per line (blank lines ignored).
 
-    Returns None when the checkout carries no tags at all (a shallow clone or a
-    source tarball). That is not the same as "nothing is released", so callers
-    must skip rather than treat every slug as unreleased.
+    A missing or EMPTY file raises, before anything is written: this repository
+    has hundreds of published releases, so an empty list is a fetch that
+    failed, and treating it as "nothing released" would silently freeze every
+    pin (or worse, be read as truth by a future caller)."""
+    try:
+        tags = [t.strip() for t in released_file.read_text(encoding="utf-8").splitlines() if t.strip()]
+    except OSError as exc:
+        raise SystemExit(f"build-catalog: cannot read --released-tags {released_file}: {exc}")
+    if not tags:
+        raise SystemExit(
+            f"build-catalog: --released-tags {released_file} is empty; refusing to "
+            f"treat that as 'nothing released'. Omit the flag to use local git tags."
+        )
+    return tags
+
+
+def _released_tags(released: list[str] | None = None) -> dict[str, str] | None:
+    """slug -> the highest `<slug>-v<x.y.z>` tag that is RELEASED.
+
+    With `released` (the published-release list from load_released_tags): the
+    highest tag per slug among those. Without it: the highest tag per slug
+    among the checkout's `git tag`. Returns None when the checkout carries no
+    tags at all (a shallow clone or a source tarball). That is not the same as
+    "nothing is released", so callers must skip rather than treat every slug
+    as unreleased.
     """
-    p = subprocess.run(
-        ["git", "-C", str(ROOT), "tag"], capture_output=True, text=True
-    )
-    if p.returncode != 0 or not p.stdout.split():
-        return None
+    if released is not None:
+        tags = released
+    else:
+        p = subprocess.run(
+            ["git", "-C", str(ROOT), "tag"], capture_output=True, text=True
+        )
+        if p.returncode != 0 or not p.stdout.split():
+            return None
+        tags = p.stdout.split()
     best: dict[str, tuple[tuple[int, ...], str]] = {}
-    for tag in p.stdout.split():
+    for tag in tags:
         m = _TAG_RE.match(tag)
         if not m:
             continue
@@ -437,7 +471,7 @@ def _released_tags() -> dict[str, str] | None:
     return {slug: tag for slug, (_v, tag) in best.items()}
 
 
-def sync_skill_readme_mcpb() -> tuple[int, list[str]]:
+def sync_skill_readme_mcpb(released_list: list[str] | None = None) -> tuple[int, list[str]]:
     """Repoint every skills/<slug>/README.md `.mcpb` download URL at the NEWEST
     TAG THAT EXISTS for that slug - never at the registry version.
 
@@ -449,7 +483,9 @@ def sync_skill_readme_mcpb() -> tuple[int, list[str]]:
     v0.0.0). Only the tag segment of the URL is rewritten; the surrounding prose
     and the asset name are left exactly as authored.
 
-    The source of the tag is `git tag`, NOT skills.json's version, and that
+    The source of the tag is `git tag` (or, in catalog.yml, the PUBLISHED
+    release list passed as --released-tags, which additionally excludes a tag
+    whose release is a stranded draft), NOT skills.json's version, and that
     choice is the whole point. In this repo the version bump lands in the commit
     and the tag is pushed by hand AFTERWARDS, so pinning the registry version is
     precisely how you point at a tag that does not exist: doing that here turned
@@ -475,7 +511,7 @@ def sync_skill_readme_mcpb() -> tuple[int, list[str]]:
     Returns (READMEs changed, warnings).
     """
     warnings: list[str] = []
-    released = _released_tags()
+    released = _released_tags(released_list)
     if released is None:
         return 0, [
             "no local git tags in this checkout - skill-README .mcpb links left "
@@ -572,7 +608,20 @@ def build_docs_catalog(skills: list[dict]) -> dict:
     return {"count": len(connectors), "connectors": connectors, "featured": featured}
 
 
-def main() -> int:
+def _released_tags_arg(argv: list[str]) -> Path | None:
+    if "--released-tags" not in argv:
+        return None
+    i = argv.index("--released-tags")
+    if i + 1 >= len(argv):
+        raise SystemExit("build-catalog: --released-tags needs a FILE")
+    return Path(argv[i + 1])
+
+
+def main(argv: list[str] | None = None) -> int:
+    released_file = _released_tags_arg(sys.argv[1:] if argv is None else argv)
+    # Read (and refuse a bad) release list BEFORE the first write, so a failed
+    # fetch leaves the tree exactly as it was.
+    released_list = load_released_tags(released_file) if released_file else None
     skill_dirs = sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir())
     skills = [build_entry(d) for d in skill_dirs]
 
@@ -631,7 +680,7 @@ def main() -> int:
     # here so it can only ever name a tag that `git tag` already lists. The
     # registry version is deliberately NOT the source: the tag is cut by hand
     # after the bump, so pinning it is how you point at a dead tag.
-    mcpb_synced, mcpb_warnings = sync_skill_readme_mcpb()
+    mcpb_synced, mcpb_warnings = sync_skill_readme_mcpb(released_list)
     for w in mcpb_warnings:
         print(f"build-catalog: WARN {w}")
 

--- a/tools/maintainer/check_release_assets.py
+++ b/tools/maintainer/check_release_assets.py
@@ -94,6 +94,21 @@ def real_size(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
+def _expected_for_entry(entry: dict, with_mcpb: bool) -> set[str]:
+    """The asset names one release_matrix skill entry must publish."""
+    names: set[str] = set()
+    for per_target in entry["assets"].values():
+        for asset in (per_target["cli"], per_target["mcp"]):
+            names.add(asset)
+            # release.yml writes a sidecar next to every binary it uploads.
+            names.add(f"{asset}.sha256")
+    if with_mcpb:
+        # release_matrix owns this name, so the workflow that attaches the
+        # bundle and the gate that requires it read one definition.
+        names.add(entry["mcpb_asset"])
+    return names
+
+
 def expected_assets(tag: str, with_mcpb: bool) -> tuple[str, list[str]]:
     """(slug, sorted expected asset names) for a per-skill release tag.
 
@@ -105,16 +120,63 @@ def expected_assets(tag: str, with_mcpb: bool) -> tuple[str, list[str]]:
     entries = [e for e in release_matrix.skill_entries() if e["name"] == slug]
     names: set[str] = set()
     for entry in entries:
-        for per_target in entry["assets"].values():
-            for asset in (per_target["cli"], per_target["mcp"]):
-                names.add(asset)
-                # release.yml writes a sidecar next to every binary it uploads.
-                names.add(f"{asset}.sha256")
-        if with_mcpb:
-            # release_matrix owns this name, so the workflow that attaches the
-            # bundle and the gate that requires it read one definition.
-            names.add(entry["mcpb_asset"])
+        names |= _expected_for_entry(entry, with_mcpb)
     return slug, sorted(names)
+
+
+def admit_published(stream) -> int:
+    """catalog.yml's admission filter for release-derived files.
+
+    Reads the PUBLISHED release listing, one JSON object per line
+    ({"tag_name": ..., "assets": [{"name", "size", "state"}, ...]}, exactly
+    what `gh api repos/<o>/<r>/releases --paginate -q '.[] | select(.draft|not)
+    | {tag_name, assets: [.assets[] | {name, size, state}]}'` prints) and
+    writes, one per line, the tags whose asset set is COMPLETE under the same
+    contract release.yml seals with (.mcpb included). Those tags - and only
+    those - may advance docs/_data/pending.json or a skill README's `.mcpb`
+    download link.
+
+    Published is necessary and not sufficient (AGENTS.md, "What counts as
+    released"): auvik-v0.1.1 is sealed, public, and carries 16 of its 25
+    assets, so a listing filtered on `draft` alone would still hand the README
+    a download that 404s. A tag naming no releasable skill expects nothing and
+    is passed through (release_state.py and build-catalog.py never consult it).
+
+    Fails CLOSED on an unreadable line: the caller must treat a non-zero exit
+    as "do not regenerate", never as "nothing is released".
+    """
+    by_slug = {e["name"]: e for e in release_matrix.skill_entries()}
+    admitted = rejected = 0
+    for n, line in enumerate(stream, 1):
+        if not line.strip():
+            continue
+        try:
+            rec = json.loads(line)
+            tag = rec["tag_name"]
+            actual = parse_assets(json.dumps(rec.get("assets", [])))
+        except (ValueError, TypeError, KeyError) as exc:
+            print(f"::error::line {n} of the release listing is unreadable ({exc}); "
+                  f"expected one {{tag_name, assets:[{{name,size,state}}]}} object per line.",
+                  file=sys.stderr)
+            return 1
+        if not isinstance(tag, str) or rec.get("draft"):
+            print(f"::error::line {n} of the release listing is a draft or has no tag_name.",
+                  file=sys.stderr)
+            return 1
+        entry = by_slug.get(tag.rsplit("-v", 1)[0])
+        expected = sorted(_expected_for_entry(entry, with_mcpb=True)) if entry else []
+        missing, incomplete, _extra = compare(expected, actual)
+        if missing or incomplete:
+            rejected += 1
+            print(f"check_release_assets: {tag} is published but INCOMPLETE "
+                  f"({len(missing)} missing, {len(incomplete)} not fully uploaded, "
+                  f"of {len(expected)} required); not admitted", file=sys.stderr)
+            continue
+        print(tag)
+        admitted += 1
+    print(f"check_release_assets: admitted {admitted} complete published release(s), "
+          f"rejected {rejected}", file=sys.stderr)
+    return 0
 
 
 def parse_assets(payload: str) -> dict[str, dict]:
@@ -296,10 +358,17 @@ def main() -> int:
                     help="print the expected names and exit, reading no stdin")
     ap.add_argument("--self-test", action="store_true",
                     help="prove this gate fires and stays silent; reads no stdin")
+    ap.add_argument("--admit-published", action="store_true",
+                    help="read a published-release listing (one JSON object per "
+                         "line: {tag_name, assets:[{name,size,state}]}) on stdin "
+                         "and print the tags whose asset set is complete, .mcpb "
+                         "included - catalog.yml's admission filter")
     args = ap.parse_args()
 
     if args.self_test:
         return _self_test()
+    if args.admit_published:
+        return admit_published(sys.stdin)
     if not args.tag:
         ap.error("--tag is required (or use --self-test)")
 

--- a/tools/maintainer/release_matrix.py
+++ b/tools/maintainer/release_matrix.py
@@ -13,12 +13,23 @@ Usage:
                                                  # not N no-op matrix rows)
     python3 tools/release_matrix.py --skills-only --changed-only <base-ref>
                                                  # only skills with changes under
-                                                 # skills/<slug>/ since merge-base
+                                                 # skills/<slug>/ since MERGE-BASE
                                                  # with <base-ref> (ci.yml PRs).
-                                                 # Falls back to the FULL matrix if
-                                                 # build machinery changed or git
-                                                 # diff fails (fail open, never
-                                                 # silently skip a needed build).
+    python3 tools/release_matrix.py --skills-only --changed-since <sha>
+                                                 # same, but the DIRECT diff
+                                                 # <sha>..HEAD, no merge-base
+                                                 # (ci.yml pushes to main, where
+                                                 # <sha> is github.event.before: a
+                                                 # force-push that rewinds main to
+                                                 # an ancestor has merge-base ==
+                                                 # HEAD and would diff nothing).
+                                                 # Both fall back to the FULL
+                                                 # matrix if build machinery
+                                                 # changed or git fails (fail
+                                                 # open, never silently skip a
+                                                 # needed build).
+    python3 tools/release_matrix.py --self-test  # prove the change-set classifier
+                                                 # BOTH directions, offline
 
 Each skill entry carries everything the build step needs:
     name, dir, module, cli_cmd, mcp_cmd, cli_bin, mcp_bin
@@ -44,9 +55,11 @@ copies that agree only because every skill happens to name its MCP binary
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Callable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import registry  # noqa: E402  (local tools/ module)
@@ -81,60 +94,384 @@ def skill_entries(with_assets: bool = True) -> list[dict]:
     return entries
 
 
-# Changes to these paths can alter WHICH skills need building or HOW they are
-# built/verified - when one of them changes, scoping is unsafe and we fall back
-# to the full matrix.
+# --------------------------------------------------------------------------- #
+# Change-set classification for --changed-only.
+#
+# Three buckets, checked in this order:
+#
+#   MACHINERY  a file that can alter WHICH skills need building or HOW a matrix
+#              row builds/verifies them. Scoping is unsafe -> FULL matrix.
+#   DERIVED    a file build-catalog.py / build-llms.py / release_state.py
+#              REGENERATE (catalog.yml auto-commits them to main as
+#              "chore: regenerate derived files ... [bot]"). No build reads
+#              any of them and no matrix-row check does -> contributes no row.
+#   skills/<slug>/**   everything else under a skill -> that skill's row.
+#
+# Why DERIVED is an explicit list and not "the commit author is the bot":
+#   * the PR path diffs a MERGE-BASE, where a commit author means nothing;
+#   * a push range can carry a bot commit AND a human commit, and the human
+#     one must still build;
+#   * an author string is a convention anyone can set, while this list is the
+#     generator's own output list, and --self-test proves it both ways.
+# The one derived file that lives INSIDE a skill directory, and so used to
+# cost a matrix row on every bot commit, is skills/<slug>/README.md: the
+# generator re-mints the version pin in its `.mcpb` download URL after every
+# release (build-catalog.py sync_skill_readme_mcpb). That file is ALSO
+# hand-edited, and check_cli_claims validates its prose against the built
+# binary, so it cannot be classified by path. It is classified by CONTENT
+# instead: a README change whose only difference is the tag segment of that
+# URL is derived; any other difference is a human edit and builds the row.
+# --------------------------------------------------------------------------- #
+
 MACHINERY = (
-    ".github/workflows/",
+    # Workflows that FEED builds. Deliberately NOT the whole .github/workflows/
+    # prefix: catalog.yml and live-verified.yml are docs auto-committers that
+    # never run a matrix row, and a comment edit to either used to cost the
+    # full fleet matrix.
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/security-gate.yml",
+    ".github/workflows/mcp-publish.yml",
+    # The matrix computation itself.
     "tools/maintainer/release_matrix.py",
     "tools/maintainer/registry.py",
+    # Every script a ci.yml matrix row executes (enumerated from its build
+    # job), plus the hash that release_state.py compares binaries by. A change
+    # to any of these changes what "verified" means for every row.
     "tools/maintainer/check_cli_claims.py",
-    "tools/maintainer/cli_hash.py",
+    "tools/maintainer/check_handfixes.py",
     "tools/maintainer/check_mcp_gate.py",
+    "tools/maintainer/check_doctor_truth.py",
+    "tools/maintainer/cli_hash.py",
+    # A Go workspace in an ANCESTOR of skills/<slug>/cli. None exists today,
+    # but `go build` walks up looking for one (GOWORK=auto), so introducing or
+    # editing one at the repo root or at skills/ changes every connector's
+    # dependency resolution without touching a single file under a skill.
+    # (One inside skills/<slug>/ is that skill's own row.)
+    "go.work",
+    "go.work.sum",
+    "skills/go.work",
+    "skills/go.work.sum",
+)
+
+# Path-classified derived files (all OUTSIDE skills/). Kept explicit so the
+# classification is readable and provable, even though a path outside skills/
+# would never have produced a row: what matters is that none of these is
+# MACHINERY, and that the list matches what catalog.yml auto-commits.
+DERIVED_EXACT = (
+    "catalog.json",
+    "README.md",
+    "docs/llms.txt",
+    "docs/llms-full.txt",
+    "docs/_data/catalog.json",
+    "docs/_data/pending.json",
+    ".github/ISSUE_TEMPLATE/it-works.yml",
+    ".github/ISSUE_TEMPLATE/bug-report.yml",
+)
+DERIVED_PREFIX = ("docs/skills/",)
+
+# The registry is an INPUT to the matrix, not machinery: a change to one
+# slug's entry (binary names, source_dir, markdown_only) re-builds THAT slug,
+# not the fleet. release stamps (version, cli_hash_at_release) land here too
+# and cost that one row, which is cheap and correct.
+REGISTRY_PATH = "tools/maintainer/skills.json"
+
+# Mirrors build-catalog.py sync_skill_readme_mcpb: only the tag segment of a
+# `.mcpb` download URL under this repo's releases is generated. Anything else
+# on the line - or any other line - is authored prose.
+_OWNER, _REPO = registry.owner_repo()
+_MCPB_PIN_RE = re.compile(
+    rf"(https://github\.com/{re.escape(_OWNER)}/{re.escape(_REPO)}"
+    rf"/releases/download/)[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+\.mcpb)"
 )
 
 
-def changed_slugs(base_ref: str, entries: list[dict]) -> list[dict] | None:
-    """Filter entries to skills changed since merge-base with base_ref.
+def is_machinery(path: str) -> bool:
+    return any(path == m or path.startswith(m) for m in MACHINERY)
+
+
+def is_derived_path(path: str) -> bool:
+    return path in DERIVED_EXACT or any(path.startswith(p) for p in DERIVED_PREFIX)
+
+
+def readme_pin_only(old: str | None, new: str | None) -> bool:
+    """True when two revisions of a skill README differ ONLY in the version tag
+    of their `.mcpb` download URL(s) - the rewrite the catalog generator
+    performs after a release. A file that is new, deleted, or different
+    anywhere else is a real change."""
+    if old is None or new is None:
+        return False
+    norm = lambda s: _MCPB_PIN_RE.sub(r"\g<1><tag>\g<2>", s)  # noqa: E731
+    return norm(old) == norm(new)
+
+
+def _skill_readme_slug(path: str) -> str | None:
+    parts = path.split("/")
+    if len(parts) == 3 and parts[0] == "skills" and parts[2] == "README.md":
+        return parts[1]
+    return None
+
+
+def classify(
+    files: list[str],
+    pin_only: Callable[[str], bool],
+    registry_delta: Callable[[], set[str] | None],
+) -> set[str] | None:
+    """Pure core of --changed-only. Returns the set of slugs to build, or None
+    for "the FULL matrix" (machinery changed, or a registry diff could not be
+    read - fail open).
+
+    `pin_only(path)` answers whether a changed skills/<slug>/README.md is a
+    generated pin re-mint; `registry_delta()` answers which slugs' skills.json
+    entries changed. Both are injected so --self-test can drive this without
+    a git checkout, and so the git-backed versions below stay thin."""
+    slugs: set[str] = set()
+    for f in files:
+        if is_machinery(f):
+            print(f"release_matrix: machinery changed ({f}); FULL matrix",
+                  file=sys.stderr)
+            return None
+    for f in files:
+        if is_derived_path(f):
+            print(f"release_matrix: derived file ({f}); no row", file=sys.stderr)
+            continue
+        if f == REGISTRY_PATH:
+            delta = registry_delta()
+            if delta is None:
+                print("release_matrix: registry diff unreadable; FULL matrix",
+                      file=sys.stderr)
+                return None
+            print(f"release_matrix: registry entries changed for {sorted(delta)}",
+                  file=sys.stderr)
+            slugs |= delta
+            continue
+        slug = _skill_readme_slug(f)
+        if slug is not None and pin_only(f):
+            print(f"release_matrix: derived .mcpb pin re-mint ({f}); no row",
+                  file=sys.stderr)
+            continue
+        if f.startswith("skills/") and f.count("/") >= 2:
+            slugs.add(f.split("/", 2)[1])
+    return slugs
+
+
+def _git_show(rev: str, path: str) -> str | None:
+    """File content at a revision, or None if it does not exist there."""
+    p = subprocess.run(
+        ["git", "show", f"{rev}:{path}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    return p.stdout if p.returncode == 0 else None
+
+
+def _registry_delta(mb: str) -> set[str] | None:
+    """Slugs whose skills.json entry differs between merge-base and HEAD.
+    None (fail open) if either revision cannot be read or parsed."""
+    try:
+        old_txt = _git_show(mb, REGISTRY_PATH)
+        new_txt = _git_show("HEAD", REGISTRY_PATH)
+        if old_txt is None or new_txt is None:
+            return None
+        old = json.loads(old_txt).get("skills", {})
+        new = json.loads(new_txt).get("skills", {})
+    except (subprocess.SubprocessError, OSError, ValueError, AttributeError):
+        return None
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        return None
+    return {s for s in set(old) | set(new) if old.get(s) != new.get(s)}
+
+
+def changed_slugs(base_ref: str, entries: list[dict], direct: bool = False) -> list[dict] | None:
+    """Filter entries to skills changed since base_ref.
+
+    `direct=False` (PRs) diffs from the MERGE-BASE of base_ref and HEAD, so a
+    base branch that advanced does not count as this change-set. `direct=True`
+    (pushes) diffs base_ref..HEAD as two points: base_ref is the tip main had
+    before the push, and the question is what the tree at HEAD changed
+    relative to it. A merge-base would be wrong there - a force-push that
+    rewinds main to an ancestor has merge-base == HEAD and diffs NOTHING while
+    the tree lost commits; the two-point diff sees those files and rebuilds
+    them. For a normal fast-forward push the two agree exactly.
 
     Returns None to mean "use the full matrix" (machinery changed, or git
     failed - fail open). The filter is skills/<slug>/** (not just cli/**):
     the ci.yml matrix job also runs check_cli_claims, which validates the
     skill's DOCS against the built binary, so a docs-only edit to a skill
-    still needs that skill's row. Non-skill changes produce an empty matrix.
+    still needs that skill's row. Derived files (see classify) and non-skill
+    changes produce no row.
     """
     try:
-        mb = subprocess.run(
-            ["git", "merge-base", base_ref, "HEAD"],
-            capture_output=True, text=True, check=True, timeout=30,
-        ).stdout.strip()
+        if direct:
+            mb = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{base_ref}^{{commit}}"],
+                capture_output=True, text=True, check=True, timeout=30,
+            ).stdout.strip()
+        else:
+            mb = subprocess.run(
+                ["git", "merge-base", base_ref, "HEAD"],
+                capture_output=True, text=True, check=True, timeout=30,
+            ).stdout.strip()
+        # --no-renames: with rename detection a move out of skills/<slug>/
+        # lists only the DESTINATION, and the skill that lost a file is never
+        # built. -z: paths arrive NUL-separated and unquoted, so a non-ASCII
+        # filename is not wrapped in "..." (core.quotePath) where it would
+        # fail every startswith() below and silently skip its skill.
         diff = subprocess.run(
-            ["git", "diff", "--name-only", mb, "HEAD"],
+            ["git", "diff", "--no-renames", "--name-only", "-z", mb, "HEAD"],
             capture_output=True, text=True, check=True, timeout=60,
         ).stdout
     except (subprocess.SubprocessError, OSError) as e:
         print(f"release_matrix: --changed-only diff failed ({e}); "
               "falling back to FULL matrix", file=sys.stderr)
         return None
-    files = [f for f in diff.splitlines() if f.strip()]
-    for f in files:
-        if any(f == m or f.startswith(m) for m in MACHINERY):
-            print(f"release_matrix: machinery changed ({f}); FULL matrix",
-                  file=sys.stderr)
-            return None
-    touched = {f.split("/", 2)[1] for f in files
-               if f.startswith("skills/") and f.count("/") >= 2}
+    files = [f for f in diff.split("\0") if f.strip()]
+
+    def pin_only(path: str) -> bool:
+        try:
+            return readme_pin_only(_git_show(mb, path), _git_show("HEAD", path))
+        except (subprocess.SubprocessError, OSError):
+            return False  # unreadable -> treat as a real change (build it)
+
+    touched = classify(files, pin_only, lambda: _registry_delta(mb))
+    if touched is None:
+        return None
     return [e for e in entries if e["name"] in touched]
 
 
+# --------------------------------------------------------------------------- #
+# --self-test: the classifier proved BOTH directions, with no git involved.
+# --------------------------------------------------------------------------- #
+
+_PIN_LINE = (
+    "[**Download Zammad MCP (.mcpb)**](https://github.com/{o}/{r}/releases/"
+    "download/{tag}/zammad-mcp.mcpb) - then open **Claude Desktop > Settings > "
+    "Extensions** and select the file.\n"
+)
+
+
+def _self_test() -> int:
+    failures: list[str] = []
+
+    def expect(cond: bool, label: str) -> None:
+        print(("  ok   " if cond else "  FAIL ") + label)
+        if not cond:
+            failures.append(label)
+
+    o, r = _OWNER, _REPO
+    pre = "# Zammad\n\nSome prose.\n\n"
+    post = "\nPrefer the Claude Code plugin?\n"
+    old = pre + _PIN_LINE.format(o=o, r=r, tag="zammad-v0.1.3") + post
+    new = pre + _PIN_LINE.format(o=o, r=r, tag="zammad-v0.1.4") + post
+
+    print("readme_pin_only:")
+    expect(readme_pin_only(old, new), "tag re-mint only -> derived")
+    expect(readme_pin_only(old, old), "identical -> derived (no change)")
+    expect(not readme_pin_only(old, new.replace("Some prose.", "Other prose.")),
+           "tag re-mint PLUS a prose edit -> real change")
+    expect(not readme_pin_only(old, pre + _PIN_LINE.format(o=o, r=r, tag="zammad-v0.1.3")
+                               .replace("Extensions", "Plugins") + post),
+           "prose edit on the pin line itself -> real change")
+    expect(not readme_pin_only(old, new.replace("zammad-mcp.mcpb", "zammad-cli.mcpb")),
+           "asset name changed -> real change")
+    expect(not readme_pin_only(old, new.replace(f"github.com/{o}/{r}", "github.com/other/repo")),
+           "a pin under another repo -> real change")
+    expect(not readme_pin_only(None, new), "new file -> real change")
+    expect(not readme_pin_only(old, None), "deleted file -> real change")
+
+    print("is_machinery:")
+    for path, want in (
+        (".github/workflows/ci.yml", True),
+        (".github/workflows/release.yml", True),
+        (".github/workflows/security-gate.yml", True),
+        (".github/workflows/mcp-publish.yml", True),
+        (".github/workflows/catalog.yml", False),
+        (".github/workflows/live-verified.yml", False),
+        ("tools/maintainer/check_doctor_truth.py", True),
+        ("tools/maintainer/check_handfixes.py", True),
+        ("tools/maintainer/check_mcp_gate.py", True),
+        ("tools/maintainer/check_cli_claims.py", True),
+        ("tools/maintainer/release_matrix.py", True),
+        ("tools/maintainer/build-catalog.py", False),
+        ("tools/maintainer/env_schema_internal.json", False),
+        ("docs/_data/pending.json", False),
+        ("go.work", True),
+        ("go.work.sum", True),
+        ("skills/go.work", True),
+        ("skills/go.work.sum", True),
+        ("skills/zammad/cli/go.work", False),   # inside a skill: that skill's row
+    ):
+        expect(is_machinery(path) is want, f"{path} -> {'machinery' if want else 'not machinery'}")
+
+    print("is_derived_path:")
+    for path, want in (
+        ("docs/_data/pending.json", True),
+        ("docs/skills/zammad.md", True),
+        ("README.md", True),
+        (".github/ISSUE_TEMPLATE/it-works.yml", True),
+        (".github/ISSUE_TEMPLATE/skill-request.yml", False),
+        ("skills/zammad/README.md", False),   # content-classified, not path
+        ("skills/zammad/cli/main.go", False),
+        ("docs/reprint-survival.md", False),
+    ):
+        expect(is_derived_path(path) is want, f"{path} -> {'derived' if want else 'not derived'}")
+
+    print("classify:")
+    pins = {"skills/zammad/README.md": True, "skills/hudu/README.md": True}
+    no_pins = {"skills/zammad/README.md": False}
+    empty_reg: Callable[[], set[str] | None] = lambda: set()  # noqa: E731
+    bot = ["docs/_data/pending.json", "skills/zammad/README.md", "skills/hudu/README.md"]
+    expect(classify(bot, pins.get, empty_reg) == set(),
+           "bot regen commit (pending.json + 2 pin re-mints) -> EMPTY matrix")
+    expect(classify(["skills/zammad/README.md"], no_pins.get, empty_reg) == {"zammad"},
+           "human README edit -> that skill's row")
+    expect(classify(["skills/zammad/cli/internal/x.go"], pins.get, empty_reg) == {"zammad"},
+           "Go change -> that skill's row")
+    expect(classify(bot + ["skills/cove/cli/go.mod"], pins.get, empty_reg) == {"cove"},
+           "bot regen + one real change in the same range -> only the real one")
+    expect(classify(["tools/maintainer/check_doctor_truth.py"], pins.get, empty_reg) is None,
+           "matrix-row checker changed -> FULL matrix")
+    expect(classify([".github/workflows/ci.yml"], pins.get, empty_reg) is None,
+           "ci.yml changed -> FULL matrix")
+    expect(classify([".github/workflows/catalog.yml", "docs/skills/hudu.md"], pins.get, empty_reg) == set(),
+           "catalog.yml + a docs page -> EMPTY matrix")
+    expect(classify(["docs/reprint-survival.md", "CONTRIBUTING.md"], pins.get, empty_reg) == set(),
+           "repo docs -> EMPTY matrix")
+    expect(classify([REGISTRY_PATH], pins.get, lambda: {"hudu"}) == {"hudu"},
+           "skills.json entry for one slug changed -> that slug's row")
+    expect(classify([REGISTRY_PATH], pins.get, lambda: None) is None,
+           "skills.json unreadable at a revision -> FULL matrix (fail open)")
+    expect(classify(["skills/_meta/SKILL.md"], pins.get, empty_reg) == {"_meta"},
+           "a non-connector skill dir still names its slug (filtered by the registry later)")
+    expect(classify(["skills/zammad/cli/internal/\u00e9.go"], pins.get, empty_reg) == {"zammad"},
+           "a non-ASCII filename (unquoted, as -z delivers it) -> that skill's row")
+    expect(classify(["docs/moved.go", "skills/zammad/cli/moved.go"], pins.get, empty_reg) == {"zammad"},
+           "a move out of a skill (both sides listed, as --no-renames delivers it) -> that skill's row")
+    expect(classify(["skills/go.work"], pins.get, empty_reg) is None,
+           "a Go workspace at skills/ (ancestor of every cli/) -> FULL matrix")
+
+    if failures:
+        print(f"\nFAIL: release_matrix self-test - {len(failures)} case(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("\nPASS: release_matrix change-set classifier - every case discriminates")
+    return 0
+
+
 def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return _self_test()
     skills_only = "--skills-only" in argv
     tag = ""
     base_ref = ""
+    direct = False
     if "--tag" in argv:
         tag = argv[argv.index("--tag") + 1]
     if "--changed-only" in argv:
         base_ref = argv[argv.index("--changed-only") + 1]
+    if "--changed-since" in argv:
+        base_ref = argv[argv.index("--changed-since") + 1]
+        direct = True
 
     entries = skill_entries(with_assets=not skills_only)
 
@@ -145,7 +482,7 @@ def main(argv: list[str]) -> int:
         entries = [e for e in entries if e["name"] == slug]
 
     if base_ref:
-        filtered = changed_slugs(base_ref, entries)
+        filtered = changed_slugs(base_ref, entries, direct=direct)
         if filtered is not None:
             entries = filtered
 

--- a/tools/maintainer/release_state.py
+++ b/tools/maintainer/release_state.py
@@ -15,6 +15,15 @@ Classification:
                    (locally; with --remote also consults `git ls-remote`)
   up-to-date       hashes match and the manifest-version tag exists
 
+A tag is necessary and not sufficient (AGENTS.md, "What counts as released"):
+with immutable releases a tag can front a stranded DRAFT that no installer can
+see. `--released-tags FILE` replaces "the tag exists" with "the tag names a
+PUBLISHED release": FILE lists one tag per line, as catalog.yml fetches it from
+`gh api repos/<owner>/<repo>/releases` (drafts excluded). With it, a tag whose
+release never sealed reads as version-pending, which is the truth an operator
+needs. The file is authoritative when given: `git tag` and --remote are not
+consulted, and a missing or empty file is an error, never "nothing released".
+
 This is a reporter, not a gate: it always exits 0. Feed --pending to a release
 loop, or --json to another tool.
 
@@ -23,6 +32,7 @@ Pure stdlib. Run locally:
     python3 tools/maintainer/release_state.py --json
     python3 tools/maintainer/release_state.py --pending
     python3 tools/maintainer/release_state.py --remote
+    python3 tools/maintainer/release_state.py --json --released-tags /tmp/released.txt
 """
 
 from __future__ import annotations
@@ -40,6 +50,26 @@ ROOT = registry.ROOT
 SKILLS_DIR = registry.SKILLS_DIR
 
 PENDING_STATES = ("never-released", "binary-pending", "version-pending")
+
+
+def load_released_tags(path: str | Path) -> set[str]:
+    """The published-release tag list, one tag per line (blank lines ignored).
+
+    Fails loudly on a missing or EMPTY file: this repository has hundreds of
+    published releases, so an empty list is a fetch that went wrong, and
+    reading it as "nothing is released" would flip every connector to pending
+    in the same derived commit that was meant to make pending.json truthful."""
+    p = Path(path)
+    try:
+        tags = {ln.strip() for ln in p.read_text(encoding="utf-8").splitlines() if ln.strip()}
+    except OSError as exc:
+        raise SystemExit(f"release_state: cannot read --released-tags {p}: {exc}")
+    if not tags:
+        raise SystemExit(
+            f"release_state: --released-tags {p} is empty; refusing to report every "
+            f"connector as pending. Omit the flag to fall back to local git tags."
+        )
+    return tags
 
 
 def manifest_version(slug: str) -> str:
@@ -87,13 +117,17 @@ def _git(args: list[str]) -> str:
     return out.stdout if out.returncode == 0 else ""
 
 
-def latest_tag(slug: str) -> tuple[str | None, str | None]:
-    """Return (tag, version) for the highest-semver local tag '<slug>-v*'.
+def latest_tag(slug: str, released: set[str] | None = None) -> tuple[str | None, str | None]:
+    """Return (tag, version) for the highest-semver tag '<slug>-v*' - among the
+    PUBLISHED releases when `released` is given, else among local git tags.
 
     Sorts by parsed version tuple in pure Python (not `sort -V`)."""
     prefix = f"{slug}-v"
-    raw = _git(["tag", "--list", f"{prefix}*"])
-    tags = [t.strip() for t in raw.splitlines() if t.strip().startswith(prefix)]
+    if released is not None:
+        tags = [t for t in released if t.startswith(prefix)]
+    else:
+        raw = _git(["tag", "--list", f"{prefix}*"])
+        tags = [t.strip() for t in raw.splitlines() if t.strip().startswith(prefix)]
     if not tags:
         return None, None
     best = max(tags, key=lambda t: _version_tuple(t[len(prefix):]))
@@ -110,7 +144,10 @@ def tag_exists_remote(tag: str) -> bool:
     return bool(raw.strip())
 
 
-def classify(slug: str, remote: bool) -> dict:
+def classify(slug: str, remote: bool, released: set[str] | None = None) -> dict:
+    """`released`, when given, is the published-release tag set (see
+    load_released_tags) and is authoritative: it replaces both the local tag
+    lookup and the --remote fallback."""
     # markdown-only skills have no cli/ to hash and never cut a binary release;
     # report a terminal "markdown-only" state (never pending).
     if registry.is_markdown_only(slug):
@@ -125,19 +162,22 @@ def classify(slug: str, remote: bool) -> dict:
     cli_dir = registry.skill_path(slug) / "cli"
     current = cli_hash.compute_cli_hash(cli_dir) if cli_dir.is_dir() else None
     entry = registry.skills().get(slug, {})
-    released = entry.get("cli_hash_at_release")
+    released_hash = entry.get("cli_hash_at_release")
     version = manifest_version(slug)
-    lt, _lt_ver = latest_tag(slug)
+    lt, _lt_ver = latest_tag(slug, released)
 
     version_tag = f"{slug}-v{version}"
-    if released is None:
+    if released_hash is None:
         state = "never-released"
-    elif current != released:
+    elif current != released_hash:
         state = "binary-pending"
     else:
-        have_tag = tag_exists_local(version_tag)
-        if not have_tag and remote:
-            have_tag = tag_exists_remote(version_tag)
+        if released is not None:
+            have_tag = version_tag in released
+        else:
+            have_tag = tag_exists_local(version_tag)
+            if not have_tag and remote:
+                have_tag = tag_exists_remote(version_tag)
         state = "up-to-date" if have_tag else "version-pending"
 
     return {
@@ -145,7 +185,7 @@ def classify(slug: str, remote: bool) -> dict:
         "version": version,
         "latest_tag": lt,
         "current_hash": current,
-        "released_hash": released,
+        "released_hash": released_hash,
     }
 
 
@@ -153,9 +193,15 @@ def main(argv: list[str]) -> int:
     as_json = "--json" in argv
     pending_only = "--pending" in argv
     remote = "--remote" in argv
+    released: set[str] | None = None
+    if "--released-tags" in argv:
+        i = argv.index("--released-tags")
+        if i + 1 >= len(argv):
+            raise SystemExit("release_state: --released-tags needs a FILE")
+        released = load_released_tags(argv[i + 1])
 
     slugs = sorted(registry.skills())
-    results = {slug: classify(slug, remote) for slug in slugs}
+    results = {slug: classify(slug, remote, released) for slug in slugs}
 
     if pending_only:
         for slug in slugs:

--- a/tools/maintainer/verify_all.sh
+++ b/tools/maintainer/verify_all.sh
@@ -48,9 +48,11 @@ done
 
 echo "== CLI claims vs built binary =="
 # Builds each CLI and checks that every command/flag the docs claim exists in the
-# real binary surface. WARN mode for now: it prints findings but does not gate,
-# while the fleet calibrates. NOTE(calibration): drop --warn after fleet calibration.
-if run_show python3 tools/maintainer/check_cli_claims.py --warn; then pass "CLI claims (warn)"; else warn "CLI claims reported findings"; fi
+# real binary surface. HARD gate: it shipped behind --warn while the fleet
+# calibrated, and --warn exits 0 on real findings. A hard-mode run over all 65
+# connectors on 2026-09-07 returned 0 findings, so a finding here is a new
+# defect. The flag still exists for a local calibration run.
+if run_show python3 tools/maintainer/check_cli_claims.py; then pass "CLI claims"; else fail "CLI claims"; fi
 
 echo "== Manifest env schema vs the binaries' env reads =="
 # Asserts every operator-facing env var a connector READS is declared in its
@@ -125,6 +127,10 @@ if python3 tools/maintainer/release_matrix.py | python3 -c 'import json,sys; m=j
 else
   cat /tmp/va.out; fail "release matrix"
 fi
+# The change-set classifier behind --changed-only (what a PR or a push to main
+# actually builds), proved both directions offline: a bot regen commit yields
+# no rows, a human README edit yields its row, a checker edit yields the fleet.
+if run python3 tools/maintainer/release_matrix.py --self-test; then pass "release matrix change-set classifier"; else fail "release matrix change-set classifier"; fi
 
 echo "== Catalog idempotency =="
 # build-catalog.py regenerates ALL of these from skills.json: the machine


### PR DESCRIPTION
## Why (measured 2026-09-06)

Every push to `main` ran ci.yml's FULL 65-row Go build matrix: `prepare` got an empty BASE on `push` events and fell back to `release_matrix.py --skills-only`. The catalog bot's `chore: regenerate derived files [bot]` commits (11 on 2026-09-06, 27 since 08-26) are docs-only (`docs/_data/pending.json` + 1-3 `skills/<slug>/README.md` `.mcpb` pin re-mints) and each burned ~210-240 runner-minutes. During the 21-tag release wave those runs pinned the org's 60-job runner pool (59/60 busy, 232 queued) and starved the release builds themselves.

Two truth defects rode along: `catalog.yml` regenerated on TAG push, before the release existed, so `pending.json` and the README download links went false-green for minutes (and would stay so forever over a stranded draft); and the `guards` job put the by-design-red "pinned URLs resolve" step in the middle of the list, so every version-bump commit skipped the 12 gates after it (env schema, MCP registry, install docs, DCO, ShellCheck, gitleaks, plugin validate, ...).

## What changed

1. **ci.yml `prepare`** diffs `push` events against `github.event.before` with a TWO-POINT diff (`release_matrix.py --changed-since <before>`, no merge-base: a force-push that rewinds main has merge-base == HEAD and would diff nothing); PRs keep the merge-base diff (`--changed-only`). All-zeros SHA, unfetchable SHA and base-less events (schedule, dispatch) fall back to the FULL matrix; `release_matrix.py` keeps its own fail-open on git errors.
2. **`release_matrix.py` change-set classifier** (explicit lists, not commit-author sniffing, documented in the file): MACHINERY -> full matrix; DERIVED (the generator's output list) -> no row; `skills/<slug>/README.md` is classified by CONTENT: if the only difference is the tag segment of its `.mcpb` download URL (the exact rewrite `build-catalog.py sync_skill_readme_mcpb` performs) it is derived, otherwise it is a human edit and builds the row; a `skills.json` edit builds only the slugs whose entries changed (unparseable -> full). `--self-test` proves 49 cases both directions and is wired into the ci.yml guards self-test step and `verify_all.sh`.
3. **Weekly full sweep**: `schedule` Sunday 06:00 UTC + `workflow_dispatch`.
4. **Concurrency**: `ci-pr-<n>` with cancel-in-progress; every other run `ci-<event>-<run_id>` WITHOUT cancel (a SHA-keyed group could still let a pending run be replaced by a second force-push to the same commit with a different `before`; coalescing main runs breaks `before` as the diff base).
5. **`pins` job**: the pinned-URL check is its own job; a by-design red can no longer skip the other guards.
6. **`check_cli_claims` is a hard gate** in ci.yml and `verify_all.sh` (`--warn` and the NOTE(calibration) comments removed).
7. **MACHINERY**: `.github/workflows/` prefix narrowed to ci.yml, release.yml, security-gate.yml, mcp-publish.yml; added the scripts the matrix rows execute (check_handfixes.py, check_mcp_gate.py, check_doctor_truth.py; check_cli_claims.py and cli_hash.py were already listed) and `go.work` / `go.work.sum` at the repo root or at `skills/` (none exists today; GOWORK=auto ancestor discovery would change every connector's dependency resolution). The diff is read with `--no-renames --name-only -z`, so a file moved OUT of a skill still names that skill and a non-ASCII filename is not quoted into a path the classifier cannot match. `check_env_schema.py`, `dep_allowlist.json`, `security_suppressions.json` are NOT matrix-row inputs (env schema runs in `guards`; the two JSON files feed security-gate.yml) so they are not listed.
8. **catalog.yml**: `push: tags:` removed; `workflow_run` on **Release** gated on `conclusion == 'success'` (a non-success event gets its own concurrency group so a skipped run can never displace a queued writer in `main-autocommit`); `release: [deleted, unpublished]` and a weekly `schedule` (Sunday 06:30 UTC) reconcile a release taken away or an event that never fired; the regenerate step lists every non-draft release with its assets (`gh api .../releases?per_page=100 --paginate -q '.[] | select(.draft|not) | {tag_name, assets: [.assets[] | {name, size, state}]}'`), pipes it through the new `check_release_assets.py --admit-published` (admits only releases whose asset set is COMPLETE under the seal contract, `.mcpb` included; fail-closed on an unreadable line) and passes the admitted tags to `release_state.py --released-tags` and `build-catalog.py --released-tags` (both fall back to `git tag` without the flag; a missing/empty list is FATAL and is refused before any file is written). Re-fetched on every push-retry. `skills/*/README.md` dropped from the PR drift gate; the two generated issue forms (`it-works.yml`, `bug-report.yml`) added to the drift gate and the auto-commit list. One derived-file list shared by the sync check, the add, and the retry loop.
9. Docs: `tools/maintainer/README.md` (script table + "What CI builds, and when") and `AGENTS.md` (released-state point 4 + General).

## Proofs

### check_cli_claims hard mode (baseline for dropping `--warn`)
```
$ for s in halopsa autotask ninjaone cove datto-rmm; do python3 tools/maintainer/check_cli_claims.py --slug $s; done
PASS: all CLI claims resolve against the built binary surface   (x5, exit 0)
$ python3 tools/maintainer/check_cli_claims.py          # whole fleet, no --warn
PASS: all CLI claims resolve against the built binary surface
exit=0
```

### release_matrix.py --self-test (49 cases, both directions, offline)
```
PASS: release_matrix change-set classifier - every case discriminates
```

### Real commits, run at each commit with `--changed-only HEAD~1` (= github.event.before for that push)
```
== bot regen: pending.json + 2 README pin re-mints  [e2771d755]       -> 0 row(s)
   stderr: derived file (docs/_data/pending.json); no row
   stderr: derived .mcpb pin re-mint (skills/unifi-network/README.md); no row
   stderr: derived .mcpb pin re-mint (skills/zammad/README.md); no row
== bot regen: pending.json only                      [0006d0882]       -> 0 row(s)
== checker edit: check_handfixes.py                  [f199efe9e]       -> 65 row(s)  (machinery changed; FULL matrix)
== human README + governance edit                    [ce67a1a28]       -> 1 row(s): ['auvik']
== release stamp commit (manifest + skills.json)     [c797b1176]       -> 1 row(s): ['threatlocker']
```

### Synthetic commits on a throwaway worktree (expected -> observed)
```
catalog.yml comment-only                         expect 0     -> 0
live-verified.yml + docs/skills page             expect 0     -> 0
ci.yml comment-only                              expect FULL  -> 65
zammad README pin re-mint only                   expect 0     -> 0
pin re-mint + a prose line in the same README    expect 1     -> 1 ['zammad']
prose-only README edit                           expect 1     -> 1 ['zammad']
bot-shaped: pending.json + 2 pin re-mints        expect 0     -> 0
pin re-mint + a Go change in another skill       expect 1     -> 1 ['cove']
skills.json: one slug's entry edited             expect 1     -> 1 ['hudu']
skills.json unparseable at HEAD                  expect FULL  -> 65 (fail open)
skill README deleted                             expect 1     -> 1 ['zammad']
check_doctor_truth.py edit                       expect FULL  -> 65
build-catalog.py + it-works.yml                  expect 0     -> 0
```

### Two-point diff vs merge-base on a push (`--changed-since`, Codex A1)
```
normal push A->B (before=A)                          --changed-only: 1 ['cove']   --changed-since: 1 ['cove']
force-push REWIND B->A (before=B, HEAD=A)            --changed-only: 0            --changed-since: 1 ['cove']   <- the defect, fixed
DIVERGENT force-push B->C (before=B, ancestor A)     --changed-only: 1 ['hudu']   --changed-since: 2 ['cove','hudu']
unreachable sha                                      --changed-since: FULL (fail open)
real bot commit e2771d755 via --changed-since HEAD~1                               -> 0 row(s)
```

### Codex round-2 fixes on real git (`--changed-since`)
```
a Go file MOVED out of skills/zammad/cli into docs/     git diff --name-only shows only docs/doctor-moved.go   -> 1 ['zammad']  (--no-renames)
a non-ASCII filename under skills/zammad/cli            git diff --name-only shows "skills/zammad/.../notes-\303\251.go" -> 1 ['zammad']  (-z)
skills/go.work added (git add -f: .gitignore lists go.work, so this guard is belt-and-braces)                  -> 65 (FULL)
root go.work added (git add -f)                                                                                  -> 65 (FULL)
```

### ci.yml `prepare` shell, simulated for every event shape
```
schedule (empty base)      -> "no diff base for a 'schedule' event - building the FULL matrix"  -> 65
push, all-zeros before     -> "::warning::base is the all-zeros SHA - building the FULL matrix"   -> 65
push, unreachable before   -> "::warning::base deadbeef... is not reachable ... FULL matrix"       -> 65
push, before = HEAD        -> "diff base: b5367397b (push)"                                        -> 0
```

### catalog.yml regenerate step, dry-run locally
```
$ gh api "repos/Servosity/msp-skills/releases?per_page=100" --paginate -q '.[] | select(.draft|not) | {tag_name, assets: [.assets[] | {name, size, state}]}'
293 non-draft releases (== git tag | wc -l; 0 drafts today); asset counts: 290 x 25, 2 x 24, 1 x 16
$ python3 tools/maintainer/check_release_assets.py --admit-published < releases.ndjson
check_release_assets: auvik-v0.1.1 is published but INCOMPLETE (9 missing, 0 not fully uploaded, of 25 required); not admitted
check_release_assets: servosity-v0.1.0 is published but INCOMPLETE (1 missing, ...); not admitted
check_release_assets: halopsa-v0.1.0 is published but INCOMPLETE (1 missing, ...); not admitted
check_release_assets: admitted 290 complete published release(s), rejected 3      (all 3 superseded by later complete releases)
$ <listing with a line lacking tag_name> | --admit-published   -> "::error::line 3 ... unreadable" exit 1 (fail closed)
$ release_state.py --json --released-tags <290 admitted> | diff docs/_data/pending.json -   -> IDENTICAL
$ build-catalog.py --released-tags <290 admitted>   -> 0 README pins changed, git status clean
$ check_release_assets.py --self-test   -> still passes
$ release_state.py --json --released-tags <all 293>   | diff docs/_data/pending.json -      -> IDENTICAL
$ release_state.py --json --released-tags <292: minus zammad-v0.1.4> | diff <above> -
<     "state": "up-to-date",          >     "state": "version-pending",
<     "latest_tag": "zammad-v0.1.4",  >     "latest_tag": "zammad-v0.1.3",
$ build-catalog.py --released-tags <292>  -> skills/zammad/README.md pin: zammad-v0.1.4 -> zammad-v0.1.3 (last PUBLISHED)
$ build-catalog.py --released-tags <293>  -> pin back to zammad-v0.1.4; git status clean (idempotent)
$ release_state.py --released-tags <empty>   -> "is empty; refusing to report every connector as pending" exit 1
$ build-catalog.py  --released-tags <empty>  -> refused BEFORE any write, exit 1; <missing file> -> exit 1
$ build-catalog.py (no flag)                 -> unchanged behaviour, idempotent
```

### Local gates
```
py_compile release_matrix.py release_state.py build-catalog.py   ok
actionlint .github/workflows/*.yml                                ok
yaml.safe_load ci.yml catalog.yml                                 ok
shellcheck verify_all.sh ci_guards.sh                             ok
ci_guards.sh                                                      All CI guards passed
check_release_contract.py   passed for 65 skill(s)
check_md_links.py           passed across 548 file(s)
registry.py --self-test / check_release_pipeline.py --self-test  PASS
check_pinned_artifacts.py --base "" --no-network   (schedule shape)  OK, exit 0
check_pinned_artifacts.py --base origin/main --no-network            OK
check_env_schema.py --base ""                      (schedule shape)  PASS, exit 0
release_state.py / --pending / check_engine_freshness.py (no flag)   unchanged output
bash tools/maintainer/verify_all.sh   VERIFY_ALL: PASS - every hard gate is green (225 PASS, 0 FAIL, 1 WARN: gitleaks not installed locally; CI runs it).
  Includes: go build+vet x65, CLI claims (hard mode, whole fleet), manifest env schema, doctor truth, security gate,
  MCP tools callable, release matrix + change-set classifier self-test, catalog and llms idempotency, install dry-runs x65,
  shellcheck, actionlint. Note: this run started before the Codex round-1 fixes; the files changed after it
  (check_release_assets.py, release_matrix.py, catalog.yml, ci.yml, docs) were re-proved individually above
  (self-tests, actionlint, yaml, md-links, ci_guards).
```

## Codex adversarial review (read-only, full diff embedded)

Run 1 (single prompt, whole diff) timed out at 570s while still reading files; no verdict. Re-run as two scoped halves, twice each.

**Part A (ci.yml, release_matrix.py, verify_all.sh) - round 1: `VERDICT: REVISE`**
1. P1 ci.yml:377 - pushes used the classifier's merge-base; a force-push that rewinds main has merge-base == HEAD and diffs nothing. **Fixed**: `--changed-since <before>` is a two-point `git diff before HEAD` for pushes; PRs keep `--changed-only` (merge-base). Proven: rewind 0 -> 1 row, divergent 1 -> 2 rows.
2. P1 release_matrix.py:118 - root `go.work` / `go.work.sum` not machinery. **Fixed** (+ self-test cases).

**Part A - round 2 (revised diff): `VERDICT: REVISE`** ("A1's two-point comparison holds; A2's root-path additions hold, with the additional shared-workspace gap")
1. P1 - `skills/go.work[.sum]` is also an ancestor of every `cli/`. **Fixed** (+ self-test).
2. P1 - rename detection lists only the destination of a move out of a skill. **Fixed**: `--no-renames`; proven on a real `git mv`.
3. P1 - `core.quotePath` wraps non-ASCII paths in quotes, defeating `startswith`. **Fixed**: `-z` + NUL split; proven on a real `notes-é.go`.
4. P1 ci.yml:29 - a SHA-keyed main group can still replace a pending run (two force-pushes to the same SHA, different `before`). **Fixed**: `ci-<event>-<run_id>`.

**Part B (catalog.yml, release_state.py, build-catalog.py, docs) - round 1: `VERDICT: REVISE`**
1. P1 catalog.yml:136 - non-draft does not prove a complete release (auvik-v0.1.1 is sealed with 16/25). **Fixed**: `check_release_assets.py --admit-published` applies the seal's completeness contract (`.mcpb` included) to the listing; admits 290/293, rejects exactly the 3 incomplete (all superseded); fail-closed on an unreadable line.
2. P1 catalog.yml:60 - a FAILED Release's skipped run could displace a queued writer in `main-autocommit`. **Fixed**: non-success `workflow_run` events get `catalog-skipped-<run_id>`.

**Part B - round 2 (revised diff): `VERDICT: REVISE`** ("B2's separate concurrency group correctly prevents unsuccessful Release runs from displacing queued writers. The shown no-flag paths preserve existing caller behavior, and missing/empty supplied lists fail closed.")
1. P1 build-catalog.py:534 - a slug with ZERO admitted releases keeps its authored README link untouched. **Rejected**: that is the generator's documented contract (it never CREATES a dead pin; `check_pinned_artifacts.py` CATCHES one; a first-release pin is authored before its tag and rewriting prose would churn every new connector's README). Every connector today has an admitted release (0 pins changed, 0 warnings with the 290 list).
2. P1 catalog.yml:30 - deleting or unpublishing a release changes neither main nor a Release run, so it was never reconciled. **Fixed**: `release: [deleted, unpublished]` trigger + weekly schedule; the writer step runs on every non-PR event and checks out `origin/main` explicitly.

Per instruction Codex ran once per half after the round-1 fixes; the round-2 fixes were not sent back to Codex and are proven locally instead (self-test 49/49, the real-git proofs above, actionlint/yaml).

## CI cost of this PR

ci.yml and release_matrix.py are MACHINERY, so: one full 65-row matrix on this PR, one on the merge push. After that, a bot regen commit costs the `guards` + `pins` + `prepare` jobs only (0 build rows), a one-skill change costs 1 row, and the weekly sweep costs 65 rows once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFJtdTa5pGzbtH3cdYfvdP
